### PR TITLE
Supported `ReactNode` and fixed a bug where inserted into the input value

### DIFF
--- a/.changeset/cyan-glasses-pretend.md
+++ b/.changeset/cyan-glasses-pretend.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/autocomplete": patch
+"@yamada-ui/select": patch
+---
+
+Fixed a bug where when a string was set to `icon` of `optionProps` or `Option`, the string was inserted into the input value.

--- a/.changeset/tame-terms-turn.md
+++ b/.changeset/tame-terms-turn.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/select": minor
+---
+
+Supported `ReactNode` in `label` of `items` and `Option` children.

--- a/packages/components/autocomplete/src/autocomplete-option.tsx
+++ b/packages/components/autocomplete/src/autocomplete-option.tsx
@@ -52,13 +52,10 @@ export const AutocompleteOption = forwardRef<AutocompleteOptionProps, "li">(
             {icon || <CheckIcon />}
           </AutocompleteItemIcon>
         ) : null}
-        {icon ? (
-          <ui.span style={{ pointerEvents: "none", flex: 1 }} lineClamp={1}>
-            {children}
-          </ui.span>
-        ) : (
-          children
-        )}
+
+        <ui.span style={{ flex: 1 }} data-label>
+          {children}
+        </ui.span>
       </ui.li>
     )
   },

--- a/packages/components/autocomplete/src/use-autocomplete.tsx
+++ b/packages/components/autocomplete/src/use-autocomplete.tsx
@@ -703,7 +703,13 @@ export const useAutocomplete = <T extends string | string[] = string>({
       const enabledValues = descendants.enabledValues()
       const selectedValues = enabledValues
         .filter(({ node }) => node.dataset.value === newValue)
-        .map(({ node }) => node.textContent ?? "")
+        .map(({ node }) => {
+          const el = Array.from(node.children).find(
+            (child) => child.getAttribute("data-label") !== null,
+          )
+
+          return el?.textContent ?? ""
+        })
 
       if (allowFree && selectedValues.length === 0) {
         selectedValues.push(newValue)

--- a/packages/components/select/src/multi-select.tsx
+++ b/packages/components/select/src/multi-select.tsx
@@ -288,10 +288,14 @@ const MultiSelectField = forwardRef<MultiSelectFieldProps, "div">(
               const isLast = label.length === index + 1
 
               return (
-                <ui.span key={index} display="inline-block" me="0.25rem">
-                  {value}
-                  {!isLast ? separator : null}
-                </ui.span>
+                <ui.span
+                  key={index}
+                  display="inline-block"
+                  me="0.25rem"
+                  dangerouslySetInnerHTML={{
+                    __html: `${value}${!isLast ? separator : ""}`,
+                  }}
+                />
               )
             })}
           </ui.span>

--- a/packages/components/select/src/option.tsx
+++ b/packages/components/select/src/option.tsx
@@ -42,13 +42,10 @@ export const Option = forwardRef<OptionProps, "li">(
             {icon || <CheckIcon />}
           </OptionIcon>
         ) : null}
-        {icon ? (
-          <ui.span style={{ pointerEvents: "none", flex: 1 }} lineClamp={1}>
-            {children}
-          </ui.span>
-        ) : (
-          children
-        )}
+
+        <ui.span style={{ flex: 1 }} data-label>
+          {children}
+        </ui.span>
       </ui.li>
     )
   },

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -9,7 +9,7 @@ import { Popover, PopoverTrigger } from "@yamada-ui/popover"
 import type { PortalProps } from "@yamada-ui/portal"
 import { Portal } from "@yamada-ui/portal"
 import { cx, getValidChildren } from "@yamada-ui/utils"
-import type { ReactElement } from "react"
+import type { ReactElement, ReactNode } from "react"
 import type { SelectIconProps } from "./select-icon"
 import { SelectIcon } from "./select-icon"
 import type { SelectListProps } from "./select-list"
@@ -24,13 +24,17 @@ import {
 import type { OptionProps } from "./"
 import { OptionGroup, Option } from "./"
 
-type SelectBaseItem = Omit<OptionProps, "value" | "children"> & {
-  label?: string
+type SelectBaseItem = Omit<OptionProps, "value" | "children">
+
+type SelectItemWithValue = SelectBaseItem & {
+  label?: ReactNode
+  value?: string
 }
 
-type SelectItemWithValue = SelectBaseItem & { value?: string }
-
-type SelectItemWithItems = SelectBaseItem & { items?: SelectItemWithValue[] }
+type SelectItemWithItems = SelectBaseItem & {
+  label?: string
+  items?: SelectItemWithValue[]
+}
 
 export type SelectItem = SelectItemWithValue | SelectItemWithItems
 
@@ -229,9 +233,13 @@ const SelectField = forwardRef<SelectFieldProps, "div">(
         __css={css}
         {...rest}
       >
-        <ui.span isTruncated={isTruncated} lineClamp={lineClamp}>
-          {label ?? placeholder}
-        </ui.span>
+        <ui.span
+          isTruncated={isTruncated}
+          lineClamp={lineClamp}
+          dangerouslySetInnerHTML={{
+            __html: label ?? placeholder ?? "",
+          }}
+        ></ui.span>
       </ui.div>
     )
   },

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -340,11 +340,17 @@ export const useSelect = <T extends MaybeValue = string>({
       const values = descendants.values()
       const selectedValues = values
         .filter(({ node }) => node.dataset.value === newValue)
-        .map(({ node, index }) =>
-          !(!!placeholder && placeholderInOptions) || index !== 0
-            ? node.textContent ?? ""
-            : undefined,
-        )
+        .map(({ node, index }) => {
+          if (!(!!placeholder && placeholderInOptions) || index !== 0) {
+            const el = Array.from(node.children).find(
+              (child) => child.getAttribute("data-label") !== null,
+            )
+
+            return el?.innerHTML ?? ""
+          } else {
+            return undefined
+          }
+        })
 
       setLabel((prev) => {
         if (!isMulti) {
@@ -797,18 +803,11 @@ export const useSelectOptionGroup = ({
 
 export type UseSelectOptionGroupReturn = ReturnType<typeof useSelectOptionGroup>
 
-export type UseSelectOptionProps = Omit<
-  HTMLUIProps<"li">,
-  "value" | "children"
-> & {
+export type UseSelectOptionProps = Omit<HTMLUIProps<"li">, "value"> & {
   /**
    * The value of the select option.
    */
   value?: string
-  /**
-   * The label of the select option.
-   */
-  children?: string
   /**
    * If `true`, the select option will be disabled.
    *


### PR DESCRIPTION
Closes #882 
Closes #881 
Closes #880 

## Description

- Supported `ReactNode` in `label` of `items` and `Option` children.
- Fixed a bug where when a string was set to `icon` of `optionProps` or `Option`, the string was inserted into the input value.

## Is this a breaking change (Yes/No):

No