### PR TITLE
test(vitest): fix glob patterns in `test.coverage.exclude`

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,7 +11,13 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["packages"],
-      exclude: ["dist", "theme", "tests", "test"],
+      exclude: [
+        "**/dist",
+        "packages/theme",
+        "packages/**/tests",
+        "packages/test",
+        "packages/nextjs",
+      ],
     },
     setupFiles: ["./scripts/setup-test.ts"],
   },


### PR DESCRIPTION
## Description

*  Glob patterns in `test.coverage.exclude` is fixed in this PR.

### Before

For example, we want `@vitest/coverage-v8` not to collect coverages of `packages/components/resizable/tests`.
 
<img width="393" alt="スクリーンショット 2024-03-04 1 03 39" src="https://github.com/yamada-ui/yamada-ui/assets/33865215/989f55cb-e6aa-488c-afce-6d4d9d65d0f9">

### After

<img width="394" alt="スクリーンショット 2024-03-04 1 01 32" src="https://github.com/yamada-ui/yamada-ui/assets/33865215/559092bd-1e4c-452c-acfa-222ec1681608">
