### PR TITLE
Fixed a bug where the sort order was not updated even if the `children` of `Reorder` were changed.

### DIFF
--- a/.changeset/strange-students-hammer.md
+++ b/.changeset/strange-students-hammer.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/reorder": patch
+---
+
+Fixed a bug where the sort order was not updated even if the `children` of `Reorder` were changed.

--- a/packages/components/reorder/src/reorder.tsx
+++ b/packages/components/reorder/src/reorder.tsx
@@ -114,11 +114,9 @@ export const Reorder = forwardRef<HTMLUListElement, ReorderProps>(
     }, [onCompleteChange, values])
 
     useUpdateEffect(() => {
-      const isDone = defaultValues.every((defaultValue) =>
-        values.includes(defaultValue),
-      )
+      const isEqual = JSON.stringify(defaultValues) === JSON.stringify(values)
 
-      if (isDone) return
+      if (isEqual) return
 
       prevValues.current = defaultValues
       setValues(defaultValues)


### PR DESCRIPTION
Closes #926

## Description

Fixed a bug where the sort order was not updated even if the `children` of `Reorder` were changed.

## Is this a breaking change (Yes/No):

No