### PR TITLE
Fixed `allowFree` of `Autocomplate` and `MultiAutocomplete`

### DIFF
--- a/.changeset/forty-dragons-learn.md
+++ b/.changeset/forty-dragons-learn.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/autocomplete": patch
+---
+
+Fixed a bug where `defaultValue` or `value` was not inserted into input value when `allowFree` was `true`.

--- a/packages/components/autocomplete/src/use-autocomplete.tsx
+++ b/packages/components/autocomplete/src/use-autocomplete.tsx
@@ -379,7 +379,12 @@ export const useAutocomplete = <T extends string | string[] = string>({
     getFormControlProperties({ omit: ["aria-readonly"] }),
   )
   const [containerProps, inputProps] = splitObject<Dict, string>(
-    omitObject(rest, [...popoverProperties, "aria-readonly"]),
+    omitObject(rest, [
+      ...popoverProperties,
+      "onKeyDown",
+      "onFocus",
+      "aria-readonly",
+    ]),
     layoutStyleProperties,
   )
 


### PR DESCRIPTION
Closes #895

## Description

Fixed a bug where `defaultValue` or `value` was not inserted into input value when `allowFree` was `true`.

## Is this a breaking change (Yes/No):

No