### PR TITLE
Fixed `placement` type exclusion in props

### DIFF
--- a/.changeset/afraid-adults-smoke.md
+++ b/.changeset/afraid-adults-smoke.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/modal": patch
+---
+
+Fixed a bug where `placement` of types.

--- a/packages/components/modal/src/drawer.tsx
+++ b/packages/components/modal/src/drawer.tsx
@@ -46,7 +46,7 @@ type DrawerOptions = {
 
 export type DrawerProps = Omit<
   ModalProps,
-  "scrollBehavior" | "animation" | "outside" | keyof ThemeProps
+  "scrollBehavior" | "animation" | "outside" | "placement" | keyof ThemeProps
 > &
   ThemeProps<"Drawer"> &
   DrawerOptions


### PR DESCRIPTION
## Description

Fixed a bug where `placement` of types.

## Is this a breaking change (Yes/No):

No