### PR TITLE
Added `__prefix` to `var` props.

### DIFF
--- a/.changeset/curly-carrots-exist.md
+++ b/.changeset/curly-carrots-exist.md
@@ -1,0 +1,8 @@
+---
+"@yamada-ui/color-picker": patch
+"@yamada-ui/layouts": patch
+"@yamada-ui/snacks": patch
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where styles were not applied when the prefix of a css variable was changed.

--- a/.changeset/witty-falcons-run.md
+++ b/.changeset/witty-falcons-run.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Added `__prefix` to `var` props.

--- a/packages/components/color-picker/src/alpha-slider.tsx
+++ b/packages/components/color-picker/src/alpha-slider.tsx
@@ -23,11 +23,13 @@ const defaultOverlays = (
       bgPosition: `0 0, 0 4px, 4px -4px, -4px 0`,
       var: [
         {
+          __prefix: "ui",
           name: "checkers",
           token: "colors",
           value: ["blackAlpha.300", "whiteAlpha.300"],
         },
         {
+          __prefix: "ui",
           name: "body",
           token: "colors",
           value: ["whiteAlpha.500", "blackAlpha.500"],

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -19,11 +19,13 @@ const defaultOverlays = (
       bgPosition: `0 0, 0 4px, 4px -4px, -4px 0`,
       var: [
         {
+          __prefix: "ui",
           name: "checkers",
           token: "colors",
           value: ["blackAlpha.300", "whiteAlpha.300"],
         },
         {
+          __prefix: "ui",
           name: "body",
           token: "colors",
           value: ["whiteAlpha.500", "blackAlpha.500"],

--- a/packages/components/layouts/src/stack.tsx
+++ b/packages/components/layouts/src/stack.tsx
@@ -236,7 +236,7 @@ export const ZStack = forwardRef<ZStackProps, "div">(
     const css: CSSUIObject = {
       position: "relative",
       overflow: "hidden",
-      var: [{ name: "space", token: "spaces", value: gap }],
+      var: [{ __prefix: "ui", name: "space", token: "spaces", value: gap }],
       ...(fit ? boxSize : {}),
     }
 

--- a/packages/components/snacks/src/snacks.tsx
+++ b/packages/components/snacks/src/snacks.tsx
@@ -95,7 +95,7 @@ export const Snacks = forwardRef<SnacksProps, "div">(
 
     const css: CSSUIObject = {
       w: "100%",
-      var: [{ name: "space", token: "spaces", value: gap }],
+      var: [{ __prefix: "ui", name: "space", token: "spaces", value: gap }],
       margin: negateMargin ? `${negatedTop} 0 ${negatedBottom}` : undefined,
     }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -266,8 +266,8 @@ export type Transforms = keyof typeof transforms
 
 export const transforms = {
   var: (values: any[], theme: StyledTheme) =>
-    values.reduce<Dict>((prev, { name, token, value }) => {
-      const prefix = theme.__config.var?.prefix ?? "ui"
+    values.reduce<Dict>((prev, { __prefix, name, token, value }) => {
+      const prefix = __prefix ?? theme.__config.var?.prefix ?? "ui"
 
       name = `--${prefix}-${name}`
 

--- a/packages/core/src/styles.ts
+++ b/packages/core/src/styles.ts
@@ -5244,6 +5244,7 @@ export type StyleProps = {
    * ```
    */
   var?: {
+    __prefix?: string
     name: string
     token?: keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">
     value: Token<StringLiteral | number>

--- a/packages/theme/src/components/indicator.ts
+++ b/packages/theme/src/components/indicator.ts
@@ -27,7 +27,14 @@ export const Indicator: ComponentStyle = {
     solid: ({ colorScheme: c = "primary" }) => ({
       bg: [`${c}.500`, `${c}.600`],
       color: `white`,
-      var: [{ name: "ping", token: "colors", value: [`${c}.300`, `${c}.400`] }],
+      var: [
+        {
+          __prefix: "ui",
+          name: "ping",
+          token: "colors",
+          value: [`${c}.300`, `${c}.400`],
+        },
+      ],
     }),
     subtle: ({ theme: t, colorMode: m, colorScheme: c = "primary" }) => ({
       bg: [
@@ -37,6 +44,7 @@ export const Indicator: ComponentStyle = {
       color: [`${c}.800`, isGray(c) ? `${c}.50` : `${c}.200`],
       var: [
         {
+          __prefix: "ui",
           name: "ping",
           token: "colors",
           value: ["blackAlpha.400", "whiteAlpha.500"],

--- a/packages/theme/src/components/stat.ts
+++ b/packages/theme/src/components/stat.ts
@@ -27,8 +27,18 @@ export const Stat: ComponentMultiStyle = {
       h: "3.5",
       verticalAlign: "middle",
       var: [
-        { name: "increase", token: "colors", value: "success.400" },
-        { name: "decrease", token: "colors", value: "danger.400" },
+        {
+          __prefix: "ui",
+          name: "increase",
+          token: "colors",
+          value: "success.400",
+        },
+        {
+          __prefix: "ui",
+          name: "decrease",
+          token: "colors",
+          value: "danger.400",
+        },
       ],
     },
   },

--- a/scripts/generate-css/ui-props.ts
+++ b/scripts/generate-css/ui-props.ts
@@ -277,7 +277,7 @@ export const uiProps = createUIProps({
   var: {
     isProcessSkip: true,
     transform: "var",
-    type: '{ name: string; token?: keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">, value: Token<StringLiteral | number> }[]',
+    type: '{ __prefix?: string; name: string; token?: keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">, value: Token<StringLiteral | number> }[]',
     hasToken: false,
     description: [
       "Set CSS variables.",


### PR DESCRIPTION
Closes #969

## Description

Fixed a bug where styles were not applied when the prefix of a css variable was changed.

## Is this a breaking change (Yes/No):

No