### PR TITLE
Fixed `minBoxSize` and `maxBoxSize` theme references

### DIFF
--- a/.changeset/blue-rings-care.md
+++ b/.changeset/blue-rings-care.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Fixed a bug where `minBoxSize` and `maxBoxSize` do not refer to theme sizes tokens.

--- a/packages/core/src/styles.ts
+++ b/packages/core/src/styles.ts
@@ -1068,8 +1068,15 @@ export const standardStyles: Configs = {
     token: "sizes",
     transform: transforms.token("sizes", transforms.fraction(transforms.px)),
   },
-  minBoxSize: { properties: ["minWidth", "minHeight"] },
-  maxBoxSize: { properties: ["maxWidth", "maxHeight"] },
+  minBoxSize: {
+    properties: ["minWidth", "minHeight"],
+    token: "sizes",
+    transform: transforms.token("sizes", transforms.fraction(transforms.px)),
+  },
+  maxBoxSize: {
+    properties: ["maxWidth", "maxHeight"],
+    transform: transforms.fraction(transforms.px),
+  },
   translateX: {
     properties: "--ui-translate-x",
     token: "spaces",
@@ -5084,14 +5091,17 @@ export type StyleProps = {
    * @see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/min-height
    * @see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/min-width
    */
-  minBoxSize?: Token<CSS.Property.MinHeight | CSS.Property.MinWidth>
+  minBoxSize?: Token<
+    CSS.Property.MinHeight | CSS.Property.MinWidth | number,
+    "sizes"
+  >
   /**
    * The CSS `max-width` and `max-height` property.
    *
    * @see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/max-height
    * @see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
    */
-  maxBoxSize?: Token<CSS.Property.MaxHeight | CSS.Property.MaxWidth>
+  maxBoxSize?: Token<CSS.Property.MaxHeight | CSS.Property.MaxWidth | number>
   /**
    * If `transform=auto` or `transform=auto-3d`, sets the value of `--ui-translate-x`.
    */

--- a/scripts/generate-css/tokens.ts
+++ b/scripts/generate-css/tokens.ts
@@ -87,6 +87,8 @@ export const tokens: Tokens = {
     "maxHeight",
     "maxBlockSize",
     "boxSize",
+    "minBoxSize",
+    "minBoxSize",
     "flexBasis",
   ],
   spaces: [

--- a/scripts/generate-css/transform-props.ts
+++ b/scripts/generate-css/transform-props.ts
@@ -145,6 +145,8 @@ export const transformProps: TransformProps = {
     { properties: "maxHeight", transform: "px" },
     { properties: "maxBlockSize", transform: "px" },
     { properties: "boxSize", transform: "px" },
+    { properties: "minBoxSize", transform: "px" },
+    { properties: "maxBoxSize", transform: "px" },
   ],
   bgClip: ["backgroundClip"],
   gradient: ["backgroundImage"],


### PR DESCRIPTION
Closes #983

## Description

Fixed a bug where `minBoxSize` and `maxBoxSize` do not refer to theme sizes tokens.

## Is this a breaking change (Yes/No):

No