### PR TITLE
fix(file-input): added the missing `key` prop when executing `cloneElement`

### DIFF
--- a/packages/components/file-input/src/file-input.tsx
+++ b/packages/components/file-input/src/file-input.tsx
@@ -170,7 +170,9 @@ export const FileInput = forwardRef<FileInputProps, "input">(
                 marginInlineEnd: "0.25rem",
               }
 
-              return el ? cloneElement(el as ReactElement, { style }) : null
+              return el
+                ? cloneElement(el as ReactElement, { style, key: index })
+                : null
             })}
           </ui.span>
         )


### PR DESCRIPTION
## Description

* Added the missing `key` prop when executing `cloneElement`