### PR TITLE
Fixed theme token usage in `Skeleton`

### DIFF
--- a/.changeset/healthy-spies-mix.md
+++ b/.changeset/healthy-spies-mix.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/skeleton": patch
+---
+
+Fixed a bug where theme tokens were used in components.

--- a/packages/components/skeleton/src/skeleton.tsx
+++ b/packages/components/skeleton/src/skeleton.tsx
@@ -114,7 +114,7 @@ export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
   const css: CSSUIObject = {
     w: isFitContent ? "fit-content" : "100%",
     maxW: "100%",
-    h: isFitContent ? "fit-content" : "4",
+    h: isFitContent ? "fit-content" : "1rem",
     boxShadow: "none",
     backgroundClip: "padding-box",
     cursor: "default",


### PR DESCRIPTION
Closes #918 

## Description

Fixed a bug where theme tokens were used in components.

## Is this a breaking change (Yes/No):

No