### PR TITLE
Stop uploading test coverages to Codecov temporarily

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Run tests
         run: pnpm test:ci
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          file: ./coverage/coverage-final.json
-          flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
+      # - name: Upload coverage
+      #   uses: codecov/codecov-action@v4
+      #   with:
+      #     fail_ci_if_error: true
+      #     file: ./coverage/coverage-final.json
+      #     flags: unittests
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     verbose: true
 
   eslint:
     name: ESLint


### PR DESCRIPTION
## Description

There are many files with coverage not exceeding 80%, so we are not fully benefiting from Codecov. On the contrary, it is having a negative impact on the development speed. I would like to suspend the uploads of coverage to Codecov until the tests are adequately in place.