### PR TITLE
fix: made the legend wrap around

### DIFF
--- a/.changeset/eleven-scissors-breathe.md
+++ b/.changeset/eleven-scissors-breathe.md
@@ -1,5 +1,5 @@
 ---
-"@yamada-ui/theme": major
+"@yamada-ui/theme": patch
 ---
 
 made the legend wrap around

--- a/.changeset/eleven-scissors-breathe.md
+++ b/.changeset/eleven-scissors-breathe.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": major
+---
+
+made the legend wrap around

--- a/packages/theme/src/components/line-chart.ts
+++ b/packages/theme/src/components/line-chart.ts
@@ -36,6 +36,7 @@ export const LineChart: ComponentMultiStyle = {
     },
     legend: {
       display: "flex",
+      flexWrap: "wrap",
       justifyContent: "flex-end",
     },
     legendItem: {


### PR DESCRIPTION
Closes #1069 

## Description
以前の挙動が以下の画像の通りでしたが、
![image](https://github.com/yamada-ui/yamada-ui/assets/75029815/dce5d13d-984c-4814-9678-2bf9201d5139)

次のように折り返されるようになりました。
![image](https://github.com/yamada-ui/yamada-ui/assets/75029815/fb3ae2c2-f7b4-44a3-b114-1dcf6761d343)

## Current behavior (updates)
凡例が多い場合、挙動が変になる

## New behavior
たくさん凡例があってもきれいに表示されることを確認しました。

## Is this a breaking change (Yes/No):
No

## Additional Information
