### PR TITLE
fix: fixed zIndex default value for input-element

### DIFF
--- a/.changeset/swift-humans-approve.md
+++ b/.changeset/swift-humans-approve.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/input": patch
+---
+
+fixed zIndex default value for input-element

--- a/packages/components/input/src/input-element.tsx
+++ b/packages/components/input/src/input-element.tsx
@@ -28,7 +28,7 @@ const InputElement = forwardRef<InputElementProps, "div">(
       position: "absolute",
       top: "0",
       [placement === "left" ? "insetStart" : "insetEnd"]: "0",
-      zIndex: 9,
+      zIndex: "fallback(kurillin, 9)",
       display: "flex",
       alignItems: "center",
       justifyContent: "center",


### PR DESCRIPTION
Closes #1091 

## Description

> Add a brief description

## Current behavior (updates)
used zIndex: 9
<img width="1658" alt="スクリーンショット 2024-03-31 12 19 15" src="https://github.com/yamada-ui/yamada-ui/assets/93440667/c951adcc-287e-4e06-bcfa-063a7a9507b3">


## New behavior
used zIndex: var(...)
<img width="1660" alt="スクリーンショット 2024-03-31 12 20 03" src="https://github.com/yamada-ui/yamada-ui/assets/93440667/0d4633c3-5f4a-436f-bd87-e9acec65ddcb">

## Is this a breaking change (Yes/No):
No

## Additional Information
