### PR TITLE
Apply theme's token to NoticeProvider component

### DIFF
--- a/.changeset/tough-steaks-attack.md
+++ b/.changeset/tough-steaks-attack.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/notice": patch
+---
+
+Apply theme's token to NoticeProvider component

--- a/packages/components/notice/src/notice-provider.tsx
+++ b/packages/components/notice/src/notice-provider.tsx
@@ -17,7 +17,7 @@ export type NoticeProviderProps = Omit<
 
 export const NoticeProvider: FC<NoticeProviderProps> = ({
   variants,
-  gap = "1rem",
+  gap = "fallback(4, 1rem)",
   appendToParentPortal,
   containerRef,
 }) => {
@@ -43,7 +43,7 @@ export const NoticeProvider: FC<NoticeProviderProps> = ({
 
     const css: CSSUIObject = {
       position: "fixed",
-      zIndex: 160,
+      zIndex: "fallback(zarbon, 160)",
       pointerEvents: "none",
       display: "flex",
       flexDirection: "column",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/1099

## Description

Apply theme's token to NoticeProvider component.

## Current behavior (updates)

zIndex:160 and gap:1rem
<img width="597" alt="スクリーンショット 2024-04-01 12 28 03" src="https://github.com/yamada-ui/yamada-ui/assets/87361015/8fb49793-2c6d-443f-993c-a527d6c6dc10">


## New behavior

zIndex:160 and gap:1rem changed to var(...)
<img width="597" alt="スクリーンショット 2024-04-01 12 26 21" src="https://github.com/yamada-ui/yamada-ui/assets/87361015/575f9c15-4285-42f9-9270-6246ced79426">

## Is this a breaking change (Yes/No):

No

## Additional Information
