### PR TITLE
fix: fixed Use theme tokens for styling values in Reorder component

### DIFF
--- a/.changeset/two-ears-listen.md
+++ b/.changeset/two-ears-listen.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/reorder": patch
+---
+
+change gap value in reorder component

--- a/packages/components/reorder/src/reorder.tsx
+++ b/packages/components/reorder/src/reorder.tsx
@@ -64,7 +64,7 @@ export const Reorder = forwardRef<HTMLUListElement, ReorderProps>(
     const {
       className,
       orientation = "vertical",
-      gap = "1rem",
+      gap = "fallback(4,1rem)",
       onChange,
       onCompleteChange,
       children,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #1095

## Description

The Reorder component was previously ignoring theme tokens when applying  styling values. This commit address the issue by ensuring that theme tokens are used when a theme is applied.

## Current behavior (updates)

The Reorder component was previously ignoring theme tokens when applying styling values.

## New behavior

 Yamada UI's style system's fallback functions are utilized. If the value of the token in the first argument does not exist, it falls back to the second argument, which serves as the fallback value.

## Is this a breaking change (Yes/No):

No

## Additional Information
