### PR TITLE
Use the theme's token in the LinkBox component.

### DIFF
--- a/.changeset/thick-bottles-teach.md
+++ b/.changeset/thick-bottles-teach.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/link": patch
+---
+
+Use the theme's token in the `LinkBox` component

--- a/packages/components/link/src/link-box.tsx
+++ b/packages/components/link/src/link-box.tsx
@@ -1,8 +1,8 @@
-import type { CSSUIObject, HTMLUIProps, ThemeProps } from "@yamada-ui/core"
+import type { HTMLUIProps, ThemeProps, CSSUIObject } from "@yamada-ui/core"
 import {
+  ui,
   forwardRef,
   omitThemeProps,
-  ui,
   useComponentStyle,
 } from "@yamada-ui/core"
 import { cx } from "@yamada-ui/utils"

--- a/packages/components/link/src/link-box.tsx
+++ b/packages/components/link/src/link-box.tsx
@@ -1,8 +1,8 @@
-import type { HTMLUIProps, ThemeProps, CSSUIObject } from "@yamada-ui/core"
+import type { CSSUIObject, HTMLUIProps, ThemeProps } from "@yamada-ui/core"
 import {
-  ui,
   forwardRef,
   omitThemeProps,
+  ui,
   useComponentStyle,
 } from "@yamada-ui/core"
 import { cx } from "@yamada-ui/utils"
@@ -64,7 +64,7 @@ export const LinkBox = forwardRef<LinkBoxProps, "div">((props, ref) => {
   const css: CSSUIObject = {
     "a[href]:not(.ui-link-box__overlay), abbr[title]": {
       position: "relative",
-      zIndex: "1",
+      zIndex: "fallback(yamcha, 1)",
     },
     ...styles,
   }


### PR DESCRIPTION
Closes #1086

## Description

Use the theme's token in the `LinkBox` component.

## Current behavior (updates)

`zIndex` in the `LinkBox` component has been ignoring theme tokens.

## New behavior

Use the theme's token in the `LinkBox` component when a theme is applied.

## Is this a breaking change (Yes/No):

No.

## Additional Information
