### PR TITLE
test(eslintrc): add `testing-library/prefer-find-by`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -119,7 +119,8 @@
         "testing-library/no-dom-import": "error",
         "testing-library/no-debugging-utils": "error",
         "testing-library/no-global-regexp-flag-in-query": "error",
-        "testing-library/no-promise-in-fire-event": "error"
+        "testing-library/no-promise-in-fire-event": "error",
+        "testing-library/prefer-find-by": "error"
       }
     }
   ]


### PR DESCRIPTION
Related #1119 

## Description

Add [`testing-library/prefer-find-by`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-find-by.md) to `.eslintrc`

There are no changes to the test code, but the aim is to prevent any inappropriate descriptions in the test code that will likely be added in the future.
