### PR TITLE
test(eslintrc): add testing-library/no-await-sync-queries

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -120,7 +120,8 @@
         "testing-library/no-debugging-utils": "error",
         "testing-library/no-global-regexp-flag-in-query": "error",
         "testing-library/no-promise-in-fire-event": "error",
-        "testing-library/prefer-find-by": "error"
+        "testing-library/prefer-find-by": "error",
+        "testing-library/no-await-sync-queries": "error"
       }
     }
   ]


### PR DESCRIPTION
Related #1119 

## Description

Add [`testing-library/no-await-sync-queries`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-await-sync-queries.md) to `.eslintrc`

There are no changes to the test code, but the aim is to prevent any inappropriate descriptions in the test code that will likely be added in the future.
