### PR TITLE
Use the theme's token in the `Breadcrumb` component

### DIFF
--- a/.changeset/purple-olives-clean.md
+++ b/.changeset/purple-olives-clean.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/breadcrumb": patch
+---
+
+Use the theme's token in the `Breadcrumb` component

--- a/packages/components/breadcrumb/src/breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/breadcrumb.tsx
@@ -30,7 +30,7 @@ type BreadcrumbOptions = {
   /**
    * The left and right margin applied to the separator.
    *
-   * @default 'sm'
+   * @default '2'
    */
   gap?: CSSUIProps["mx"]
   /**
@@ -55,7 +55,7 @@ export const Breadcrumb = forwardRef<BreadcrumbProps, "nav">((props, ref) => {
     className,
     children,
     separator = "/",
-    gap = "0.5rem",
+    gap = "fallback(2, 0.5rem)",
     listProps,
     ...rest
   } = omitThemeProps(mergedProps)


### PR DESCRIPTION
Closes #1093 

## Description

Use the theme's token in the `Breadcrumb` component if a theme is applied.

## Current behavior (updates)

The theme's token in the `Breadcrumb` component is ignored.

## New behavior

The theme's token in the `Breadcrumb` component will properly be used when a theme is applied.

## Is this a breaking change (Yes/No): No

## Additional Information

N/A