### PR TITLE
fix: use the theme's token in the number-input component

### DIFF
--- a/.changeset/new-terms-refuse.md
+++ b/.changeset/new-terms-refuse.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/number-input": patch
+---
+
+use the theme's token in the NumberInput component

--- a/packages/components/number-input/src/number-input.tsx
+++ b/packages/components/number-input/src/number-input.tsx
@@ -749,7 +749,7 @@ const NumberInputAddon = forwardRef<NumberInputAddonProps, "div">(
       insetEnd: "0px",
       margin: "1px",
       height: "calc(100% - 2px)",
-      zIndex: "1",
+      zIndex: "fallback(yamcha, 1)",
       ...styles.addon,
     }
 


### PR DESCRIPTION
Closes #1085 

## Description

> use the theme's token in the number-input component

## Current behavior (updates)

> z-index is described by number

## New behavior

> z-index is described by the theme's token

## Is this a breaking change (Yes/No):

> No