### PR TITLE
fix: bugs where theme is not applied

### DIFF
--- a/.changeset/six-ducks-remain.md
+++ b/.changeset/six-ducks-remain.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+If a theme is applied, change to use the theme tokens

--- a/packages/components/toggle/src/toggle.tsx
+++ b/packages/components/toggle/src/toggle.tsx
@@ -150,7 +150,7 @@ export const Toggle = forwardRef(
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
-        gap: "0.5rem",
+        gap: "fallback(2, 0.5rem)",
         appearance: "none",
         userSelect: "none",
         position: "relative",
@@ -159,7 +159,7 @@ export const Toggle = forwardRef(
         outline: "none",
         pointerEvents: isReadOnly ? "none" : "auto",
         ...styles,
-        ...(isRounded ? { borderRadius: "9999px" } : {}),
+        ...(isRounded ? { borderRadius: "fallback(full, 9999px)" } : {}),
       }),
       [isRounded, styles, isReadOnly],
     )


### PR DESCRIPTION
Closes #1082 

## Description

> If a theme is applied, change to use the theme tokens

## Current behavior (updates)

> styling values in components ignore theme tokens

## New behavior

>  If the value of the token in the first argument does not exist, it returns the second argument, the fallback value.

## Is this a breaking change (Yes/No):

> No

## Additional Information
