### PR TITLE
fix: theme token in ColorSwatch

### DIFF
--- a/.changeset/red-jeans-divide.md
+++ b/.changeset/red-jeans-divide.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": major
+---
+
+fix theme token in ColorSwatch

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -121,11 +121,11 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
     <ui.div
       ref={ref}
       className={cx("ui-color-swatch", className)}
-      {...(isRounded ? { rounded: "9999px" } : {})}
+      {...(isRounded ? { rounded: "fallback(full, 9999px)" } : {})}
       __css={css}
       {...rest}
     >
-      <ui.div {...(isRounded ? { rounded: "9999px" } : {})}>
+      <ui.div {...(isRounded ? { rounded: "fallback(full, 9999px)" } : {})}>
         {overlays.map((props, index) => (
           <ui.div
             key={index}
@@ -137,7 +137,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
               bottom: 0,
               ...styles.overlay,
             }}
-            {...(isRounded ? { rounded: "9999px" } : {})}
+            {...(isRounded ? { rounded: "fallback(full, 9999px)" } : {})}
             {...props}
           />
         ))}


### PR DESCRIPTION
Closes #1084

## Description
If a theme is applied, that use the theme's token.

## Current behavior (updates)
If the value of the token in the first argument does not exist, it returns the second argument, the fallback value.

## New behavior
If the value of the token in the first argument does not exist, it returns the second argument, the fallback value.

## Is this a breaking change (Yes/No):
No

## Additional Information
