### PR TITLE
fixed `examples/hono` flashes in color mode

### DIFF
--- a/examples/hono/src/client.tsx
+++ b/examples/hono/src/client.tsx
@@ -1,6 +1,4 @@
 import {
-  ColorModeScript,
-  ThemeSchemeScript,
   UIProvider,
   colorModeManager,
   themeSchemeManager,
@@ -13,17 +11,6 @@ import { theme, config } from "./theme"
 const App = ({ children }: { children: ReactNode }) => {
   return (
     <>
-      <ColorModeScript
-        type="cookie"
-        nonce="testing"
-        initialColorMode={config.initialColorMode}
-      />
-      <ThemeSchemeScript
-        type="cookie"
-        nonce="testing"
-        initialThemeScheme={config.initialThemeScheme}
-      />
-
       <UIProvider
         config={config}
         theme={theme}

--- a/examples/hono/src/index.tsx
+++ b/examples/hono/src/index.tsx
@@ -1,12 +1,18 @@
+import { ColorModeScript, ThemeSchemeScript } from "@yamada-ui/react"
 import { Hono } from "hono"
+import { getCookie } from "hono/cookie"
 import { renderToString } from "react-dom/server"
+import { config } from "./theme"
 
 const app = new Hono()
 
 app.get("*", (c) => {
+  const colorMode = getCookie(c, "ui-color-mode")
+  const themeScheme = getCookie(c, "ui-theme-scheme")
+
   return c.html(
     renderToString(
-      <html lang="ja" data-mode="light">
+      <html lang="ja">
         <head>
           <title>Hono App - Yamada UI</title>
           <meta charSet="utf-8" />
@@ -15,6 +21,16 @@ app.get("*", (c) => {
           <script type="module" src="/src/client.tsx"></script>
         </head>
         <body>
+          <ColorModeScript
+            type="cookie"
+            nonce="testing"
+            initialColorMode={colorMode ?? config.initialColorMode}
+          />
+          <ThemeSchemeScript
+            type="cookie"
+            nonce="testing"
+            initialThemeScheme={themeScheme ?? config.initialThemeScheme}
+          />
           <div id="root"></div>
         </body>
       </html>,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #1186 

## Description

Fixed `examples/hono` flashes in color mode.

## Current behavior (updates)

`Hono` example flashes when reloading.

## New behavior

`Hono` example no longer flashes when reloading.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
