### PR TITLE
Fixed disabled `MenuItem` hover/focus styles

### DIFF
--- a/.changeset/small-foxes-care.md
+++ b/.changeset/small-foxes-care.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where hover and focus styling was applied even when `MenuItem` was disabled.

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -29,9 +29,15 @@ export const Menu: ComponentMultiStyle = {
       },
       _hover: {
         bg: ["blackAlpha.100", "whiteAlpha.100"],
+        _disabled: {
+          bg: ["white", "black"],
+        },
       },
       _active: {
         bg: ["blackAlpha.200", "whiteAlpha.200"],
+        _disabled: {
+          bg: ["white", "black"],
+        },
       },
       _disabled: {
         opacity: 0.4,


### PR DESCRIPTION
Closes #1200

## Description

Fixed disabled `MenuItem` hover/focus styles.

## Is this a breaking change (Yes/No):

No