### PR TITLE
fix(cli): added path to `generated-theme.types.d.ts` for windows

### DIFF
--- a/.changeset/tall-experts-switch.md
+++ b/.changeset/tall-experts-switch.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/cli": patch
+---
+
+Fixed a bug that `generated-theme.types.d.ts` cannot be searched on windows.

--- a/packages/cli/src/command/tokens/resolve-output-path.ts
+++ b/packages/cli/src/command/tokens/resolve-output-path.ts
@@ -13,6 +13,8 @@ const resolveThemePath = async (): Promise<string | undefined> => {
   const paths = [
     path.join("node_modules", ".pnpm", "@yamada-ui+core@*", ...themePath),
     path.join(...themePath),
+    path.posix.join("node_modules", ".pnpm", "@yamada-ui+core@*", ...themePath),
+    path.posix.join(...themePath),
   ]
 
   const triedPaths = await Promise.all(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #1236

## Description

If `pnpm yamada-cli tokens` is run on windows, it cannot find `generated-theme.types.d.ts` and an error occurs.

## Current behavior (updates)

The path to `generated-theme.types.d.ts` for windows is not registered.

## New behavior

Added path to `generated-theme.types.d.ts` for windows.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
