### PR TITLE
Changed the tag of the Card component from section to article

### DIFF
--- a/.changeset/late-scissors-retire.md
+++ b/.changeset/late-scissors-retire.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/card": patch
+---
+
+Fixed a bug in which `section` tags were used in the Card component

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -57,7 +57,7 @@ export const Card = forwardRef<CardProps, "article">((props, ref) => {
 
   return (
     <CardProvider value={styles}>
-      <ui.section
+      <ui.article
         ref={ref}
         className={cx("ui-card", className)}
         __css={css}
@@ -81,7 +81,7 @@ export const CardHeader = forwardRef<CardHeaderProps, "header">(
     }
 
     return (
-      <ui.div
+      <ui.header
         ref={ref}
         className={cx("ui-card__header", className)}
         __css={css}
@@ -129,7 +129,7 @@ export const CardFooter = forwardRef<CardFooterProps, "footer">(
     }
 
     return (
-      <ui.div
+      <ui.footer
         ref={ref}
         className={cx("ui-card__footer", className)}
         __css={css}

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -32,7 +32,7 @@ export type CardProps = Omit<HTMLUIProps<"article">, "direction"> &
   CardOptions
 
 /**
- * `Card` is a component that groups and displays related information. By default, it renders a `section` element.
+ * `Card` is a component that groups and displays related information. By default, it renders a `article` element.
  *
  * @see Docs https://yamada-ui.com/components/data-display/card
  */

--- a/packages/components/card/tests/card.test.tsx
+++ b/packages/components/card/tests/card.test.tsx
@@ -29,28 +29,6 @@ describe("<Card />", () => {
     expect(articleElement).not.toBeNull()
   })
 
-  test("<CardHeader /> renders <ui.header /> component", () => {
-    const { container } = render(
-      <Card>
-        <CardHeader>CardHeader</CardHeader>
-      </Card>,
-    )
-    const headerElement = container.querySelector("header")
-
-    expect(headerElement).not.toBeNull()
-  })
-
-  test("<CardFooter /> renders <ui.footer /> component", () => {
-    const { container } = render(
-      <Card>
-        <CardFooter>CardFooter</CardFooter>
-      </Card>,
-    )
-    const footerElement = container.querySelector("footer")
-
-    expect(footerElement).not.toBeNull()
-  })
-
   test("<CardHeader /> renders correctly", () => {
     const { getByTestId } = render(
       <Card>
@@ -89,6 +67,17 @@ describe("<Card />", () => {
       justifyContent: "flex-start",
       alignItems: "center",
     })
+  })
+
+  test("<CardHeader /> renders <ui.header /> component", () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>CardHeader</CardHeader>
+      </Card>,
+    )
+    const headerElement = container.querySelector("header")
+
+    expect(headerElement).not.toBeNull()
   })
 
   test("<CardBody /> renders correctly", () => {
@@ -169,5 +158,16 @@ describe("<Card />", () => {
       justifyContent: "flex-start",
       alignItems: "center",
     })
+  })
+
+  test("<CardFooter /> renders <ui.footer /> component", () => {
+    const { container } = render(
+      <Card>
+        <CardFooter>CardFooter</CardFooter>
+      </Card>,
+    )
+    const footerElement = container.querySelector("footer")
+
+    expect(footerElement).not.toBeNull()
   })
 })

--- a/packages/components/card/tests/card.test.tsx
+++ b/packages/components/card/tests/card.test.tsx
@@ -22,6 +22,35 @@ describe("<Card />", () => {
     })
   })
 
+  test("<Card /> renders <ui.article /> component", () => {
+    const { container } = render(<Card>Card</Card>)
+    const articleElement = container.querySelector("article")
+
+    expect(articleElement).not.toBeNull()
+  })
+
+  test("<CardHeader /> renders <ui.header /> component", () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>CardHeader</CardHeader>
+      </Card>,
+    )
+    const headerElement = container.querySelector("header")
+
+    expect(headerElement).not.toBeNull()
+  })
+
+  test("<CardFooter /> renders <ui.footer /> component", () => {
+    const { container } = render(
+      <Card>
+        <CardFooter>CardFooter</CardFooter>
+      </Card>,
+    )
+    const footerElement = container.querySelector("footer")
+
+    expect(footerElement).not.toBeNull()
+  })
+
   test("<CardHeader /> renders correctly", () => {
     const { getByTestId } = render(
       <Card>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #1237

## Description

Changed the tag of the Card component from section to article.

## Current behavior (updates)

- `Card` rendered by section tag.
-  `CardHeader` and `CardFooter` rendered div tags.

## New behavior

- `Card` render by article tag.
-  `CardHeader` render by header tag.
-  `CardFooter` render by footer tag.

## Is this a breaking change (Yes/No):

No

## Additional Information

None
