### PR TITLE
Supported for nested keys in `pickObject` and `omitObject`

### DIFF
--- a/.changeset/blue-lemons-repair.md
+++ b/.changeset/blue-lemons-repair.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Updated `DonutChart` and `PieChart` sizes.

--- a/.changeset/lemon-needles-tickle.md
+++ b/.changeset/lemon-needles-tickle.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/utils": minor
+---
+
+Support for nested keys in `pickObject` and `omitObject`.

--- a/.changeset/tiny-countries-push.md
+++ b/.changeset/tiny-countries-push.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Fixed a bug where `mergeStyle` or `mergeMultiStyle` was not merging correctly.

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,14 @@
     },
     "import/resolver": {
       "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx", ".mts", ".d.ts"]
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx",
+          ".mts",
+          ".d.ts"
+        ]
       }
     }
   },
@@ -44,16 +51,37 @@
       }
     ],
     "no-var": "error",
-    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "no-console": [
+      "warn",
+      {
+        "allow": [
+          "warn",
+          "error"
+        ]
+      }
+    ],
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "off",
     "react/no-unescaped-entities": "off",
     "react/jsx-curly-brace-presence": "error",
     "react/jsx-no-leaked-render": "error",
-    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_"
+      }
+    ],
     "@typescript-eslint/consistent-type-imports": "error",
     "unused-imports/no-unused-imports": "error",
-    "vitest/consistent-test-it": ["error", { "fn": "test" }],
+    "vitest/consistent-test-it": [
+      "error",
+      {
+        "fn": "test"
+      }
+    ],
     "vitest/expect-expect": "off",
     "vitest/no-alias-methods": "error",
     "vitest/no-conditional-expect": "error",
@@ -83,37 +111,57 @@
     "vitest/require-hook": "off",
     "vitest/require-to-throw-message": "error",
     "vitest/require-top-level-describe": "error",
-    "vitest/valid-expect": ["error", {
-      "alwaysAwait": true
-    }]
+    "vitest/valid-expect": [
+      "error",
+      {
+        "alwaysAwait": true
+      }
+    ]
   },
   "overrides": [
     {
-      "files": ["**/*.ts", "**/*.tsx"],
+      "files": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "parserOptions": {
-        "project": ["tsconfig.json"]
+        "project": [
+          "tsconfig.json"
+        ]
       }
     },
     {
-      "files": ["scripts/**/*", "packages/cli/**/*", "stories/**/*"],
+      "files": [
+        "scripts/**/*",
+        "packages/cli/**/*",
+        "stories/**/*"
+      ],
       "rules": {
         "no-console": "off"
       }
     },
     {
-      "files": ["scripts/setup-test.ts"],
+      "files": [
+        "scripts/setup-test.ts"
+      ],
       "rules": {
         "vitest/prefer-spy-on": "off"
       }
     },
     {
-      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx"
+      ],
       "rules": {
         "vitest/require-hook": "error"
       }
     },
     {
-      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx"
+      ],
       "rules": {
         "testing-library/prefer-query-by-disappearance": "error",
         "testing-library/no-dom-import": "error",

--- a/packages/core/src/generated-theme.types.ts
+++ b/packages/core/src/generated-theme.types.ts
@@ -751,7 +751,7 @@ export interface GeneratedTheme extends UITheme {
       variants: "solid" | "dashed" | "dotted" | (string & {})
     }
     DonutChart: {
-      sizes: "sm" | "md" | "lg" | "full" | (string & {})
+      sizes: "sm" | "md" | "lg" | (string & {})
       variants: string & {}
     }
     Drawer: {
@@ -854,7 +854,7 @@ export interface GeneratedTheme extends UITheme {
       variants: "simple" | "striped" | "unstyled" | (string & {})
     }
     PieChart: {
-      sizes: "sm" | "md" | "lg" | "full" | (string & {})
+      sizes: "sm" | "md" | "lg" | (string & {})
       variants: string & {}
     }
     PinInput: {

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -8,6 +8,7 @@ import {
   isObject,
   runIfFunc,
   isFunction,
+  merge,
 } from "@yamada-ui/utils"
 import type { CSSUIObject, ThemeProps, UIStyle, UIStyleProps } from "./css"
 import { analyzeBreakpoints, createVars } from "./css"
@@ -304,12 +305,22 @@ const internalFilterStyle =
         target[nestedKey] = (props) =>
           internalFilterStyle(value(props), newKeys, isMulti, newRefs)(func)
       } else {
-        target[nestedKey] = internalFilterStyle(
-          value,
-          newKeys,
-          isMulti,
-          newRefs,
-        )(func)
+        if (
+          func === omitObject ||
+          Object.keys(value).some((key) => newKeys.includes(key))
+        ) {
+          target[nestedKey] = internalFilterStyle(
+            value,
+            newKeys,
+            isMulti,
+            newRefs,
+          )(func)
+        } else {
+          target[nestedKey] = merge(
+            target[nestedKey],
+            internalFilterStyle(value, newKeys, isMulti, newRefs)(func),
+          )
+        }
       }
     })
 

--- a/packages/core/tests/merge-style.test.ts
+++ b/packages/core/tests/merge-style.test.ts
@@ -110,7 +110,7 @@ describe("mergeStyle", () => {
     }
 
     expect(
-      mergeStyle(target, source)({ omit: ["variants", "sm"] }),
+      mergeStyle(target, source)({ omit: ["variants", "sizes.sm"] }),
     ).toStrictEqual(expected)
   })
 
@@ -149,15 +149,12 @@ describe("mergeStyle", () => {
         solid: { bg: "primary" },
       },
       sizes: {
-        md: { w: "md" },
+        sm: { w: "sm" },
       },
     }
 
     expect(
-      mergeStyle(
-        target,
-        source,
-      )({ pick: ["sizes", "md", "variants", "solid"] }),
+      mergeStyle(target, source)({ pick: ["sizes.sm", "variants"] }),
     ).toStrictEqual(expected)
   })
 
@@ -440,10 +437,16 @@ describe("mergeMultiStyle", () => {
         container: { p: "lg", _hover: { color: "success" }, m: "md" },
         inner: { p: { base: "md", lg: "sm" } },
       },
+      variants: {
+        solid: { container: { bg: "primary" } },
+      },
     }
 
     expect(
-      mergeMultiStyle(target, source)({ pick: ["baseStyle", "inner"] }),
+      mergeMultiStyle(
+        target,
+        source,
+      )({ pick: ["baseStyle", "inner", "variants.solid"] }),
     ).toStrictEqual(expected)
   })
 
@@ -476,7 +479,7 @@ describe("mergeMultiStyle", () => {
       mergeMultiStyle(
         target,
         source,
-      )({ pick: ["variants", "solid", "container"] }),
+      )({ pick: ["variants.solid", "container"] }),
     ).toStrictEqual(expected)
   })
 

--- a/packages/utils/tests/object.test.ts
+++ b/packages/utils/tests/object.test.ts
@@ -21,10 +21,24 @@ describe("Object", () => {
     })
   })
 
+  describe("omitObject with nested keys", () => {
+    test("should omit specified keys from an object", () => {
+      const obj = { a: { b: 2, c: 3 }, d: 4 }
+      expect(omitObject(obj, ["a.b", "d"])).toStrictEqual({ a: { c: 3 } })
+    })
+  })
+
   describe("pickObject", () => {
     test("should pick specified keys from an object", () => {
       const obj = { a: 1, b: 2, c: 3 }
       expect(pickObject(obj, ["a", "c"])).toStrictEqual({ a: 1, c: 3 })
+    })
+  })
+
+  describe("pickObject with nested keys", () => {
+    test("should omit specified keys from an object", () => {
+      const obj = { a: { b: 2, c: 3 }, d: 4 }
+      expect(pickObject(obj, ["a.b", "d"])).toStrictEqual({ a: { b: 2 }, d: 4 })
     })
   })
 


### PR DESCRIPTION
Closes #1284

## Description

Supported for nested keys in `pickObject` and `omitObject`.

## Is this a breaking change (Yes/No):

No