### PR TITLE
fix: fixed type of TextStyles and LayerStyles

### DIFF
--- a/.changeset/ten-hotels-yawn.md
+++ b/.changeset/ten-hotels-yawn.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Fixed a bug where TextStyles and LayerStyles have more types than necessary.

--- a/packages/core/src/theme.types.ts
+++ b/packages/core/src/theme.types.ts
@@ -457,8 +457,8 @@ export type ThemeConfig = {
   }
 }
 
-export type LayerStyles = Record<string, UIStyle>
-export type TextStyles = Record<string, UIStyle>
+export type LayerStyles = Record<string, CSSUIObject>
+export type TextStyles = Record<string, CSSUIObject>
 export type ThemeTokens = {
   [key: string | number]:
     | string


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #1303  <!-- Github issue # here -->

## Description

> Add a brief description

Fixed a bug where TextStyles and LayerStyles have more types than necessary.

## Current behavior (updates)

> Please describe the current behavior that you are modifying

## New behavior

> Please describe the behavior or changes this PR adds

Fixed the type of TextStyles and LayerStyles so that only objects should be accepted according to issue.

## Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
