### PR TITLE
fix: add `aria-label` to `menu` in storybook for a11y

### DIFF
--- a/stories/components/overlay/menu.stories.tsx
+++ b/stories/components/overlay/menu.stories.tsx
@@ -58,6 +58,7 @@ export const withCommand: Story = () => {
       <MenuButton
         as={IconButton}
         icon={<Icon icon={faBars} />}
+        aria-label="Menu"
         variant="outline"
       />
 
@@ -76,6 +77,7 @@ export const withIcon: Story = () => {
       <MenuButton
         as={IconButton}
         icon={<Icon icon={faBars} />}
+        aria-label="Menu"
         variant="outline"
       />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1250 

## Description

In `Menu` component's Storybook cases, withIcon and withCommand, `MenuButton` lacked discernible text, causing an a11y violation. To address this issue, I added the `aria-label` attribute to provide a text alternative for screen readers.

## Current behavior (updates)

`With Command`
1 Violations
![image](https://github.com/yamada-ui/yamada-ui/assets/50776036/ad75b8d5-6ad2-4738-a476-3e394c0858fc)

`With Icon`  
1 Violations  
![image](https://github.com/yamada-ui/yamada-ui/assets/50776036/ca714cf2-1c93-42d5-bb66-5cd58784108f)


## New behavior

`With Command`  
0 Violations  
![image](https://github.com/yamada-ui/yamada-ui/assets/50776036/1c94b57f-fa60-414a-87c0-8096c3b56c0c)

`With Icon`
0 Violations  
![image](https://github.com/yamada-ui/yamada-ui/assets/50776036/1d0ee498-47cc-4568-9da9-77ddf1a4df2e)


## Is this a breaking change (Yes/No):
No

## Additional Information
