### PR TITLE
fix: hidden button(calendar__month__day) if the custom component is a not displayed element for a11y

### DIFF
--- a/.changeset/twenty-tips-push.md
+++ b/.changeset/twenty-tips-push.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/calendar": patch
+---
+
+Fixed to set `display: none` on button if a custom component is not displayed element (e.g. null, undefined, boolean) in order to address a11y violations.

--- a/packages/components/calendar/src/month.tsx
+++ b/packages/components/calendar/src/month.tsx
@@ -188,6 +188,21 @@ export const Month: FC<MonthProps> = ({
                             index,
                           })
 
+                          const day = customDay({
+                            date,
+                            row,
+                            col,
+                            weekday: weekdays[col],
+                            isSelected,
+                            isWeekend,
+                            isOutside,
+                          })
+
+                          const isDisplayed =
+                            day !== null &&
+                            day !== undefined &&
+                            typeof day !== "boolean"
+
                           return (
                             <ui.td
                               key={col}
@@ -206,20 +221,14 @@ export const Month: FC<MonthProps> = ({
                                   p: 0,
                                   fontSize: undefined,
                                   fontWeight: "normal",
-                                  ...(isHidden ? { display: "none" } : {}),
+                                  ...(isHidden || !isDisplayed
+                                    ? { display: "none" }
+                                    : {}),
                                   ...styles.day,
                                 }}
                                 {...props}
                               >
-                                {customDay({
-                                  date,
-                                  row,
-                                  col,
-                                  weekday: weekdays[col],
-                                  isSelected,
-                                  isWeekend,
-                                  isOutside,
-                                })}
+                                {day}
                               </Button>
                             </ui.td>
                           )

--- a/packages/components/calendar/src/month.tsx
+++ b/packages/components/calendar/src/month.tsx
@@ -2,7 +2,13 @@ import type { ButtonProps } from "@yamada-ui/button"
 import { Button } from "@yamada-ui/button"
 import type { HTMLUIProps } from "@yamada-ui/core"
 import { ui } from "@yamada-ui/core"
-import { cx, dataAttr, filterUndefined } from "@yamada-ui/utils"
+import {
+  cx,
+  dataAttr,
+  filterUndefined,
+  isNull,
+  isUndefined,
+} from "@yamada-ui/utils"
 import dayjs from "dayjs"
 import type { FC } from "react"
 import { useMemo } from "react"
@@ -199,8 +205,8 @@ export const Month: FC<MonthProps> = ({
                           })
 
                           const isDisplayed =
-                            day !== null &&
-                            day !== undefined &&
+                            !isNull(day) &&
+                            !isUndefined(day) &&
                             typeof day !== "boolean"
 
                           return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1254 

## Description

If a custom component was a not displayed element (e.g. null, undefined, boolean), there was no identifiable text in the button (calendar__month__day), causing an a11y violation. To address this issue, the custom component now sets `display: none` when the element is not displayed.

## Current behavior (updates)

`Custom Day Button`

![CleanShot 2024-04-28 at 12 44 46@2x](https://github.com/yamada-ui/yamada-ui/assets/50891407/3e5f10b0-9461-48f0-a844-c271fe4808da)

## New behavior

`Custom Day Button`

![CleanShot 2024-04-28 at 12 44 29@2x](https://github.com/yamada-ui/yamada-ui/assets/50891407/dbaf1fef-98b3-48fe-9d0c-35c2b84d9de3)

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

No

## Additional Information
