### PR TITLE
fix: add `placeholder` to `colorPicker` in storybook for a11y

### DIFF
--- a/stories/components/forms/color-picker.stories.tsx
+++ b/stories/components/forms/color-picker.stories.tsx
@@ -13,32 +13,40 @@ const meta: Meta<typeof ColorPicker> = {
   component: ColorPicker,
 }
 
+const defaultPlaceholder = "#4387f4"
+
 export default meta
 
 export const basic: Story = () => {
-  return <ColorPicker placeholder="#4387f4" />
+  return <ColorPicker placeholder={defaultPlaceholder} />
 }
 
 export const withDefaultValue: Story = () => {
-  return <ColorPicker defaultValue="#4387f4ff" />
+  return (
+    <ColorPicker placeholder={defaultPlaceholder} defaultValue="#4387f4ff" />
+  )
 }
 
 export const withFallbackValue: Story = () => {
-  return <ColorPicker fallbackValue="#000000" />
+  return (
+    <ColorPicker placeholder={defaultPlaceholder} fallbackValue="#000000" />
+  )
 }
 
 export const withDefaultColor: Story = () => {
-  return <ColorPicker defaultColor="#4387f4ff" />
+  return (
+    <ColorPicker placeholder={defaultPlaceholder} defaultColor="#4387f4ff" />
+  )
 }
 
 export const withChildren: Story = () => {
   return (
     <>
-      <ColorPicker placeholder="#4387f4">
+      <ColorPicker placeholder={defaultPlaceholder}>
         <Button>Submit</Button>
       </ColorPicker>
 
-      <ColorPicker placeholder="#4387f4">
+      <ColorPicker placeholder={defaultPlaceholder}>
         {({ value }) => <Button>Submit {value}</Button>}
       </ColorPicker>
     </>
@@ -79,7 +87,13 @@ export const withVariant: Story = () => {
 }
 
 export const withFormat: Story = () => {
-  return <ColorPicker defaultValue="hsla(240, 100%, 50%, 1)" format="hsla" />
+  return (
+    <ColorPicker
+      placeholder="hsla(240, 100%, 50%, 1)"
+      defaultValue="hsla(240, 100%, 50%, 1)"
+      format="hsla"
+    />
+  )
 }
 
 export const withFormatInput: Story = () => {
@@ -94,6 +108,7 @@ export const withFormatInput: Story = () => {
 export const withSwatches: Story = () => {
   return (
     <ColorPicker
+      placeholder={defaultPlaceholder}
       swatchesLabel="Saved Colors"
       swatches={[
         "#2e2e2e",
@@ -118,6 +133,7 @@ export const withSwatches: Story = () => {
 export const withSwatchesColumns: Story = () => {
   return (
     <ColorPicker
+      placeholder={defaultPlaceholder}
       swatchesLabel="Saved Colors"
       swatchesColumns={{ base: 8, md: 7 }}
       swatches={[
@@ -143,6 +159,7 @@ export const withSwatchesColumns: Story = () => {
 export const withCloseOnSelectSwatch: Story = () => {
   return (
     <ColorPicker
+      placeholder={defaultPlaceholder}
       swatchesLabel="Saved Colors"
       swatches={[
         "#2e2e2e",
@@ -166,12 +183,13 @@ export const withCloseOnSelectSwatch: Story = () => {
 }
 
 export const disabledAllowInput: Story = () => {
-  return <ColorPicker placeholder="#4387f4ff" allowInput={false} />
+  return <ColorPicker placeholder={defaultPlaceholder} allowInput={false} />
 }
 
 export const disabledPicker: Story = () => {
   return (
     <ColorPicker
+      placeholder={defaultPlaceholder}
       withPicker={false}
       swatchesLabel="Saved Colors"
       swatches={[
@@ -196,23 +214,25 @@ export const disabledPicker: Story = () => {
 }
 
 export const disabledChannel: Story = () => {
-  return <ColorPicker withChannel={false} />
+  return <ColorPicker placeholder={defaultPlaceholder} withChannel={false} />
 }
 
 export const disabledSwatch: Story = () => {
-  return <ColorPicker withSwatch={false} />
+  return <ColorPicker placeholder={defaultPlaceholder} withSwatch={false} />
 }
 
 export const disabledEyeDropper: Story = () => {
-  return <ColorPicker withEyeDropper={false} />
+  return <ColorPicker placeholder={defaultPlaceholder} withEyeDropper={false} />
 }
 
 export const enabledColorPickerEyeDropper: Story = () => {
-  return <ColorPicker withColorSelectorEyeDropper />
+  return (
+    <ColorPicker placeholder={defaultPlaceholder} withColorSelectorEyeDropper />
+  )
 }
 
 export const enabledResult: Story = () => {
-  return <ColorPicker withResult />
+  return <ColorPicker placeholder={defaultPlaceholder} withResult />
 }
 
 export const withBorderColor: Story = () => {
@@ -235,32 +255,32 @@ export const withBorderColor: Story = () => {
 }
 
 export const withPlacement: Story = () => {
-  return <ColorPicker placeholder="#4387f4" placement="bottom-end" />
+  return <ColorPicker placeholder={defaultPlaceholder} placement="bottom-end" />
 }
 
 export const withOffset: Story = () => {
-  return <ColorPicker placeholder="#4387f4" offset={[16, 16]} />
+  return <ColorPicker placeholder={defaultPlaceholder} offset={[16, 16]} />
 }
 
 export const withGutter: Story = () => {
-  return <ColorPicker placeholder="#4387f4" gutter={32} />
+  return <ColorPicker placeholder={defaultPlaceholder} gutter={32} />
 }
 
 export const withDuration: Story = () => {
-  return <ColorPicker placeholder="#4387f4" duration={0.4} />
+  return <ColorPicker placeholder={defaultPlaceholder} duration={0.4} />
 }
 
 export const isDisabled: Story = () => {
   return (
     <>
-      <ColorPicker placeholder="#4387f4" isDisabled />
+      <ColorPicker placeholder={defaultPlaceholder} isDisabled />
 
       <FormControl
         isDisabled
         label="Pick color"
         helperMessage="Please select your favorite color"
       >
-        <ColorPicker placeholder="#4387f4" />
+        <ColorPicker placeholder={defaultPlaceholder} />
       </FormControl>
     </>
   )
@@ -269,14 +289,14 @@ export const isDisabled: Story = () => {
 export const isReadonly: Story = () => {
   return (
     <>
-      <ColorPicker placeholder="#4387f4" isReadOnly />
+      <ColorPicker placeholder={defaultPlaceholder} isReadOnly />
 
       <FormControl
         isReadOnly
         label="Pick color"
         helperMessage="Please select your favorite color"
       >
-        <ColorPicker placeholder="#4387f4" />
+        <ColorPicker placeholder={defaultPlaceholder} />
       </FormControl>
     </>
   )
@@ -289,11 +309,13 @@ export const customEyeDropperIcon: Story = () => {
         eyeDropperProps={{
           color: "primary",
         }}
+        placeholder={defaultPlaceholder}
       />
       <ColorPicker
         eyeDropperProps={{
           children: <Icon icon={faPoo} />,
         }}
+        placeholder={defaultPlaceholder}
       />
     </>
   )
@@ -302,7 +324,13 @@ export const customEyeDropperIcon: Story = () => {
 export const customControl: Story = () => {
   const [value, onChange] = useState<string>("#4387f4ff")
 
-  return <ColorPicker value={value} onChange={onChange} />
+  return (
+    <ColorPicker
+      placeholder={defaultPlaceholder}
+      value={value}
+      onChange={onChange}
+    />
+  )
 }
 
 export const reactHookForm: Story = () => {


### PR DESCRIPTION
Closes #1241 

## Description

In Menu component's Storybook 15 cases, `colorPicker` lacked discernible text, causing an a11y violation. To address this issue, I added the `placeholder` attribute to provide a text alternative for screen readers.

## Current behavior (updates)

Here are the test results when running test-storybook limited to
`stories/components/forms/color-picker.stories.tsx:`
(Error details are omitted. Issue: #1241  )
```
$ pnpm test-storybook
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
 FAIL   browser: chromium  stories/components/forms/color-picker.stories.tsx (19.835 s)
  ● Components / Forms / ColorPicker › withDefaultValue › smoke-test
  ● Components / Forms / ColorPicker › withFallbackValue › smoke-test
  ● Components / Forms / ColorPicker › withDefaultColor › smoke-test
  ● Components / Forms / ColorPicker › withFormat › smoke-test
  ● Components / Forms / ColorPicker › withSwatches › smoke-test
  ● Components / Forms / ColorPicker › withSwatchesColumns › smoke-test
  ● Components / Forms / ColorPicker › withCloseOnSelectSwatch › smoke-test
  ● Components / Forms / ColorPicker › disabledPicker › smoke-test
  ● Components / Forms / ColorPicker › disabledChannel › smoke-test
  ● Components / Forms / ColorPicker › disabledSwatch › smoke-test
  ● Components / Forms / ColorPicker › disabledEyeDropper › smoke-test
  ● Components / Forms / ColorPicker › enabledColorPickerEyeDropper › smoke-test
  ● Components / Forms / ColorPicker › enabledResult › smoke-test
  ● Components / Forms / ColorPicker › customEyeDropperIcon › smoke-test
  ● Components / Forms / ColorPicker › customControl › smoke-test

Test Suites: 1 failed, 1 total
Tests:       15 failed, 15 passed, 30 total
Snapshots:   0 total
Time:        20.973 s
Ran all test suites.

```
## New behavior
Here are the test results when running test-storybook limited to
`stories/components/forms/color-picker.stories.tsx:`

```
$ pnpm test-storybook
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
 PASS   browser: chromium  stories/components/forms/color-picker.stories.tsx (19.523 s)

Test Suites: 1 passed, 1 total
Tests:       30 passed, 30 total
Snapshots:   0 total
Time:        20.45 s
Ran all test suites.
```
## Is this a breaking change (Yes/No):
No

## Additional Information
