### PR TITLE
Updated `omitThemeProps` to support custom keys.

### DIFF
--- a/.changeset/tricky-papayas-occur.md
+++ b/.changeset/tricky-papayas-occur.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Updated `omitThemeProps` to accept custom keys.

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -204,8 +204,13 @@ const mergeVars =
 const omitTheme = (theme: Dict): Dict =>
   omitObject(theme, ["__cssMap", "__cssVar", "__breakpoints"])
 
-export const omitThemeProps = <T extends ThemeProps>(props: T) =>
-  omitObject(props, ["size", "variant", "colorScheme"])
+export const omitThemeProps = <
+  T extends ThemeProps,
+  K extends Exclude<keyof T, "size" | "variant" | "colorScheme"> = never,
+>(
+  props: T,
+  keys: K[] = [],
+) => omitObject(props, ["size", "variant", "colorScheme", ...keys])
 
 type MergeStyleOptions = Omit<Partial<FilterStyleOptions>, "isMulti">
 


### PR DESCRIPTION
Closes #1311

## Description

Updated `omitThemeProps` to support custom keys.

## Is this a breaking change (Yes/No):

No