### PR TITLE
test(useResizeObserver): enhanced test coverage

### DIFF
--- a/packages/hooks/use-resize-observer/tests/index.test.tsx
+++ b/packages/hooks/use-resize-observer/tests/index.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react"
+import { Button } from "@yamada-ui/react"
+import { useResizeObserver } from "../src"
+
+describe("useResizeObserver", () => {
+  const defaultResizeObserver = global.ResizeObserver
+
+  beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        ;(() => {
+          cb(
+            [
+              {
+                contentRect: {
+                  height: 320,
+                  width: 400,
+                },
+              },
+            ] as ResizeObserverEntry[],
+            this,
+          )
+        })()
+      }
+      observe = vi.fn()
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+    }
+  })
+
+  afterAll(() => {
+    global.ResizeObserver = defaultResizeObserver
+  })
+
+  const ButtonWithSize = () => {
+    const [ref, rect] = useResizeObserver()
+    return (
+      <Button ref={ref}>
+        {rect.width} x {rect.height}
+      </Button>
+    )
+  }
+
+  test("return contentRect value correctly", async () => {
+    render(<ButtonWithSize />)
+    const button = await screen.findByRole("button")
+
+    expect(button.textContent).toBe("400 x 320")
+  })
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1054  <!-- Github issue # here -->

## Description

This teste is that useResizeOver returns rect correctly when used on a component with useResizeOver's ref.

## Additional Information

Since global.ResizeObserver is mock, I confirmed that Rect refers to the value of ResizeObserverEntry.contentRect
