### PR TITLE
Removed incorrect `aria-readonly` attribute

### DIFF
--- a/.changeset/large-wombats-dream.md
+++ b/.changeset/large-wombats-dream.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/file-input": patch
+---
+
+Fixed a bug where `aria-readonly` was assigned to an element even though the `readOnly` attribute was not assigned.

--- a/packages/components/file-input/src/file-input.tsx
+++ b/packages/components/file-input/src/file-input.tsx
@@ -207,7 +207,6 @@ export const FileInput = forwardRef<FileInputProps, "input">(
           ref={mergeRefs(inputRef, ref)}
           type="file"
           aria-hidden
-          aria-readonly
           tabIndex={-1}
           id={id}
           name={name}


### PR DESCRIPTION
Closes #1320

## Description

Fixed a bug where `aria-readonly` was assigned to an element even though the `readOnly` attribute was not assigned.

## Is this a breaking change (Yes/No):

No