### PR TITLE
refactor: delete the redundant the omitObject function

### DIFF
--- a/.changeset/tidy-years-reflect.md
+++ b/.changeset/tidy-years-reflect.md
@@ -1,5 +1,5 @@
 ---
-"@yamada-ui/image": minor
+"@yamada-ui/image": patch
 ---
 
 delete the redundant omitObject

--- a/.changeset/tidy-years-reflect.md
+++ b/.changeset/tidy-years-reflect.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/image": minor
+---
+
+delete the redundant omitObject

--- a/packages/components/image/src/image.tsx
+++ b/packages/components/image/src/image.tsx
@@ -47,6 +47,8 @@ export const Image = forwardRef<ImageProps, "img">((props, ref) => {
     crossOrigin,
     className,
     fallbackStrategy = "beforeLoadOrError",
+    onError,
+    onLoad,
     referrerPolicy,
     size: boxSize,
     fit: objectFit,
@@ -55,7 +57,7 @@ export const Image = forwardRef<ImageProps, "img">((props, ref) => {
 
   ignoreFallback = loading != null || ignoreFallback || !fallback
 
-  const status = useImage({ ...props, crossOrigin, ignoreFallback })
+  const status = useImage({ ...props, ignoreFallback })
 
   const css = useMemo(() => ({ boxSize, objectFit }), [boxSize, objectFit])
 
@@ -71,7 +73,7 @@ export const Image = forwardRef<ImageProps, "img">((props, ref) => {
           className={cx("ui-image--fallback", className)}
           src={fallback as string | undefined}
           __css={css}
-          {...(ignoreFallback ? rest : omitObject(rest, ["onError", "onLoad"]))}
+          {...(ignoreFallback ? { ...rest, onError, onLoad } : rest)}
         />
       )
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1321 <!-- Github issue # here -->
- https://github.com/yamada-ui/yamada-ui/issues/1321

## Description

This PR updates the `Image` component, refining the handling of fallback images based on image load states and errors. It specifically adjusts property handling in the `useImage` hook and modifies the conditional prop spreading in the image rendering logic.

## Current behavior (updates)

Currently, the `Image` component might not correctly handle `crossOrigin` attributes when determining image statuses, and its conditional prop spreading logic in the rendering phase can be misleading, causing `onError` and `onLoad` to be omitted unpredictably.

## New behavior

- **Include `crossOrigin` in `useImage` Hook:** Ensures that `crossOrigin` is considered in the image loading process, enhancing adherence to security and access policies.
- **Adjusted Conditional Rest Spread Logic:** Changes how additional props are spread based on the `ignoreFallback` state, making it more intuitive and ensuring `onError` and `onLoad` handlers are included as expected.

## Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information

These changes aim to improve the robustness and clarity of the `Image` component's fallback mechanism, ensuring a more reliable and predictable behavior in image handling scenarios, especially in environments with strict content security policies.
