### PR TITLE
fix: integrate omitobject with omitothemeprops

### DIFF
--- a/.changeset/red-pans-impress.md
+++ b/.changeset/red-pans-impress.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/modal": patch
+---
+
+Integrate `omitObject` with `omitThemeProps`

--- a/.changeset/rotten-tips-study.md
+++ b/.changeset/rotten-tips-study.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/modal": patch
+"@yamada-ui/table": patch
+---
+
+Integrate `omitObject` with `omitThemeProps`

--- a/packages/components/modal/src/drawer.tsx
+++ b/packages/components/modal/src/drawer.tsx
@@ -14,7 +14,6 @@ import {
   getValidChildren,
   findChildren,
   cx,
-  omitObject,
   isArray,
 } from "@yamada-ui/utils"
 import type { FC } from "react"
@@ -150,7 +149,7 @@ export const Drawer = forwardRef<DrawerProps, "div">(
       blankForDragProps,
       portalProps,
       ...rest
-    } = omitThemeProps(mergedProps)
+    } = omitThemeProps(mergedProps, ["isFullHeight"])
 
     const validChildren = getValidChildren(children)
 
@@ -195,7 +194,7 @@ export const Drawer = forwardRef<DrawerProps, "div">(
               withCloseButton,
               withDragBar,
               blankForDragProps,
-              ...omitObject(rest, ["isFullHeight"]),
+              ...rest,
               placement,
               closeOnDrag,
             }}

--- a/packages/components/table/src/paging-table.tsx
+++ b/packages/components/table/src/paging-table.tsx
@@ -6,7 +6,7 @@ import type { PaginationProps } from "@yamada-ui/pagination"
 import { Pagination } from "@yamada-ui/pagination"
 import type { SelectProps } from "@yamada-ui/select"
 import { Select } from "@yamada-ui/select"
-import { cx, isFunction, omitObject } from "@yamada-ui/utils"
+import { cx, isFunction } from "@yamada-ui/utils"
 import type { ForwardedRef, ReactNode, Ref } from "react"
 import { forwardRef } from "react"
 import type { TableBodyProps } from "./tbody"
@@ -161,7 +161,12 @@ export const PagingTable = forwardRef(
       layout,
       children,
       ...computedProps
-    } = omitThemeProps(mergedProps)
+    } = omitThemeProps(mergedProps, [
+      "highlightOnSelected",
+      "highlightOnHover",
+      "withBorder",
+      "withColumnBorders",
+    ])
 
     const {
       state,
@@ -176,12 +181,7 @@ export const PagingTable = forwardRef(
       pageSizeList,
       ...rest
     } = useTable<Y>({
-      ...omitObject(computedProps, [
-        "highlightOnSelected",
-        "highlightOnHover",
-        "withBorder",
-        "withColumnBorders",
-      ]),
+      ...computedProps,
       checkboxProps: { colorScheme, ...checkboxProps },
       enablePagination: true,
     })


### PR DESCRIPTION
Closes #1324, #1326

## Description
Integrate `omitObject` handling with `omitThemeProps`.

## New behavior

Integrate `omitObject` with `omitThemeProps`

## Is this a breaking change (No)

## Additional Information
This pull request is being submitted again based on the first feedback.
And I have added new pull request "#1326" on May 7th.