### PR TITLE
Integrate `omitobject` handling with `omitthemeprops`

### DIFF
--- a/.changeset/large-hats-switch.md
+++ b/.changeset/large-hats-switch.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/modal": patch
+---
+
+Integrate `omitObject` handling with `omitThemeProps`

--- a/packages/components/modal/src/drawer.tsx
+++ b/packages/components/modal/src/drawer.tsx
@@ -14,7 +14,6 @@ import {
   getValidChildren,
   findChildren,
   cx,
-  omitObject,
   isArray,
 } from "@yamada-ui/utils"
 import type { FC } from "react"
@@ -150,7 +149,7 @@ export const Drawer = forwardRef<DrawerProps, "div">(
       blankForDragProps,
       portalProps,
       ...rest
-    } = omitThemeProps(mergedProps)
+    } = omitThemeProps(mergedProps, ["isFullHeight"])
 
     const validChildren = getValidChildren(children)
 
@@ -195,7 +194,7 @@ export const Drawer = forwardRef<DrawerProps, "div">(
               withCloseButton,
               withDragBar,
               blankForDragProps,
-              ...omitObject(rest, ["isFullHeight"]),
+              ...rest,
               placement,
               closeOnDrag,
             }}


### PR DESCRIPTION
Closes #1324 

## Description

Integrate `omitObject` handling with `omitThemeProps`

## Is this a breaking change (Yes/No):

No