### PR TITLE
fix: deleted unnecessary omitObject in ColorPicker

### DIFF
--- a/.changeset/early-cheetahs-wave.md
+++ b/.changeset/early-cheetahs-wave.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+Unnecessary omitObject in ColorPicker is integrated with omitThemeProps.

--- a/packages/components/color-picker/src/color-picker.tsx
+++ b/packages/components/color-picker/src/color-picker.tsx
@@ -7,12 +7,7 @@ import {
 } from "@yamada-ui/core"
 import { Popover, PopoverContent, PopoverTrigger } from "@yamada-ui/popover"
 import { Portal, type PortalProps } from "@yamada-ui/portal"
-import {
-  cx,
-  getValidChildren,
-  isValidElement,
-  omitObject,
-} from "@yamada-ui/utils"
+import { cx, getValidChildren, isValidElement } from "@yamada-ui/utils"
 import { cloneElement } from "react"
 import type { ColorSelectorProps } from "./color-selector"
 import { ColorSelector } from "./color-selector"
@@ -123,7 +118,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, "input">(
       channelProps,
       portalProps = { isDisabled: true },
       ...computedProps
-    } = omitThemeProps(omitObject(mergedProps, ["withSwatch"]))
+    } = omitThemeProps(mergedProps, ["withSwatch"])
     const {
       allowInput,
       eyeDropperSupported,


### PR DESCRIPTION
Closes #1315 

## Description

Fixed to integrate unnecessary omitObject in ColorPicker with omitThemeProps.