### PR TITLE
Exclude maintainer if already has a PR to review

### DIFF
--- a/scripts/observe-pull-requests.ts
+++ b/scripts/observe-pull-requests.ts
@@ -11,7 +11,7 @@ type Collaborator = Awaited<
 type Review = Awaited<
   ReturnType<typeof octokit.pulls.listReviews>
 >["data"][number]
-type Reviewer = Awaited<ReturnType<typeof getPullRequest>>["user"]
+type Reviewers = Awaited<ReturnType<typeof getPullRequest>>["reviewers"]
 type RequestedReviewers = Awaited<
   ReturnType<typeof getPullRequest>
 >["requested_reviewers"]
@@ -127,7 +127,7 @@ const getReviewers = async (pullRequests: Issue[]) => {
     [key: number]: {
       requested_reviewers: RequestedReviewers
       draft: boolean | undefined
-      reviewers: Reviewer[]
+      reviewers: Reviewers
       head: Head
     }
   } = {}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1522

## Description

With this PR, assigning reviews will be less biased as it will cycle through maintainers who doesn't have a PR to review.

## Current behavior (updates)

Some maintainers are not getting review assigned due to how we pick reviewers randomly.

## New behavior

Excludes maintainer if they already have a PR to review.

## Is this a breaking change (Yes/No):

No