### PR TITLE
feat(markdown): enable use of strong syntax (`**`) within note syntax

### DIFF
--- a/.changeset/tough-apricots-fly.md
+++ b/.changeset/tough-apricots-fly.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/markdown": patch
+---
+
+Enable use of strong syntax (`**`) within note syntax

--- a/packages/components/markdown/src/remark-ui-component.ts
+++ b/packages/components/markdown/src/remark-ui-component.ts
@@ -1,7 +1,7 @@
 import type { AlertStatus } from "@yamada-ui/core"
 import { isNull, isUndefined } from "@yamada-ui/utils"
 import type { Parent as HastParent } from "hast"
-import type { Break, Paragraph, PhrasingContent, Root } from "mdast"
+import type { Break, Paragraph, PhrasingContent, Root, Strong } from "mdast"
 import type { ElementContent } from "react-markdown/lib"
 import { match, P } from "ts-pattern"
 import type { Plugin } from "unified"
@@ -160,6 +160,11 @@ export const remarkUIComponent: Plugin<[], Root, Root> = () => {
               buf.push(breakNode)
             }
           })
+          .with({ type: "strong" }, (strongNode) => {
+            if (isMerging) {
+              buf.push(strongNode)
+            }
+          })
           .with(P._, () => {})
       }
 
@@ -214,6 +219,15 @@ export const rehypeBreakPlugin: Plugin = () => {
         tagName: "br",
         properties: {},
         children: [],
+      })
+    })
+
+    visit(tree, "strong", (node: Strong, index: number, parent: HastParent) => {
+      parent.children.splice(index!, 1, {
+        type: "element",
+        tagName: "strong",
+        properties: {},
+        children: [...node.children] as ElementContent[],
       })
     })
   }

--- a/packages/components/markdown/tests/with-note-components.test.tsx
+++ b/packages/components/markdown/tests/with-note-components.test.tsx
@@ -253,5 +253,21 @@ describe("Markdown / With Note Components", () => {
       const thirdLineText = screen.queryByText(/:::/)
       expect(thirdLineText).toBeNull()
     })
+
+    test("When the markdown syntax for strong (**) is used, it should render as a <strong> tag.", async () => {
+      const content = dedent`
+        :::note status=success
+        This is a success **note**.
+        :::
+      `
+      render(<Markdown>{content}</Markdown>)
+
+      const text = screen.queryByText(/This is a success/)
+      expect(text).toBeInTheDocument()
+
+      const strong = text!.querySelector("strong")
+      expect(strong).toBeInTheDocument()
+      expect(strong).toHaveTextContent("note")
+    })
   })
 })


### PR DESCRIPTION
## Description

With this PR, the following Markdown will render as shown in the following image.

```markdown
:::note status=error
Status is **error**.
:::
```

![image](https://github.com/yamada-ui/yamada-ui/assets/33865215/dd6f0615-23eb-4ba3-b303-54b73d51f7fa)

