### PR TITLE
refactor(menuoptiongroup): integrate `omitObject` handling with `omitThemeProps`

### DIFF
--- a/.changeset/six-waves-switch.md
+++ b/.changeset/six-waves-switch.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/menu-option-group": patch
+---
+
+Remove unnecessary omitObjects in MenuOptionGroup component

--- a/packages/components/menu/src/menu-option-group.tsx
+++ b/packages/components/menu/src/menu-option-group.tsx
@@ -1,6 +1,6 @@
 import type { ComponentArgs, HTMLUIProps } from "@yamada-ui/core"
 import { useControllableState } from "@yamada-ui/use-controllable-state"
-import { cx, getValidChildren, omitObject, isArray } from "@yamada-ui/utils"
+import { cx, getValidChildren, isArray } from "@yamada-ui/utils"
 import type { ForwardedRef, Ref } from "react"
 import { cloneElement, forwardRef, useCallback } from "react"
 import { MenuGroup } from "./menu-group"
@@ -41,7 +41,9 @@ export const MenuOptionGroup = forwardRef(
   <Y extends string | string[] = string>(
     {
       className,
+      value: valueProp,
       defaultValue,
+      onChange: onChangeProp,
       type,
       children,
       ...rest
@@ -53,8 +55,9 @@ export const MenuOptionGroup = forwardRef(
     defaultValue ??= (isRadio ? "" : []) as Y
 
     const [value, setValue] = useControllableState({
-      ...rest,
+      value: valueProp,
       defaultValue,
+      onChange: onChangeProp,
     })
 
     const onChange = useCallback(
@@ -94,7 +97,7 @@ export const MenuOptionGroup = forwardRef(
       <MenuGroup
         ref={ref}
         className={cx("ui-menu__item--group--option", className)}
-        {...omitObject(rest, ["value", "onChange"])}
+        {...rest}
       >
         {cloneChildren}
       </MenuGroup>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1328  <!-- Github issue # here -->

## Description
Removed unnecessary `omitObject` in the `MenuOptionGroup` component to integrate its handling with `omitThemeProps`. 

## Is this a breaking change (Yes/No):
No