### PR TITLE
Corrected readOnly behavior in `MultiSelect`

### DIFF
--- a/.changeset/sweet-items-try.md
+++ b/.changeset/sweet-items-try.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where the clear button of `MultiSelect` could be clicked when `isReadOnly` was `true`.

--- a/packages/theme/src/components/multi-select.ts
+++ b/packages/theme/src/components/multi-select.ts
@@ -11,6 +11,9 @@ export const MultiSelect: ComponentMultiStyle = mergeMultiStyle(Select, {
       _hover: {
         opacity: 0.8,
       },
+      _readOnly: {
+        pointerEvents: "none",
+      },
       _disabled: {
         pointerEvents: "none",
         opacity: 0.4,


### PR DESCRIPTION
Closes #1582

## Description

Corrected readOnly behavior in `MultiSelect`.

## Is this a breaking change (Yes/No):

No