### PR TITLE
fix: use `@testing-library/user-event` to implement keyboard event in `Menu` component test

### DIFF
--- a/.changeset/blue-monkeys-sniff.md
+++ b/.changeset/blue-monkeys-sniff.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/menu": major
+---
+
+Fix `Menu` component test

--- a/packages/components/menu/tests/menu.test.tsx
+++ b/packages/components/menu/tests/menu.test.tsx
@@ -234,7 +234,7 @@ describe("<Menu />", () => {
   })
 
   test("keydown events for ArrowDown", async () => {
-    const { getByRole } = render(
+    const { user } = render(
       <Menu>
         <MenuButton>Menu</MenuButton>
         <MenuList>
@@ -244,16 +244,15 @@ describe("<Menu />", () => {
       </Menu>,
     )
 
-    const menuButton = getByRole("button", { name: "Menu" })
-
-    fireEvent.focus(menuButton)
-
-    await act(() => fireEvent.keyDown(menuButton, { key: "ArrowDown" }))
+    // focus the menu button
+    await user.keyboard("[Tab]")
+    // open the menu
+    await user.keyboard("[ArrowDown]")
     expect(screen.getByText("Add item")).toHaveFocus()
   })
 
   test("keydown events for ArrowUp", async () => {
-    const { getByRole } = render(
+    const { user } = render(
       <Menu>
         <MenuButton>Menu</MenuButton>
         <MenuList>
@@ -263,16 +262,15 @@ describe("<Menu />", () => {
       </Menu>,
     )
 
-    const menuButton = getByRole("button", { name: "Menu" })
-
-    fireEvent.focus(menuButton)
-
-    await act(() => fireEvent.keyDown(menuButton, { key: "ArrowUp" }))
+    // focus the menu button
+    await user.keyboard("[Tab]")
+    // open the menu
+    await user.keyboard("[ArrowUp]")
     expect(screen.getByText("Edit item")).toHaveFocus()
   })
 
   test("keydown events for Enter", async () => {
-    const { getByRole } = render(
+    const { user } = render(
       <Menu>
         <MenuButton>Menu</MenuButton>
         <MenuList>
@@ -281,12 +279,10 @@ describe("<Menu />", () => {
         </MenuList>
       </Menu>,
     )
-
-    const menuButton = getByRole("button", { name: "Menu" })
-
-    fireEvent.focus(menuButton)
-
-    await act(() => fireEvent.keyDown(menuButton, { key: "Enter" }))
+    // focus the menu button
+    await user.keyboard("[Tab]")
+    // open the menu
+    await user.keyboard("[Enter]")
     expect(screen.getByText("Add item")).toHaveFocus()
   })
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1605

## Description

This fix lets `Menu` component test passed as this updated way of testing can correctly detect `tab-index=-1` is not focusable.

## Current behavior (updates)

> Please describe the current behavior that you are modifying

- Execute `pnpm test menu`
- The test result will be:
<img width="581" alt="image" src="https://github.com/yamada-ui/yamada-ui/assets/74392116/b1c351cb-db98-48a7-9107-3dccf6e67389">

- One of the test case's failed results shows:
<img width="974" alt="image" src="https://github.com/yamada-ui/yamada-ui/assets/74392116/3fe27981-aec3-42d5-a4f9-f727bd9c5b9a">

- This means that even the element that has `tab-index=-1` attribute can be focused with the current test code, which is `<ul />`.
- However, if it isn't in the testing environment, the element which has `tab-index=-1` attribute is correctly ignored, and `Menu` component is working correctly in the production, so the test code is the one to be correted.
 
## New behavior

> Please describe the behavior or changes this PR adds

- With the change of this PR, the element which has `tab-index=-1` attribute will be successfully ignored since the test code now uses `@testing-library/user-event` to implement keyboard event instead of using fireEvent from `@testing-library/react`.

<img width="942" alt="image" src="https://github.com/yamada-ui/yamada-ui/assets/74392116/10e2ad45-d8d9-4161-9e07-73dc44ac07cb">

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
Nothing.