### PR TITLE
test(icon): replace `Md3dRotation` with `FaMarkdown`

### DIFF
--- a/packages/components/icon/tests/icon.test.tsx
+++ b/packages/components/icon/tests/icon.test.tsx
@@ -1,5 +1,5 @@
 import { a11y } from "@yamada-ui/test"
-import { Md3dRotation } from "react-icons/md"
+import { FaMarkdown } from "react-icons/fa"
 import { Icon } from "../src"
 
 describe("<Icon/>", () => {
@@ -8,6 +8,6 @@ describe("<Icon/>", () => {
   })
 
   test("passes a11y test given a third-party icon", async () => {
-    await a11y(<Icon as={Md3dRotation} />)
+    await a11y(<Icon as={FaMarkdown} />)
   })
 })


### PR DESCRIPTION
Fix: `packages/components/icon/tests/icon.test.tsx(2,10): error TS2724: '"react-icons/md"' has no exported member named 'Md3dRotation'. Did you mean 'Md3DRotation'?`

![image](https://github.com/yamada-ui/yamada-ui/assets/33865215/0dbc916d-4cfb-451a-90e8-ea6189b729fd)
