### PR TITLE
Fixed incorrect percentage of coverage issue

### DIFF
--- a/scripts/coverage-issues.ts
+++ b/scripts/coverage-issues.ts
@@ -28,7 +28,7 @@ const ISSUE_BODY = (packageName: string, files: Record<string, number[]>) =>
     `package: ${packageName}`,
     "",
     "### Description",
-    `\`${packageName}\` has a test coverage of less than 80%. We will enhance it to above 80%.`,
+    `\`${packageName}\` has a test coverage of less than ${TARGET_COVERAGE}%. We will enhance it to above ${TARGET_COVERAGE}%.`,
     "",
     "### Target files",
     ...Object.entries(files).flatMap(([path, lines]) => [


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1624

## Description

Fixed incorrect percentage of coverage issue.
`TARGET_COVERAGE` is now displayed.

## Current behavior (updates)

NIL

## New behavior

NIL

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
