### PR TITLE
Fixed document `Tabs` active indicator

### DIFF
--- a/docs/components/navigation/tabs.tsx
+++ b/docs/components/navigation/tabs.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, Box, Tabs as UITabs, Tab } from "@yamada-ui/react"
 import type { BoxProps } from "@yamada-ui/react"
 import { usePage } from "contexts/page-context"
-import { useRouter } from "next/router"
 import { memo } from "react"
 import { NextLink } from "./next-link"
 
@@ -9,14 +8,13 @@ export type TabsProps = BoxProps
 
 export const Tabs = memo(
   forwardRef<TabsProps, "div">(({ ...rest }, ref) => {
-    const { documentTabs } = usePage()
-    const { asPath } = useRouter()
+    const { documentTabs, slug: currentSlug } = usePage()
 
     return documentTabs?.length ? (
       <Box ref={ref} as="nav" mt="normal" {...rest}>
         <UITabs
           as="ul"
-          index={documentTabs.findIndex(({ slug }) => slug === asPath)}
+          index={documentTabs.findIndex(({ slug }) => slug === currentSlug)}
         >
           {documentTabs.map(({ title, slug }) => (
             <Tab as="li" key={slug} p="0">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1661

## Description

Fixed document `Tabs` active indicator.

## Current behavior (updates)

![image](https://github.com/yamada-ui/yamada-ui/assets/61367823/6f6fc584-7009-42a0-ab3f-4d270618395c)

## New behavior

Fixed to show active indicator even with query.

## Is this a breaking change (Yes/No):

No