### PR TITLE
Made full-width spaces a half-width in `Tabs` documentation

### DIFF
--- a/.changeset/fresh-emus-press.md
+++ b/.changeset/fresh-emus-press.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/tabs": patch
+---
+
+Fix JSDoc having a full-width space.

--- a/docs/contents/components/disclosure/tabs/props.ja.mdx
+++ b/docs/contents/components/disclosure/tabs/props.ja.mdx
@@ -70,7 +70,7 @@ tab: Props
   name="isManual"
   type="boolean"
   description={
-    "If `true`, the tabs will be manually activated and　display its panel by pressing Space or Enter.\n\nIf `false`, the tabs will be automatically activated and their panel is displayed when they receive focus."
+    "If `true`, the tabs will be manually activated and display its panel by pressing Space or Enter.\n\nIf `false`, the tabs will be automatically activated and their panel is displayed when they receive focus."
   }
   defaultValue={"false"}
 />

--- a/docs/contents/components/disclosure/tabs/props.mdx
+++ b/docs/contents/components/disclosure/tabs/props.mdx
@@ -70,7 +70,7 @@ tab: Props
   name="isManual"
   type="boolean"
   description={
-    "If `true`, the tabs will be manually activated and　display its panel by pressing Space or Enter.\n\nIf `false`, the tabs will be automatically activated and their panel is displayed when they receive focus."
+    "If `true`, the tabs will be manually activated and display its panel by pressing Space or Enter.\n\nIf `false`, the tabs will be automatically activated and their panel is displayed when they receive focus."
   }
   defaultValue={"false"}
 />

--- a/packages/components/tabs/DOCS.json
+++ b/packages/components/tabs/DOCS.json
@@ -43,7 +43,7 @@
       "type": "boolean",
       "defaultValue": false,
       "required": false,
-      "description": "If `true`, the tabs will be manually activated and　display its panel by pressing Space or Enter.\n\nIf `false`, the tabs will be automatically activated and their panel is displayed when they receive focus."
+      "description": "If `true`, the tabs will be manually activated and display its panel by pressing Space or Enter.\n\nIf `false`, the tabs will be automatically activated and their panel is displayed when they receive focus."
     },
     "lazyBehavior": {
       "type": "LazyMode",

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -65,7 +65,7 @@ type TabsOptions = {
    */
   align?: "start" | "end" | "center"
   /**
-   * If `true`, the tabs will be manually activated and　display its panel by pressing Space or Enter.
+   * If `true`, the tabs will be manually activated and display its panel by pressing Space or Enter.
    *
    * If `false`, the tabs will be automatically activated and their panel is displayed when they receive focus.
    *


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1664

## Description

This PR fixes the full-width spaces to be half-width.

## Current behavior (updates)

There were full-width spaces in English sentences.

## New behavior

It is now half-width spaces.

## Is this a breaking change (Yes/No):

No