### PR TITLE
Remove `cleanup` in `toggle-group` test code

### DIFF
--- a/packages/components/toggle/tests/toggle-group.test.tsx
+++ b/packages/components/toggle/tests/toggle-group.test.tsx
@@ -1,12 +1,8 @@
-import { cleanup, render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import { a11y } from "@yamada-ui/test"
 import { ToggleGroup, Toggle } from "../src"
 
 describe("<ToggleGroup />", () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   test("should render ToggleGroup and its children correctly", async () => {
     const { container } = render(
       <ToggleGroup>


### PR DESCRIPTION
Closes #1649

## Description

There is a cleanup in the `toggle-group` test code. We think that cleanup should be removed since it is now in the library.

## Is this a breaking change (Yes/No):

No.
