### PR TITLE
Fixed `isRefObject` to return false if null or undefined is passed.

### DIFF
--- a/.changeset/seven-zoos-trade.md
+++ b/.changeset/seven-zoos-trade.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/utils": major
+---
+
+Fixed isRefObject to return false if null or undefined is passed.

--- a/packages/utils/src/react.tsx
+++ b/packages/utils/src/react.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import type { Merge } from "."
-import { isNumber, isString } from "."
+import { isNumber, isObject, isString } from "."
 
 type DOMElement = Element & HTMLOrSVGElement
 
@@ -182,7 +182,7 @@ export const cx = (...classNames: (string | undefined)[]) =>
 type ReactRef<T> = React.Ref<T> | React.MutableRefObject<T> | React.LegacyRef<T>
 
 export const isRefObject = (val: any): val is { current: any } =>
-  "current" in val
+  isObject(val) && "current" in val
 
 export const assignRef = <T extends any = any>(
   ref: ReactRef<T> | undefined,

--- a/packages/utils/tests/react.test.tsx
+++ b/packages/utils/tests/react.test.tsx
@@ -170,6 +170,14 @@ describe("React", () => {
       const nonRefObject = { notCurrent: null }
       expect(isRefObject(nonRefObject)).toBeFalsy()
     })
+
+    test("should return false for null", () => {
+      expect(isRefObject(null)).toBeFalsy()
+    })
+
+    test("should return false for undefined", () => {
+      expect(isRefObject(undefined)).toBeFalsy()
+    })
   })
 
   describe("useMergeRefs", () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1608 

## Description

Fixed isRefObject to return false if null or undefined is passed.

(Since I am not the assignee of this issue, I will leave the merge decision to the maintainer.)

## Current behavior (updates)

Error if null or undefined is passed to isRefObject.

## New behavior

If null or undefined is passed to isRefObject, false is returned.

## Is this a breaking change (Yes/No):

No.

## Additional Information
