### PR TITLE
fix: remove act

### DIFF
--- a/packages/components/pin-input/tests/pin-input.test.tsx
+++ b/packages/components/pin-input/tests/pin-input.test.tsx
@@ -29,10 +29,8 @@ describe("<PinInput />", () => {
     const inputs = await findAllByRole("textbox")
     const firstInput = inputs[0]
 
-    await act(async () => {
-      await user.tab()
-      await user.paste("a1")
-    })
+    await user.tab()
+    await user.paste("a1")
 
     await waitFor(() => {
       expect(firstInput).toHaveValue("a1")


### PR DESCRIPTION
Closes #1687

## Description

warning happened below. remove act.
```
stderr | packages/components/pin-input/tests/pin-input.test.tsx > <PinInput /> > allows alphanumeric input when type is "alphanumeric"
Warning: The current testing environment is not configured to support act(...)
Warning: The current testing environment is not configured to support act(...)
```

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
