### PR TITLE
Updated `color-picker` test

### DIFF
--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -49,11 +49,11 @@ describe("<ColorPicker />", () => {
   })
 
   test("ColorPicker renders as disabled", () => {
-    render(<ColorPicker data-testid="colorPicker" disabled />)
+    render(<ColorPicker disabled />)
 
-    const colorPicker = screen.getByTestId("colorPicker")
+    const colorPicker = screen.getByRole("textbox")
 
-    expect(colorPicker).toHaveAttribute("disabled")
+    expect(colorPicker).toBeDisabled()
   })
 
   test("ColorSelector renders initially when isOpen is specified for ColorPicer", () => {
@@ -62,5 +62,13 @@ describe("<ColorPicker />", () => {
     const popover = document.getElementsByClassName("ui-popover")
 
     expect(popover[0]).toBeVisible()
+  })
+
+  test("ColorSelector does not render initially when isOpen is not specified for ColorPicer", () => {
+    render(<ColorPicker data-testid="colorPicker" />)
+
+    const popover = document.getElementsByClassName("ui-popover")
+
+    expect(popover[0]).not.toBeVisible()
   })
 })

--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -61,6 +61,6 @@ describe("<ColorPicker />", () => {
 
     const popover = document.getElementsByClassName("ui-popover")
 
-    expect(popover[0]).toBeInTheDocument()
+    expect(popover[0]).toBeVisible()
   })
 })

--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -57,17 +57,17 @@ describe("<ColorPicker />", () => {
   })
 
   test("ColorSelector renders initially when isOpen is specified for ColorPicer", () => {
-    render(<ColorPicker data-testid="colorPicker" isOpen />)
+    const { container } = render(<ColorPicker isOpen />)
 
-    const popover = document.getElementsByClassName("ui-popover")
+    const popover = container.querySelectorAll(".ui-popover")
 
     expect(popover[0]).toBeVisible()
   })
 
   test("ColorSelector does not render initially when isOpen is not specified for ColorPicer", () => {
-    render(<ColorPicker data-testid="colorPicker" />)
+    const { container } = render(<ColorPicker />)
 
-    const popover = document.getElementsByClassName("ui-popover")
+    const popover = container.querySelectorAll(".ui-popover")
 
     expect(popover[0]).not.toBeVisible()
   })

--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -56,7 +56,7 @@ describe("<ColorPicker />", () => {
     expect(colorPicker).toBeDisabled()
   })
 
-  test("ColorSelector renders initially when isOpen is specified for ColorPicer", () => {
+  test("ColorSelector renders initially when isOpen is specified for ColorPicker", () => {
     const { container } = render(<ColorPicker isOpen />)
 
     const popover = container.querySelectorAll(".ui-popover")
@@ -64,7 +64,7 @@ describe("<ColorPicker />", () => {
     expect(popover[0]).toBeVisible()
   })
 
-  test("ColorSelector does not render initially when isOpen is not specified for ColorPicer", () => {
+  test("ColorSelector does not render initially when isOpen is not specified for ColorPicker", () => {
     const { container } = render(<ColorPicker />)
 
     const popover = container.querySelectorAll(".ui-popover")

--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -47,4 +47,20 @@ describe("<ColorPicker />", () => {
 
     resetEyeDropperMock()
   })
+
+  test("ColorPicker renders as disabled", () => {
+    render(<ColorPicker data-testid="colorPicker" disabled />)
+
+    const colorPicker = screen.getByTestId("colorPicker")
+
+    expect(colorPicker).toHaveAttribute("disabled")
+  })
+
+  test("ColorSelector renders initially when isOpen is specified for ColorPicer", () => {
+    render(<ColorPicker data-testid="colorPicker" isOpen />)
+
+    const popover = document.getElementsByClassName("ui-popover")
+
+    expect(popover[0]).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1452 <!-- Github issue # here -->

## Description

I tested that when 'disabled' is provided, ColorPicker becomes disabled, and when 'isOpen' is provided, the popover is initially displayed.