### PR TITLE
Make tooltip component headless

### DIFF
--- a/.changeset/friendly-lemons-suffer.md
+++ b/.changeset/friendly-lemons-suffer.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/tooltip": major
+---
+
+Make tooltip component headless

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -349,7 +349,6 @@ export const Tooltip = forwardRef<TooltipProps, "div">(
     const trigger = cloneElement(child, getTriggerProps(child.props, child.ref))
 
     const css: CSSUIObject = {
-      position: "relative",
       ...styles,
     }
 

--- a/packages/theme/src/components/tooltip.ts
+++ b/packages/theme/src/components/tooltip.ts
@@ -14,5 +14,6 @@ export const Tooltip: ComponentStyle = {
     boxShadow: ["md", "dark-md"],
     maxW: "xs",
     zIndex: "dodoria",
+    position: "relative",
   },
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1912 

## Description

Make tooltip component headless.

## Current behavior (updates)

The current `@yamada-ui/tooltip` component has minimal styles defined within its source code. These styles are applied directly within the component, which limits the flexibility of UI customization across different projects. The styles are primarily defined by a CSSUIObject and set to a prop named `__css`.

## New behavior

This PR refactors the `@yamada-ui/tooltip` component to be headless, transferring the internal styles to the theme package. The styles previously defined within the component are now moved to `packages/theme/src/components`, allowing for more flexible and project-specific UI customization. This change ensures that the component can be styled through the theme, promoting a more consistent and adaptable design approach across various projects.

## Is this a breaking change (Yes/No):

No

## Additional Information
Nothing