### PR TITLE
refactor: make headless in `alert`

### DIFF
--- a/.changeset/giant-impalas-stare.md
+++ b/.changeset/giant-impalas-stare.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/alert": major
+"@yamada-ui/theme": major
+---
+
+Changed `alert` component to headless.

--- a/packages/components/alert/src/alert.tsx
+++ b/packages/components/alert/src/alert.tsx
@@ -75,11 +75,6 @@ export const Alert = forwardRef<AlertProps, "div">(
     const { className, children, ...rest } = omitThemeProps(mergedProps)
 
     const css: CSSUIObject = {
-      w: "100%",
-      display: "flex",
-      alignItems: "center",
-      position: "relative",
-      overflow: "hidden",
       ...styles.container,
     }
 
@@ -144,7 +139,6 @@ export const AlertTitle = forwardRef<AlertTitleProps, "p">(
     const { styles } = useAlert()
 
     const css: CSSUIObject = {
-      display: "block",
       ...styles.title,
     }
 

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -4,6 +4,11 @@ import { shadeColor, tintColor } from "@yamada-ui/utils"
 export const Alert: ComponentMultiStyle = {
   baseStyle: {
     container: {
+      w: "100%",
+      display: "flex",
+      alignItems: "center",
+      position: "relative",
+      overflow: "hidden",
       px: 4,
       py: 3,
       rounded: "md",
@@ -19,6 +24,7 @@ export const Alert: ComponentMultiStyle = {
       fontSize: "xl",
     },
     title: {
+      display: "block",
       marginEnd: 2,
       fontWeight: "bold",
       lineHeight: 5,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1849 

## Description

Currently, the `@yamada-ui/alert` component has minimal styles set within the component's source code.
We want to make this style transferable to the theme and make the component headless, enabling more flexible UI customization.

## New behavior

Make headless

## Is this a breaking change (Yes/No):

No
