### PR TITLE
Make the `table` component headless

### DIFF
--- a/.changeset/funny-ducks-stare.md
+++ b/.changeset/funny-ducks-stare.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/table": major
+---
+
+Make `table` component headless

--- a/.changeset/mighty-apples-ring.md
+++ b/.changeset/mighty-apples-ring.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": major
+---
+
+Make the `table` component headless

--- a/packages/components/table/src/table.tsx
+++ b/packages/components/table/src/table.tsx
@@ -120,7 +120,6 @@ export const Table = forwardRef(
     })
 
     const css: CSSUIObject = {
-      w: "100%",
       tableLayout: layout,
       ...styles.table,
     }

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -5,6 +5,9 @@ import { NativeTable } from "./native-table"
 export const Table: ComponentMultiStyle = mergeMultiStyle(NativeTable, {
   baseStyle: {
     sortIcon: {},
+    table: {
+      w: "100%",
+    },
   },
 
   sizes: {


### PR DESCRIPTION
Closes #1907 

## Description

Currently, the `@yamada-ui/table` component has minimal styles set within the component's source code.
We want to make this style transferable to the theme and make the component headless, enabling more flexible UI customization.

## Is this a breaking change (Yes/No):

No
