### PR TITLE
Added lint rule prohibiting import of `@yamada-ui/react`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,12 @@
   "rules": {},
   "overrides": [
     {
+      "files": "packages/**/src/*",
+      "rules": {
+        "no-restricted-imports": ["error", "@yamada-ui/react"]
+      }
+    },
+    {
       "files": ["scripts/**/*", "packages/cli/**/*", "stories/**/*"],
       "rules": {
         "no-console": "off"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1956

## Description

<!-- Add a brief description. -->
Added lint rule prohibiting import of `@yamada-ui/react`.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
NIL

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Importing `@yamada-iu/react` in a component causes a lint error.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
