### PR TITLE
Make the `menu` component headless

### DIFF
--- a/.changeset/tasty-laws-joke.md
+++ b/.changeset/tasty-laws-joke.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/menu": major
+"@yamada-ui/theme": major
+---
+
+Changed `menu` component to headless.

--- a/packages/components/menu/src/menu-button.tsx
+++ b/packages/components/menu/src/menu-button.tsx
@@ -81,13 +81,7 @@ export const MenuButton = forwardRef<MenuButtonProps, "button">(
 const Button = forwardRef<MenuButtonProps, "button">((rest, ref) => {
   const { styles } = useMenu()
 
-  const css: CSSUIObject = {
-    display: "inline-flex",
-    appearance: "none",
-    alignItems: "center",
-    outline: 0,
-    ...styles.button,
-  }
+  const css: CSSUIObject = { ...styles.button }
 
   return <ui.button ref={ref} __css={css} {...rest} />
 })

--- a/packages/components/menu/src/menu-item.tsx
+++ b/packages/components/menu/src/menu-item.tsx
@@ -262,19 +262,7 @@ export const MenuItem = forwardRef<MenuItemProps, "button">(
         children
       )
 
-    const css: CSSUIObject = {
-      textDecoration: "none",
-      color: "inherit",
-      userSelect: "none",
-      display: "flex",
-      width: "100%",
-      alignItems: "center",
-      textAlign: "start",
-      flex: "0 0 auto",
-      outline: 0,
-      gap: "0.75rem",
-      ...styles.item,
-    }
+    const css: CSSUIObject = { ...styles.item }
 
     return (
       <UpstreamMenuItemProvider

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -3,6 +3,10 @@ import type { ComponentMultiStyle } from "@yamada-ui/core"
 export const Menu: ComponentMultiStyle = {
   baseStyle: {
     button: {
+      display: "inline-flex",
+      appearance: "none",
+      alignItems: "center",
+      outline: 0,
       transitionProperty: "common",
       transitionDuration: "normal",
     },
@@ -18,6 +22,16 @@ export const Menu: ComponentMultiStyle = {
       zIndex: "guldo",
     },
     item: {
+      textDecoration: "none",
+      color: "inherit",
+      userSelect: "none",
+      display: "flex",
+      width: "100%",
+      alignItems: "center",
+      textAlign: "start",
+      flex: "0 0 auto",
+      outline: 0,
+      gap: "0.75rem",
       cursor: "pointer",
       py: "1.5",
       px: "3",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1881

## Description

Currently, the `@yamada-ui/menu` component has minimal styles set within the component's source code.
We want to make this style transferable to the theme and make the component headless, enabling more flexible UI customization.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

No.

## Additional Information
