### PR TITLE
refactor: make the `pin-input` component headless

### DIFF
--- a/.changeset/rare-rivers-doubt.md
+++ b/.changeset/rare-rivers-doubt.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/pin-input": major
+"@yamada-ui/theme": major
+---
+
+Make the component headless

--- a/packages/components/pin-input/src/pin-input.tsx
+++ b/packages/components/pin-input/src/pin-input.tsx
@@ -364,8 +364,6 @@ export const PinInput = forwardRef<PinInputProps, "div">(
     )
 
     const css: CSSUIObject = {
-      display: "flex",
-      alignItems: "center",
       ...styles.container,
     }
 

--- a/packages/theme/src/components/pin-input.ts
+++ b/packages/theme/src/components/pin-input.ts
@@ -5,6 +5,8 @@ import { Input } from "./input"
 export const PinInput: ComponentMultiStyle = mergeMultiStyle(Input, {
   baseStyle: {
     container: {
+      display: "flex",
+      alignItems: "center",
       gap: "sm",
     },
     field: {


### PR DESCRIPTION
Closes #1889 

## Description

Currently, the `@yamada-ui/pin-input` component has minimal styles set within the component's source code.
We want to make this style transferable to the theme and make the component headless, enabling more flexible UI customization.

## Is this a breaking change (Yes/No):

No