### PR TITLE
fix(use-pan-event): remove unnecessary `cancelSync`

### DIFF
--- a/.changeset/polite-pens-joke.md
+++ b/.changeset/polite-pens-joke.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/use-pan-event": patch
+---
+
+Fixed a bug that caused event processing to not occur due to incorrect usage of `cancelSync`.

--- a/packages/hooks/use-pan-event/src/index.ts
+++ b/packages/hooks/use-pan-event/src/index.ts
@@ -5,7 +5,7 @@ import {
   getEventPoint,
   isMultiTouchEvent,
 } from "@yamada-ui/utils"
-import sync, { cancelSync, getFrameData } from "framesync"
+import sync, { getFrameData } from "framesync"
 import type { RefObject } from "react"
 import { useEffect, useRef } from "react"
 
@@ -163,7 +163,7 @@ const panEvent = (
 
     onSessionEnd?.(ev, panInfo)
 
-    end()
+    removeListeners()
 
     if (!onEnd || !startEvent) return
 
@@ -174,21 +174,15 @@ const panEvent = (
     handlers = newHandlers
   }
 
-  let removeListeners = pipe(
+  const removeListeners = pipe(
     addPointerEvent(win, "pointermove", onPointerMove),
     addPointerEvent(win, "pointerup", onPointerUp),
     addPointerEvent(win, "pointercancel", onPointerUp),
   )
 
-  const end = () => {
-    removeListeners?.()
-
-    cancelSync.update(updatePoint)
-  }
-
   return {
     updateHandlers,
-    end,
+    removeListeners,
   }
 }
 
@@ -249,7 +243,7 @@ export const usePanEvent = (
 
   useEffect(() => {
     return () => {
-      panSession.current?.end()
+      panSession.current?.removeListeners()
       panSession.current = null
     }
   }, [])


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #1953

## Description

<!-- Add a brief description. -->
Fixed a bug that caused event processing to not occur due to incorrect usage of `cancelSync`.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
In rare cases, `onStart`, `onEnd`, etc. may not work.
## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No.
## Additional Information
`cancelSync` is a function to cancel processing during processing registered with `sync.update`, etc.
```ts
import sync, { cancelSync } from 'framesync';

let count = 0;

const process = sync.render(() => {
  count++;
  if (count >= 10) cancelSync.render(process);
}, true);
```