### PR TITLE
Updated paths in .eslintignore file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,6 @@ dist
 node_modules
 build
 pnpm-lock.yaml
-./examples
+/examples
 coverage
 storybook-static


### PR DESCRIPTION
## Description

Fixed a bug where eslint rules were applied to `./examples`.

## Is this a breaking change (Yes/No):

No