### PR TITLE
Fix a typo about `check` in `List` component

### DIFF
--- a/docs/contents/components/data-display/list/index.mdx
+++ b/docs/contents/components/data-display/list/index.mdx
@@ -84,7 +84,7 @@ To use custom icons for items, use `ListIcon`.
     オ…オレたちが勝てるわけはなかったはずだ………
   </ListItem>
   <ListItem>
-    <ListIcon as={check} color="green.500" />
+    <ListIcon as={Check} color="green.500" />
     オレは試合場のゴミ拾いみたいなもんかよ…
   </ListItem>
 </List>


### PR DESCRIPTION
Closes #2183 

## Description
Fix typo `check` to `Check`.

## Current behavior
<img width="300" alt="スクリーンショット 2024-06-28 午前9 48 09" src="https://github.com/yamada-ui/yamada-ui/assets/83833293/c160ec32-8a04-4560-b081-3f0829089e93">

## New behavior
<img width="300" alt="スクリーンショット 2024-06-28 午前10 01 24" src="https://github.com/yamada-ui/yamada-ui/assets/83833293/0a680a34-f1a1-4eec-8722-9a3b647a2b23">

## Is this a breaking change (Yes/No):
No

## Additional Information
None