### PR TITLE
docs(dropzone): added ` to description

### DIFF
--- a/docs/contents/components/forms/dropzone/index.ja.mdx
+++ b/docs/contents/components/forms/dropzone/index.ja.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dropzone
-description: "Dropzone`は、ファイルをドラッグアンドドロップでアップロードするために使用されるコンポーネントです。"
+description: "`Dropzone`は、ファイルをドラッグアンドドロップでアップロードするために使用されるコンポーネントです。"
 package_name: "@yamada-ui/dropzone"
 is_tabs: true
 with_description: true

--- a/docs/contents/components/forms/dropzone/index.mdx
+++ b/docs/contents/components/forms/dropzone/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dropzone
-description: "Dropzone is a component used for uploading files via drag and drop."
+description: "`Dropzone` is a component used for uploading files via drag and drop."
 package_name: "@yamada-ui/dropzone"
 is_tabs: true
 with_description: true


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2185

## Description

This PR makes the description use \`\` for `Dropzone`.

## Current behavior (updates)

The documentation did not have \` around the word `Dropzone` properly.

## New behavior

Makes them \`Dropzone\`.

## Is this a breaking change (Yes/No):

No