### PR TITLE
Fixed transparent bg on disabled calendar

### DIFF
--- a/.changeset/lucky-keys-crash.md
+++ b/.changeset/lucky-keys-crash.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where the background was transparent when hovering over a disabled and selected value in the `Calendar` component.

--- a/packages/theme/src/components/calendar.ts
+++ b/packages/theme/src/components/calendar.ts
@@ -113,13 +113,13 @@ export const Calendar: ComponentMultiStyle = {
           _between: {
             bg: ["initial", "initial"],
           },
+          _disabled: {
+            bg: ["initial", "initial"],
+          },
           _selected: {
             bg: isGray(c)
               ? [`${c}.100`, `${c}.700`]
               : [isAccessible(c) ? `${c}.400` : `${c}.500`, `${c}.600`],
-          },
-          _disabled: {
-            bg: ["initial", "initial"],
           },
         },
         _today: {
@@ -179,14 +179,14 @@ export const Calendar: ComponentMultiStyle = {
           _between: {
             bg: ["initial", "initial"],
           },
+          _disabled: {
+            bg: ["initial", "initial"],
+          },
           _selected: {
             bg: [
               isGray(c) ? `${c}.50` : `${c}.100`,
               shadeColor(`${c}.300`, 58)(t, m),
             ],
-          },
-          _disabled: {
-            bg: ["initial", "initial"],
           },
         },
         _today: {


### PR DESCRIPTION
Closes #2230

## Description

Fixed transparent bg on disabled calendar.

## Is this a breaking change (Yes/No):

No