### PR TITLE
Enhance the accessibility of `MultiAutocomplete`

### DIFF
--- a/.changeset/real-lamps-approve.md
+++ b/.changeset/real-lamps-approve.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/autocomplete": minor
+---
+
+Enhance the accessibility of `MultiAutocomplete` component

--- a/packages/components/autocomplete/src/multi-autocomplete.tsx
+++ b/packages/components/autocomplete/src/multi-autocomplete.tsx
@@ -350,6 +350,7 @@ const MultiAutocompleteField = forwardRef<MultiAutocompleteFieldProps, "input">(
             overflow="hidden"
             marginBlockStart="0.125rem"
             marginBlockEnd="0.125rem"
+            aria-multiselectable="true"
             placeholder={
               !label || !label?.length || (keepPlaceholder && isOpen)
                 ? placeholder


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2051 

## Description

Enhance the accessibility of `MultiAutocomplete` (`@yamada-ui/multi-autocomplete`) component