### PR TITLE
fixed faild `motion` and `transitions` tests

### DIFF
--- a/packages/components/motion/tests/motion.test.tsx
+++ b/packages/components/motion/tests/motion.test.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, Button, useBoolean } from "@yamada-ui/react"
-import { render, a11y, screen, fireEvent, waitFor } from "@yamada-ui/test"
+import { render, a11y, screen, waitFor } from "@yamada-ui/test"
 import { Motion } from "../src"
 
 describe("<Motion />", () => {
@@ -20,10 +20,15 @@ describe("<Motion />", () => {
 
   test("Motion renders correctly with initial", async () => {
     render(<Motion initial={{ x: 10, opacity: 0 }}>Motion</Motion>)
-    await waitFor(() =>
-      expect(screen.queryByText("Motion")).toHaveStyle({
-        transform: "translateX(10px) translateZ(0)",
-      }),
+
+    const motion = await screen.findByText("Motion")
+
+    await waitFor(
+      () =>
+        expect(motion).toHaveStyle({
+          transform: "translateX(10px) translateZ(0)",
+        }),
+      { timeout: 500 },
     )
   })
 
@@ -33,11 +38,16 @@ describe("<Motion />", () => {
         Motion
       </Motion>,
     )
-    await waitFor(() => {
-      expect(screen.queryByText("Motion")).toHaveStyle({
-        transform: "translateX(100px) translateZ(0)",
-      })
-    })
+
+    const motion = await screen.findByText("Motion")
+
+    await waitFor(
+      () =>
+        expect(motion).toHaveStyle({
+          transform: "translateX(100px) translateZ(0)",
+        }),
+      { timeout: 500 },
+    )
   })
 
   test("Motion renders correctly with exit and transition", async () => {
@@ -62,19 +72,19 @@ describe("<Motion />", () => {
       )
     }
 
-    render(<MotionExpample />)
+    const { user } = render(<MotionExpample />)
 
-    const toggleButton = screen.getByRole("button")
+    const toggleButton = screen.getByRole("button", { name: /click/i })
 
-    fireEvent.click(toggleButton)
+    await user.click(toggleButton)
     await waitFor(() => {
-      expect(screen.queryByText("Motion")).toHaveStyle("opacity: 1")
+      expect(screen.queryByText("Motion")).toHaveStyle({ opacity: "1" })
     })
 
-    fireEvent.click(toggleButton)
+    await user.click(toggleButton)
     await waitFor(
       () => {
-        expect(screen.queryByText("Motion")).toHaveStyle("opacity: 0")
+        expect(screen.queryByText("Motion")).toHaveStyle({ opacity: "0" })
       },
       { timeout: 300 },
     )

--- a/packages/components/motion/tests/motion.test.tsx
+++ b/packages/components/motion/tests/motion.test.tsx
@@ -21,9 +21,9 @@ describe("<Motion />", () => {
   test("Motion renders correctly with initial", async () => {
     render(<Motion initial={{ x: 10, opacity: 0 }}>Motion</Motion>)
     await waitFor(() =>
-      expect(screen.queryByText("Motion")).toHaveStyle(
-        "transform: translateX(10px) translateZ(0);",
-      ),
+      expect(screen.queryByText("Motion")).toHaveStyle({
+        transform: "translateX(10px) translateZ(0)",
+      }),
     )
   })
 
@@ -34,9 +34,9 @@ describe("<Motion />", () => {
       </Motion>,
     )
     await waitFor(() => {
-      expect(screen.queryByText("Motion")).toHaveStyle(
-        "transform: translateX(100px) translateZ(0);",
-      )
+      expect(screen.queryByText("Motion")).toHaveStyle({
+        transform: "translateX(100px) translateZ(0)",
+      })
     })
   })
 

--- a/packages/components/motion/tests/motion.test.tsx
+++ b/packages/components/motion/tests/motion.test.tsx
@@ -20,8 +20,10 @@ describe("<Motion />", () => {
 
   test("Motion renders correctly with initial", async () => {
     render(<Motion initial={{ x: 10, opacity: 0 }}>Motion</Motion>)
-    expect(screen.queryByText("Motion")).toHaveStyle(
-      "transform: translateX(10px) translateZ(0);",
+    await waitFor(() =>
+      expect(screen.queryByText("Motion")).toHaveStyle(
+        "transform: translateX(10px) translateZ(0);",
+      ),
     )
   })
 

--- a/packages/components/transitions/tests/collapse.test.tsx
+++ b/packages/components/transitions/tests/collapse.test.tsx
@@ -33,18 +33,22 @@ describe("<Collapse />", () => {
     await waitFor(() => expect(collapse).not.toBeVisible())
   })
 
-  test("animationOpacity set to true by default", () => {
+  test("animationOpacity set to true by default", async () => {
     const { getByTestId } = render(<Collapse isOpen data-testid="collapse" />)
 
-    expect(getByTestId("collapse")).toHaveStyle({ opacity: "1" })
+    await waitFor(() =>
+      expect(getByTestId("collapse")).toHaveStyle({ opacity: "1" }),
+    )
   })
 
-  test("no opacity when animationOpacity set to false", () => {
+  test("no opacity when animationOpacity set to false", async () => {
     const { getByTestId } = render(
       <Collapse isOpen animationOpacity={false} data-testid="collapse" />,
     )
 
-    expect(getByTestId("collapse")).not.toHaveStyle({ opacity: "1" })
+    await waitFor(() =>
+      expect(getByTestId("collapse")).not.toHaveStyle({ opacity: "1" }),
+    )
   })
 
   test("height changes correctly after isOpen set to true", async () => {
@@ -67,7 +71,7 @@ describe("<Collapse />", () => {
     const { user } = render(<TestComponent />)
 
     const collapse = screen.getByTestId("collapse")
-    expect(collapse).toHaveStyle({ height: "50px" })
+    await waitFor(() => expect(collapse).toHaveStyle({ height: "50px" }))
 
     const button = await screen.findByRole("button", { name: /button/i })
 

--- a/packages/components/transitions/tests/collapse.test.tsx
+++ b/packages/components/transitions/tests/collapse.test.tsx
@@ -14,17 +14,16 @@ describe("<Collapse />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <Collapse isOpen={isOpen} data-testid="collapse" />
+          <Collapse isOpen={isOpen}>Collapse</Collapse>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    const collapse = screen.getByTestId("collapse")
-    expect(collapse).not.toBeVisible()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    const collapse = await screen.findByText("Collapse")
+    expect(collapse).not.toBeVisible()
 
     await user.click(button)
     await waitFor(() => expect(collapse).toBeVisible())
@@ -34,21 +33,23 @@ describe("<Collapse />", () => {
   })
 
   test("animationOpacity set to true by default", async () => {
-    const { getByTestId } = render(<Collapse isOpen data-testid="collapse" />)
+    render(<Collapse isOpen>Collapse</Collapse>)
 
-    await waitFor(() =>
-      expect(getByTestId("collapse")).toHaveStyle({ opacity: "1" }),
-    )
+    const collapse = await screen.findByText("Collapse")
+
+    await waitFor(() => expect(collapse).toHaveStyle({ opacity: "1" }))
   })
 
   test("no opacity when animationOpacity set to false", async () => {
-    const { getByTestId } = render(
-      <Collapse isOpen animationOpacity={false} data-testid="collapse" />,
+    render(
+      <Collapse isOpen animationOpacity={false}>
+        Collapse
+      </Collapse>,
     )
 
-    await waitFor(() =>
-      expect(getByTestId("collapse")).not.toHaveStyle({ opacity: "1" }),
-    )
+    const collapse = await screen.findByText("Collapse")
+
+    await waitFor(() => expect(collapse).not.toHaveStyle({ opacity: "1" }))
   })
 
   test("height changes correctly after isOpen set to true", async () => {
@@ -58,22 +59,18 @@ describe("<Collapse />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <Collapse
-            startingHeight={50}
-            endingHeight={200}
-            isOpen={isOpen}
-            data-testid="collapse"
-          />
+          <Collapse startingHeight={50} endingHeight={200} isOpen={isOpen}>
+            Collapse
+          </Collapse>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    const collapse = screen.getByTestId("collapse")
-    await waitFor(() => expect(collapse).toHaveStyle({ height: "50px" }))
-
     const button = await screen.findByRole("button", { name: /button/i })
+    const collapse = await screen.findByText("Collapse")
+    await waitFor(() => expect(collapse).toHaveStyle({ height: "50px" }))
 
     await user.click(button)
     await waitFor(() => expect(collapse).toHaveStyle({ height: "200px" }))
@@ -86,21 +83,23 @@ describe("<Collapse />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <Collapse isOpen={isOpen} unmountOnExit data-testid="collapse" />
+          <Collapse isOpen={isOpen} unmountOnExit>
+            Collapse
+          </Collapse>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    expect(screen.queryByTestId("collapse")).toBeNull()
+    expect(screen.queryByText("Collapse")).toBeNull()
 
     const button = await screen.findByRole("button", { name: /button/i })
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("collapse")).toBeVisible())
+    await waitFor(() => expect(screen.getByText("Collapse")).toBeVisible())
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("collapse")).toBeNull())
+    await waitFor(() => expect(screen.queryByText("Collapse")).toBeNull())
   })
 })

--- a/packages/components/transitions/tests/fade.test.tsx
+++ b/packages/components/transitions/tests/fade.test.tsx
@@ -14,17 +14,16 @@ describe("<Fade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <Fade isOpen={isOpen} data-testid="fade" />
+          <Fade isOpen={isOpen}>Fade</Fade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    const collapse = screen.getByTestId("fade")
-    expect(collapse).not.toBeVisible()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    const collapse = await screen.findByText("Fade")
+    expect(collapse).not.toBeVisible()
 
     await user.click(button)
     await waitFor(() => expect(collapse).toBeVisible())
@@ -40,21 +39,22 @@ describe("<Fade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <Fade isOpen={isOpen} unmountOnExit data-testid="fade" />
+          <Fade isOpen={isOpen} unmountOnExit>
+            Fade
+          </Fade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    expect(screen.queryByTestId("fade")).toBeNull()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    expect(screen.queryByText("Fade")).toBeNull()
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("fade")).toBeVisible())
+    await waitFor(() => expect(screen.getByText("Fade")).toBeVisible())
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("fade")).toBeNull())
+    await waitFor(() => expect(screen.queryByText("Fade")).toBeNull())
   })
 })

--- a/packages/components/transitions/tests/scale-fade.test.tsx
+++ b/packages/components/transitions/tests/scale-fade.test.tsx
@@ -14,17 +14,16 @@ describe("<ScaleFade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <ScaleFade isOpen={isOpen} data-testid="scale-fade" />
+          <ScaleFade isOpen={isOpen}>ScaleFade</ScaleFade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    const collapse = screen.getByTestId("scale-fade")
-    expect(collapse).not.toBeVisible()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    const collapse = await screen.findByText("ScaleFade")
+    expect(collapse).not.toBeVisible()
 
     await user.click(button)
     await waitFor(() => expect(collapse).toBeVisible())
@@ -40,23 +39,23 @@ describe("<ScaleFade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <ScaleFade isOpen={isOpen} unmountOnExit data-testid="scale-fade" />
+          <ScaleFade isOpen={isOpen} unmountOnExit>
+            ScaleFade
+          </ScaleFade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    expect(screen.queryByTestId("scale-fade")).toBeNull()
+    expect(screen.queryByText("ScaleFade")).toBeNull()
 
     const button = await screen.findByRole("button", { name: /button/i })
 
     await user.click(button)
-    await waitFor(() =>
-      expect(screen.queryByTestId("scale-fade")).toBeVisible(),
-    )
+    await waitFor(() => expect(screen.getByText("ScaleFade")).toBeVisible())
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("scale-fade")).toBeNull())
+    await waitFor(() => expect(screen.queryByText("ScaleFade")).toBeNull())
   })
 })

--- a/packages/components/transitions/tests/slide-fade.test.tsx
+++ b/packages/components/transitions/tests/slide-fade.test.tsx
@@ -14,17 +14,16 @@ describe("<SlideFade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <SlideFade isOpen={isOpen} data-testid="slide-fade" />
+          <SlideFade isOpen={isOpen}>SlideFade</SlideFade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    const slideFade = screen.getByTestId("slide-fade")
-    expect(slideFade).not.toBeVisible()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    const slideFade = await screen.findByText("SlideFade")
+    expect(slideFade).not.toBeVisible()
 
     await user.click(button)
     await waitFor(() => expect(slideFade).toBeVisible())
@@ -40,21 +39,18 @@ describe("<SlideFade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <SlideFade
-            isOpen={isOpen}
-            initial="initial"
-            data-testid="slide-fade"
-          />
+          <SlideFade isOpen={isOpen} initial="initial">
+            SlideFade
+          </SlideFade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    const slideFade = screen.getByTestId("slide-fade")
-    expect(slideFade).not.toBeVisible()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    const slideFade = await screen.findByText("SlideFade")
+    expect(slideFade).not.toBeVisible()
 
     await user.click(button)
     await waitFor(() => expect(slideFade).toBeVisible())
@@ -64,36 +60,44 @@ describe("<SlideFade />", () => {
   })
 
   test("default offset is set correctly", async () => {
-    const { getByTestId } = render(<SlideFade data-testid="slide-fade" />)
+    render(<SlideFade>SlideFade</SlideFade>)
 
-    await waitFor(() =>
-      expect(getByTestId("slide-fade")).toHaveStyle({
-        transform: "translateX(0px) translateY(8px) translateZ(0)",
-      }),
+    const slideFade = await screen.findByText("SlideFade")
+
+    await waitFor(
+      () =>
+        expect(slideFade).toHaveStyle({
+          transform: "translateX(0px) translateY(8px) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
   test("applies offsetX correctly", async () => {
-    const { getByTestId } = render(
-      <SlideFade offsetX={10} data-testid="slide-fade" />,
-    )
+    render(<SlideFade offsetX={10}>SlideFade</SlideFade>)
 
-    await waitFor(() =>
-      expect(getByTestId("slide-fade")).toHaveStyle({
-        transform: "translateX(10px) translateY(8px) translateZ(0)",
-      }),
+    const slideFade = await screen.findByText("SlideFade")
+
+    await waitFor(
+      () =>
+        expect(slideFade).toHaveStyle({
+          transform: "translateX(10px) translateY(8px) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
   test("applies offsetY correctly", async () => {
-    const { getByTestId } = render(
-      <SlideFade offsetY={10} data-testid="slide-fade" />,
-    )
+    render(<SlideFade offsetY={10}>SlideFade</SlideFade>)
 
-    await waitFor(() =>
-      expect(getByTestId("slide-fade")).toHaveStyle({
-        transform: "translateX(0px) translateY(10px) translateZ(0)",
-      }),
+    const slideFade = await screen.findByText("SlideFade")
+
+    await waitFor(
+      () =>
+        expect(slideFade).toHaveStyle({
+          transform: "translateX(0px) translateY(10px) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
@@ -104,23 +108,23 @@ describe("<SlideFade />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <SlideFade isOpen={isOpen} unmountOnExit data-testid="slide-fade" />
+          <SlideFade isOpen={isOpen} unmountOnExit>
+            SlideFade
+          </SlideFade>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    expect(screen.queryByTestId("slide-fade")).toBeNull()
-
     const button = await screen.findByRole("button", { name: /button/i })
 
-    await user.click(button)
-    await waitFor(() =>
-      expect(screen.queryByTestId("slide-fade")).toBeVisible(),
-    )
+    expect(screen.queryByText("SlideFade")).toBeNull()
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("slide-fade")).toBeNull())
+    await waitFor(() => expect(screen.getByText("SlideFade")).toBeVisible())
+
+    await user.click(button)
+    await waitFor(() => expect(screen.queryByText("SlideFade")).toBeNull())
   })
 })

--- a/packages/components/transitions/tests/slide-fade.test.tsx
+++ b/packages/components/transitions/tests/slide-fade.test.tsx
@@ -63,32 +63,38 @@ describe("<SlideFade />", () => {
     await waitFor(() => expect(slideFade).not.toBeVisible())
   })
 
-  test("default offset is set correctly", () => {
+  test("default offset is set correctly", async () => {
     const { getByTestId } = render(<SlideFade data-testid="slide-fade" />)
 
-    expect(getByTestId("slide-fade")).toHaveStyle({
-      transform: "translateX(0px) translateY(8px) translateZ(0)",
-    })
+    await waitFor(() =>
+      expect(getByTestId("slide-fade")).toHaveStyle({
+        transform: "translateX(0px) translateY(8px) translateZ(0)",
+      }),
+    )
   })
 
-  test("applies offsetX correctly", () => {
+  test("applies offsetX correctly", async () => {
     const { getByTestId } = render(
       <SlideFade offsetX={10} data-testid="slide-fade" />,
     )
 
-    expect(getByTestId("slide-fade")).toHaveStyle({
-      transform: "translateX(10px) translateY(8px) translateZ(0)",
-    })
+    await waitFor(() =>
+      expect(getByTestId("slide-fade")).toHaveStyle({
+        transform: "translateX(10px) translateY(8px) translateZ(0)",
+      }),
+    )
   })
 
-  test("applies offsetY correctly", () => {
+  test("applies offsetY correctly", async () => {
     const { getByTestId } = render(
       <SlideFade offsetY={10} data-testid="slide-fade" />,
     )
 
-    expect(getByTestId("slide-fade")).toHaveStyle({
-      transform: "translateX(0px) translateY(10px) translateZ(0)",
-    })
+    await waitFor(() =>
+      expect(getByTestId("slide-fade")).toHaveStyle({
+        transform: "translateX(0px) translateY(10px) translateZ(0)",
+      }),
+    )
   })
 
   test("unmountOnExit works correctly", async () => {

--- a/packages/components/transitions/tests/slide.test.tsx
+++ b/packages/components/transitions/tests/slide.test.tsx
@@ -11,9 +11,9 @@ describe("<Slide />", () => {
     const { getByTestId } = render(<Slide isOpen data-testid="slide" />)
 
     await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle(
-        "transform: translateX(100%) translateY(0px) translateZ(0);",
-      ),
+      expect(getByTestId("slide")).toHaveStyle({
+        transform: "translateX(100%) translateY(0px) translateZ(0)",
+      }),
     )
   })
 
@@ -23,9 +23,9 @@ describe("<Slide />", () => {
     )
 
     await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle(
-        "transform: translateX(0px) translateY(-100%) translateZ(0);",
-      ),
+      expect(getByTestId("slide")).toHaveStyle({
+        transform: "translateX(0px) translateY(-100%) translateZ(0)",
+      }),
     )
   })
 
@@ -35,9 +35,9 @@ describe("<Slide />", () => {
     )
 
     await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle(
-        "transform: translateX(-100%) translateY(0px) translateZ(0);",
-      ),
+      expect(getByTestId("slide")).toHaveStyle({
+        transform: "translateX(-100%) translateY(0px) translateZ(0)",
+      }),
     )
   })
 
@@ -47,9 +47,9 @@ describe("<Slide />", () => {
     )
 
     await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle(
-        "transform: translateX(100%) translateY(0px) translateZ(0);",
-      ),
+      expect(getByTestId("slide")).toHaveStyle({
+        transform: "translateX(100%) translateY(0px) translateZ(0)",
+      }),
     )
   })
 
@@ -59,9 +59,9 @@ describe("<Slide />", () => {
     )
 
     await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle(
-        "transform: translateX(0px) translateY(100%) translateZ(0);",
-      ),
+      expect(getByTestId("slide")).toHaveStyle({
+        transform: "translateX(0px) translateY(100%) translateZ(0)",
+      }),
     )
   })
 

--- a/packages/components/transitions/tests/slide.test.tsx
+++ b/packages/components/transitions/tests/slide.test.tsx
@@ -10,8 +10,10 @@ describe("<Slide />", () => {
   test("applies default styles correctly", async () => {
     const { getByTestId } = render(<Slide isOpen data-testid="slide" />)
 
-    expect(getByTestId("slide")).toHaveStyle(
-      "transform: translateX(100%) translateY(0px) translateZ(0);",
+    await waitFor(() =>
+      expect(getByTestId("slide")).toHaveStyle(
+        "transform: translateX(100%) translateY(0px) translateZ(0);",
+      ),
     )
   })
 
@@ -20,8 +22,10 @@ describe("<Slide />", () => {
       <Slide isOpen placement="top" data-testid="slide" />,
     )
 
-    expect(getByTestId("slide")).toHaveStyle(
-      "transform: translateX(0px) translateY(-100%) translateZ(0);",
+    await waitFor(() =>
+      expect(getByTestId("slide")).toHaveStyle(
+        "transform: translateX(0px) translateY(-100%) translateZ(0);",
+      ),
     )
   })
 
@@ -30,8 +34,10 @@ describe("<Slide />", () => {
       <Slide isOpen placement="left" data-testid="slide" />,
     )
 
-    expect(getByTestId("slide")).toHaveStyle(
-      "transform: translateX(-100%) translateY(0px) translateZ(0);",
+    await waitFor(() =>
+      expect(getByTestId("slide")).toHaveStyle(
+        "transform: translateX(-100%) translateY(0px) translateZ(0);",
+      ),
     )
   })
 
@@ -40,8 +46,10 @@ describe("<Slide />", () => {
       <Slide isOpen placement="right" data-testid="slide" />,
     )
 
-    expect(getByTestId("slide")).toHaveStyle(
-      "transform: translateX(100%) translateY(0px) translateZ(0);",
+    await waitFor(() =>
+      expect(getByTestId("slide")).toHaveStyle(
+        "transform: translateX(100%) translateY(0px) translateZ(0);",
+      ),
     )
   })
 
@@ -50,8 +58,10 @@ describe("<Slide />", () => {
       <Slide isOpen placement="bottom" data-testid="slide" />,
     )
 
-    expect(getByTestId("slide")).toHaveStyle(
-      "transform: translateX(0px) translateY(100%) translateZ(0);",
+    await waitFor(() =>
+      expect(getByTestId("slide")).toHaveStyle(
+        "transform: translateX(0px) translateY(100%) translateZ(0);",
+      ),
     )
   })
 

--- a/packages/components/transitions/tests/slide.test.tsx
+++ b/packages/components/transitions/tests/slide.test.tsx
@@ -8,60 +8,88 @@ describe("<Slide />", () => {
   })
 
   test("applies default styles correctly", async () => {
-    const { getByTestId } = render(<Slide isOpen data-testid="slide" />)
+    render(<Slide isOpen>Slide</Slide>)
 
-    await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle({
-        transform: "translateX(100%) translateY(0px) translateZ(0)",
-      }),
+    const slide = await screen.findByText("Slide")
+
+    await waitFor(
+      () =>
+        expect(slide).toHaveStyle({
+          transform: "translateX(100%) translateY(0px) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
   test("applies styles correctly for top placement", async () => {
-    const { getByTestId } = render(
-      <Slide isOpen placement="top" data-testid="slide" />,
+    render(
+      <Slide isOpen placement="top">
+        Slide
+      </Slide>,
     )
 
-    await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle({
-        transform: "translateX(0px) translateY(-100%) translateZ(0)",
-      }),
+    const slide = await screen.findByText("Slide")
+
+    await waitFor(
+      () =>
+        expect(slide).toHaveStyle({
+          transform: "translateX(0px) translateY(-100%) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
   test("applies styles correctly for left placement", async () => {
-    const { getByTestId } = render(
-      <Slide isOpen placement="left" data-testid="slide" />,
+    render(
+      <Slide isOpen placement="left">
+        Slide
+      </Slide>,
     )
 
-    await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle({
-        transform: "translateX(-100%) translateY(0px) translateZ(0)",
-      }),
+    const slide = await screen.findByText("Slide")
+
+    await waitFor(
+      () =>
+        expect(slide).toHaveStyle({
+          transform: "translateX(-100%) translateY(0px) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
   test("applies styles correctly for right placement", async () => {
-    const { getByTestId } = render(
-      <Slide isOpen placement="right" data-testid="slide" />,
+    render(
+      <Slide isOpen placement="right">
+        Slide
+      </Slide>,
     )
 
-    await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle({
-        transform: "translateX(100%) translateY(0px) translateZ(0)",
-      }),
+    const slide = await screen.findByText("Slide")
+
+    await waitFor(
+      () =>
+        expect(slide).toHaveStyle({
+          transform: "translateX(100%) translateY(0px) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
   test("applies styles correctly for bottom placement", async () => {
-    const { getByTestId } = render(
-      <Slide isOpen placement="bottom" data-testid="slide" />,
+    render(
+      <Slide isOpen placement="bottom">
+        Slide
+      </Slide>,
     )
 
-    await waitFor(() =>
-      expect(getByTestId("slide")).toHaveStyle({
-        transform: "translateX(0px) translateY(100%) translateZ(0)",
-      }),
+    const slide = await screen.findByText("Slide")
+
+    await waitFor(
+      () =>
+        expect(slide).toHaveStyle({
+          transform: "translateX(0px) translateY(100%) translateZ(0)",
+        }),
+      { timeout: 300 },
     )
   })
 
@@ -72,21 +100,22 @@ describe("<Slide />", () => {
       return (
         <>
           <Button onClick={onToggle}>button</Button>
-          <Slide isOpen={isOpen} unmountOnExit data-testid="slide" />
+          <Slide isOpen={isOpen} unmountOnExit>
+            Slide
+          </Slide>
         </>
       )
     }
 
     const { user } = render(<TestComponent />)
 
-    expect(screen.queryByTestId("slide")).toBeNull()
-
     const button = await screen.findByRole("button", { name: /button/i })
+    expect(screen.queryByText("Slide")).toBeNull()
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("slide")).toBeVisible())
+    await waitFor(() => expect(screen.getByText("Slide")).toBeVisible())
 
     await user.click(button)
-    await waitFor(() => expect(screen.queryByTestId("slide")).toBeNull())
+    await waitFor(() => expect(screen.queryByText("Slide")).toBeNull())
   })
 })


### PR DESCRIPTION


## Description

<!-- Add a brief description. -->
The test checked in the `toHaveStyle` assertion is failing, so the `waitFor` enclosed
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
NIL
## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
NIL
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
