### PR TITLE
refactor(report-insights): made `publish` option work in report insight script

### DIFF
--- a/scripts/report-insights.ts
+++ b/scripts/report-insights.ts
@@ -352,8 +352,6 @@ const sendDiscordChannel =
   async (reports: string[]) => {
     const url = process.env.DISCORD_INSIGHTS_WEBHOOK_URL
 
-    if (!url) throw new Error("Missing Discord Webhook URL\n")
-
     for await (const [index, contents] of Object.entries(
       chunkArray(reports, 10),
     )) {
@@ -377,6 +375,8 @@ const sendDiscordChannel =
       const content = chunks.join("\n")
 
       if (publish) {
+        if (!url) throw new Error("Missing Discord Webhook URL\n")
+
         const data = { username: "GitHub", content }
 
         const headers = { "Content-Type": "application/json" }
@@ -442,11 +442,7 @@ const main = async () => {
         const insights = await getInsights(options)(collaborators)
         const reports = createReports(options)(insights)
 
-        if (publish) {
-          await sendDiscordChannel(options)(reports)
-        } else {
-          console.log(reports)
-        }
+        await sendDiscordChannel(options)(reports)
       },
     )
 

--- a/scripts/report-insights.ts
+++ b/scripts/report-insights.ts
@@ -442,7 +442,11 @@ const main = async () => {
         const insights = await getInsights(options)(collaborators)
         const reports = createReports(options)(insights)
 
-        await sendDiscordChannel(options)(reports)
+        if (publish) {
+          await sendDiscordChannel(options)(reports)
+        } else {
+          console.log(reports)
+        }
       },
     )
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2295

## Description

I have made the report insights script work properly with `publish` option.

## Current behavior (updates)

It tried to send discord message regardless of `publish` option.

## New behavior

It will console.log the report if `publish` is false.

## Is this a breaking change (Yes/No):

No