### PR TITLE
Added `onConsoleLog` filter for stderr

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
         "packages/nextjs",
       ],
     },
+    onConsoleLog: (_log, type) => type !== "stderr",
     setupFiles: ["./scripts/setup-test.ts"],
   },
 })


### PR DESCRIPTION
## Description

When you do a test that expects an error to be thrown, the error is what you expect, but the error is displayed in the console and the log is tainted.Use `onConsoleLog` to disable the display of errors.

## Is this a breaking change (Yes/No):

No