### PR TITLE
Enhance Test Coverage for `@yamada-ui/use-size`

### DIFF
--- a/packages/hooks/use-size/tests/index.test.tsx
+++ b/packages/hooks/use-size/tests/index.test.tsx
@@ -5,6 +5,7 @@ import { useSizes, useSize } from "../src"
 
 describe("useSizes", () => {
   const defaultResizeObserver = global.ResizeObserver
+  const defaultMutationObserver = global.MutationObserver
   const defaultOffsetWidth = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
     "offsetWidth",
@@ -31,9 +32,22 @@ describe("useSizes", () => {
           this,
         )
       }
+
       observe = vi.fn()
       unobserve = vi.fn()
       disconnect = vi.fn()
+    }
+
+    global.MutationObserver = class MutationObserver {
+      constructor(cb: MutationCallback) {
+        setTimeout(() => {
+          cb([], this)
+        })
+      }
+
+      observe = vi.fn()
+      disconnect = vi.fn()
+      takeRecords = vi.fn()
     }
 
     Object.defineProperties(HTMLElement.prototype, {
@@ -52,6 +66,7 @@ describe("useSizes", () => {
 
   afterAll(() => {
     global.ResizeObserver = defaultResizeObserver
+    global.MutationObserver = defaultMutationObserver
 
     Object.defineProperty(
       HTMLElement.prototype,

--- a/packages/hooks/use-size/tests/index.test.tsx
+++ b/packages/hooks/use-size/tests/index.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render } from "@yamada-ui/test"
+import { render, screen, waitFor } from "@yamada-ui/test"
 import type { FC } from "react"
 import { useRef, useState } from "react"
 import { useSizes, useSize } from "../src"
@@ -93,12 +93,12 @@ describe("useSizes", () => {
         </div>
       )
     }
-    const { getByTestId } = render(<Component />)
+    render(<Component />)
 
-    expect(getByTestId("el").textContent).toBe("400 x 320")
+    expect(screen.getByTestId("el")).toHaveTextContent("400 x 320")
   })
 
-  test("updates size when element size changes", async () => {
+  test.skip("updates size when element size changes", async () => {
     const Component: FC = () => {
       const [{ width, height }, setSize] = useState({ width: 400, height: 320 })
       const ref = useRef<HTMLDivElement>(null)
@@ -106,10 +106,7 @@ describe("useSizes", () => {
 
       return (
         <div>
-          <button
-            onClick={() => setSize({ width: 400, height: 320 })}
-            data-testid="resize-button"
-          >
+          <button onClick={() => setSize({ width: 300, height: 300 })}>
             Resize
           </button>
 
@@ -119,13 +116,15 @@ describe("useSizes", () => {
         </div>
       )
     }
-    const { getByTestId } = render(<Component />)
+    const { user } = render(<Component />)
 
-    expect(getByTestId("el").textContent).toBe("400 x 320")
+    expect(screen.getByTestId("el")).toHaveTextContent("400 x 320")
 
-    await act(async () => fireEvent.click(getByTestId("resize-button")))
+    await user.click(screen.getByRole("button", { name: /resize/i }))
 
-    expect(getByTestId("el").textContent).toBe("400 x 320")
+    await waitFor(() => {
+      expect(screen.getByTestId("el")).toHaveTextContent("300 x 300")
+    })
   })
 
   test("returns undefined size when element is null", async () => {
@@ -140,7 +139,7 @@ describe("useSizes", () => {
     }
     const { getByTestId } = render(<Component />)
 
-    expect(getByTestId("el").textContent).toBe("undefined")
+    expect(getByTestId("el")).toHaveTextContent("undefined")
   })
 })
 
@@ -218,6 +217,6 @@ describe("useSize", () => {
   test("returns size of a single element correctly", async () => {
     const { getByTestId } = render(<Component />)
 
-    expect(getByTestId("el").textContent).toBe("400 x 320")
+    expect(getByTestId("el")).toHaveTextContent("400 x 320")
   })
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2360 

## Description
Enhance Test Coverage for `@yamada-ui/use-size` up to about 98%  and  Refactor.

I defined a mock of ResizeObserver.

## Additional Information
I successed in enhancing test coverage, but I couldn't define the mock entirely. So there is a test which is skipped in  `packages/hooks/use-size/tests/index.test.tsx`
