### PR TITLE
Updated default start date calculation

### DIFF
--- a/docs/pages/insights/index.page.tsx
+++ b/docs/pages/insights/index.page.tsx
@@ -28,7 +28,7 @@ export const getServerSideProps = async (
   const start =
     isString(query.start) && dayjs(query.start).isValid()
       ? query.start
-      : dayjs().tz().subtract(7, "d").format("YYYY-MM-DD")
+      : dayjs().tz().subtract(6, "d").format("YYYY-MM-DD")
   const end =
     isString(query.end) && dayjs(query.end).isValid()
       ? query.end


### PR DESCRIPTION
## Description

Updated default start date calculation.

Currently, the default value is 1 week, but 8 days have been selected.

## Is this a breaking change (Yes/No):

No