### PR TITLE
useMotionAnimationFrame does not exist

### DIFF
--- a/docs/contents/components/other/motion/index.ja.mdx
+++ b/docs/contents/components/other/motion/index.ja.mdx
@@ -98,14 +98,14 @@ return (
 )
 ```
 
-### `useMotionAnimationFrame`を使う
+### `useAnimationFrame`を使う
 
-`useMotionAnimationFrame`は、要素のアニメーションフレームごとに1回コールバックを実行します。コールバックは、**コールバックが最初に呼び出されてからの合計時間**と**最後のアニメーションフレームからの合計時間**を取得することができます。
+`useAnimationFrame`は、要素のアニメーションフレームごとに1回コールバックを実行します。コールバックは、**コールバックが最初に呼び出されてからの合計時間**と**最後のアニメーションフレームからの合計時間**を取得することができます。
 
 ```tsx functional=true
 const containerRef = useRef<HTMLDivElement>(null)
 
-useMotionAnimationFrame((time, delta) => {
+useAnimationFrame((time, delta) => {
   const rotate = Math.sin(time / 10000) * 200
   const y = (1 + Math.sin(time / 1000)) * -50
 

--- a/docs/contents/components/other/motion/index.mdx
+++ b/docs/contents/components/other/motion/index.mdx
@@ -98,14 +98,14 @@ return (
 )
 ```
 
-### Usage of `useMotionAnimationFrame`
+### Usage of `useAnimationFrame`
 
-`useMotionAnimationFrame` executes a callback once for each animation frame of the element. The callback can get the **total time since the callback was first called** and the **total time from the last animation frame**.
+`useAnimationFrame` executes a callback once for each animation frame of the element. The callback can get the **total time since the callback was first called** and the **total time from the last animation frame**.
 
 ```tsx functional=true
 const containerRef = useRef<HTMLDivElement>(null)
 
-useMotionAnimationFrame((time, delta) => {
+useAnimationFrame((time, delta) => {
   const rotate = Math.sin(time / 10000) * 200
   const y = (1 + Math.sin(time / 1000)) * -50
 

--- a/docs/contents/styled-system/animation.ja.mdx
+++ b/docs/contents/styled-system/animation.ja.mdx
@@ -557,14 +557,14 @@ return (
 )
 ```
 
-#### `useMotionAnimationFrame`を使う
+#### `useAnimationFrame`を使う
 
-`useMotionAnimationFrame`は、要素のアニメーションフレームごとに1回コールバックを実行します。コールバックは、**コールバックが最初に呼び出されてからの合計時間**と**最後のアニメーションフレームからの合計時間**を取得することができます。
+`useAnimationFrame`は、要素のアニメーションフレームごとに1回コールバックを実行します。コールバックは、**コールバックが最初に呼び出されてからの合計時間**と**最後のアニメーションフレームからの合計時間**を取得することができます。
 
 ```tsx functional=true
 const containerRef = useRef<HTMLDivElement>(null)
 
-useMotionAnimationFrame((time, delta) => {
+useAnimationFrame((time, delta) => {
   const rotate = Math.sin(time / 10000) * 200
   const y = (1 + Math.sin(time / 1000)) * -50
 

--- a/docs/contents/styled-system/animation.mdx
+++ b/docs/contents/styled-system/animation.mdx
@@ -557,14 +557,14 @@ return (
 )
 ```
 
-#### Usage of `useMotionAnimationFrame`
+#### Usage of `useAnimationFrame`
 
-`useMotionAnimationFrame` executes a callback once for each animation frame of the element. The callback can get the **total time since the callback was first called** and the **total time from the last animation frame**.
+`useAnimationFrame` executes a callback once for each animation frame of the element. The callback can get the **total time since the callback was first called** and the **total time from the last animation frame**.
 
 ```tsx functional=true
 const containerRef = useRef<HTMLDivElement>(null)
 
-useMotionAnimationFrame((time, delta) => {
+useAnimationFrame((time, delta) => {
   const rotate = Math.sin(time / 10000) * 200
   const y = (1 + Math.sin(time / 1000)) * -50
 


### PR DESCRIPTION
Closes #2433 <!-- Github issue # here -->

## Description

`useMotionAnimationFrame` does not exist.

The correct name is `useAnimationFrame`.

## New behavior

- replace `useMotionAnimationFrame` to `useAnimationFrame`

