### PR TITLE
Fixed a bug where the width was not changed even if `width` etc. was set in `listProps` of `Select` and `MultiSelect`.

### DIFF
--- a/.changeset/bright-tigers-lick.md
+++ b/.changeset/bright-tigers-lick.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/autocomplete": patch
+---
+
+Fixed a bug where the width was not changed even if `width` etc. was set in `listProps` of `Autocomplete` and `MultiAutocomplete`.

--- a/.changeset/green-berries-leave.md
+++ b/.changeset/green-berries-leave.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/select": patch
+---
+
+Fixed a bug where the width was not changed even if `width` etc. was set in `listProps` of `Select` and `MultiSelect`.

--- a/packages/components/autocomplete/src/autocomplete-list.tsx
+++ b/packages/components/autocomplete/src/autocomplete-list.tsx
@@ -20,7 +20,7 @@ export const AutocompleteList = forwardRef<AutocompleteListProps, "ul">(
     minWidth ??= (styles.list?.minWidth ??
       styles.list?.minW) as CSSUIProps["minWidth"]
 
-    const css: CSSUIObject = { ...styles.list }
+    const css: CSSUIObject = { ...styles.list, width, minWidth }
 
     return (
       <PopoverContent

--- a/packages/components/select/src/select-list.tsx
+++ b/packages/components/select/src/select-list.tsx
@@ -20,7 +20,7 @@ export const SelectList = forwardRef<SelectListProps, "ul">(
     minWidth ??= (styles.list?.minWidth ??
       styles.list?.minW) as CSSUIProps["minWidth"]
 
-    const css: CSSUIObject = { ...styles.list }
+    const css: CSSUIObject = { ...styles.list, width, minWidth }
 
     return (
       <PopoverContent


### PR DESCRIPTION
Closes #2443

## Description

Fixed a bug where the width was not changed even if `width` etc. was set in `listProps` of `Select` and `MultiSelect`.

## Is this a breaking change (Yes/No):

No