### PR TITLE
docs: change 'size' to 'fontSize' in Dropzone MDX

### DIFF
--- a/.changeset/shaggy-mice-worry.md
+++ b/.changeset/shaggy-mice-worry.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/dropzone": minor
+---
+
+Update Dropzone MDX documentation to change "size" prop to "fontSize" for Upload, X, and Image components.

--- a/docs/contents/components/forms/dropzone/index.ja.mdx
+++ b/docs/contents/components/forms/dropzone/index.ja.mdx
@@ -162,15 +162,15 @@ import {
 <Dropzone accept={IMAGE_ACCEPT_TYPE} maxSize={3 * 1024 ** 2}>
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">
@@ -206,15 +206,15 @@ import {
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">
@@ -239,15 +239,15 @@ import {
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">
@@ -272,15 +272,15 @@ import {
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">

--- a/docs/contents/components/forms/dropzone/index.mdx
+++ b/docs/contents/components/forms/dropzone/index.mdx
@@ -162,15 +162,15 @@ To control the display based on whether the file is accepted or rejected, use `D
 <Dropzone accept={IMAGE_ACCEPT_TYPE} maxSize={3 * 1024 ** 2}>
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">
@@ -206,15 +206,15 @@ Please note that it is always called regardless of whether the dropped file is a
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">
@@ -239,15 +239,15 @@ To handle only accepted files, use `onDropAccepted`.
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">
@@ -272,15 +272,15 @@ To handle only rejected files, use `onDropRejected`.
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload size="6xl" color="primary" />
+      <Upload fontSize="6xl" color="primary" />
     </DropzoneAccept>
 
     <DropzoneReject>
-      <X size="6xl" color="danger" />
+      <X fontSize="6xl" color="danger" />
     </DropzoneReject>
 
     <DropzoneIdle>
-      <Image size="6xl" />
+      <Image fontSize="6xl" />
     </DropzoneIdle>
 
     <VStack gap="2xs">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2493

## Description
Update the Dropzone MDX documentation to change the "size" prop to "fontSize" for the Upload, X, and Image components.

## Current behavior (updates)
Deprecated props in the Lucide icon used on the Dropzone page.

## New behavior
The Dropzone MDX documentation now uses the "fontSize" prop for the Upload, X, and Image components.

## Is this a breaking change (Yes/No):
No

## Additional Information
None