### PR TITLE
Fix deprecated `size` prop usage in `Menu` test code

### DIFF
--- a/packages/components/menu/tests/menu.test.tsx
+++ b/packages/components/menu/tests/menu.test.tsx
@@ -26,7 +26,7 @@ describe("<Menu />", () => {
       <Menu>
         <MenuButton
           as={Button}
-          rightIcon={<Icon size="xs" icon={faChevronDown} />}
+          rightIcon={<Icon fontSize="xs" icon={faChevronDown} />}
         >
           Menu
         </MenuButton>


### PR DESCRIPTION
Closes #2489

## Description

This pull request addresses an issue where deprecated `size` props were being used in the `Menu` component's test code. The `size` prop has been replaced with `fontSize` to align with the current API standards.

## Current behavior (updates)

Currently, the `Menu` component's test code uses the deprecated `size` prop, which is no longer supported and should be replaced with `fontSize`.

## New behavior

The `Menu` component's test code now uses the `fontSize` prop instead of the deprecated `size` prop, ensuring compatibility with the current API.

## Is this a breaking change (Yes/No):

No

## Additional Information

No additional information.