### PR TITLE
Fix deprecated `size` props usage in the Storybook `Loading` page

### DIFF
--- a/stories/components/feedback/loading.stories.tsx
+++ b/stories/components/feedback/loading.stories.tsx
@@ -13,13 +13,13 @@ export default meta
 export const basic: Story = () => {
   return (
     <Wrap gap="md">
-      <Loading variant="oval" size="6xl" color="red.500" />
-      <Loading variant="grid" size="6xl" color="orange.500" />
-      <Loading variant="audio" size="6xl" color="yellow.500" />
-      <Loading variant="dots" size="6xl" color="green.500" />
-      <Loading variant="puff" size="6xl" color="teal.500" />
-      <Loading variant="rings" size="6xl" color="blue.500" />
-      <Loading variant="circles" size="6xl" color="cyan.500" />
+      <Loading variant="oval" fontSize="6xl" color="red.500" />
+      <Loading variant="grid" fontSize="6xl" color="orange.500" />
+      <Loading variant="audio" fontSize="6xl" color="yellow.500" />
+      <Loading variant="dots" fontSize="6xl" color="green.500" />
+      <Loading variant="puff" fontSize="6xl" color="teal.500" />
+      <Loading variant="rings" fontSize="6xl" color="blue.500" />
+      <Loading variant="circles" fontSize="6xl" color="cyan.500" />
     </Wrap>
   )
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2485 

## Description
Replaced the deprecated `size` prop with fontSize in the Storybook `Loading` page.

## Current behavior (updates)
Currently, the `Loading` component uses the deprecated `size` prop in the Storybook `Loading` page.

## New behavior

The `Loading` component now uses the `fontSize` prop in the Storybook `Loading` page.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information

None