### PR TITLE
refactor: Deprecated props are being used in the Storybook Theme/Loadingpage.

### DIFF
--- a/stories/system/theme/loading.stories.tsx
+++ b/stories/system/theme/loading.stories.tsx
@@ -170,7 +170,7 @@ export const useCustomLoading = () => {
                   boxShadow: ["lg", "dark-lg"],
                 }}
               >
-                <Loading variant="dots" size="6xl" />
+                <Loading variant="dots" fontSize="6xl" />
 
                 <VStack align="center" mb="md" gap="sm">
                   <Text>Downloading files…</Text>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/2508

## Description
- As the subject suggests, I have changed the deprecated size prop in the Loading component to fontSize.

<!-- Add a brief description. -->

## Current behavior (updates)
- None

<!-- Please describe the current behavior that you are modifying. -->

## New behavior
- None

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
- No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
- None
