### PR TITLE
docs: Update icon to use fontSize instead of size

### DIFF
--- a/docs/contents/components/media-and-icons/icon/index.ja.mdx
+++ b/docs/contents/components/media-and-icons/icon/index.ja.mdx
@@ -29,12 +29,12 @@ import { FaRobot } from "react-icons/fa"
 
 ```tsx
 <Wrap gap="md">
-  <Icon as={FaRobot} size="xl" />
-  <Icon as={FaRobot} size="2xl" />
-  <Icon as={FaRobot} size="3xl" />
-  <Icon as={FaRobot} size="4xl" />
-  <Icon as={FaRobot} size="5xl" />
-  <Icon as={FaRobot} size="6xl" />
+  <Icon as={FaRobot} fontSize="xl" />
+  <Icon as={FaRobot} fontSize="2xl" />
+  <Icon as={FaRobot} fontSize="3xl" />
+  <Icon as={FaRobot} fontSize="4xl" />
+  <Icon as={FaRobot} fontSize="5xl" />
+  <Icon as={FaRobot} fontSize="6xl" />
 </Wrap>
 ```
 

--- a/docs/contents/components/media-and-icons/icon/index.mdx
+++ b/docs/contents/components/media-and-icons/icon/index.mdx
@@ -25,16 +25,16 @@ import { FaRobot } from "react-icons/fa"
 <Icon as={FaRobot} />
 ```
 
-### Change Size
+### Change fontSize
 
 ```tsx
 <Wrap gap="md">
-  <Icon as={FaRobot} size="xl" />
-  <Icon as={FaRobot} size="2xl" />
-  <Icon as={FaRobot} size="3xl" />
-  <Icon as={FaRobot} size="4xl" />
-  <Icon as={FaRobot} size="5xl" />
-  <Icon as={FaRobot} size="6xl" />
+  <Icon as={FaRobot} fontSize="xl" />
+  <Icon as={FaRobot} fontSize="2xl" />
+  <Icon as={FaRobot} fontSize="3xl" />
+  <Icon as={FaRobot} fontSize="4xl" />
+  <Icon as={FaRobot} fontSize="5xl" />
+  <Icon as={FaRobot} fontSize="6xl" />
 </Wrap>
 ```
 


### PR DESCRIPTION
Closes # [2486](https://github.com/yamada-ui/yamada-ui/issues/2486)

## Description

I changed the deprecated `size` props to `fontSize` in the Icon docs.

## Current behavior (updates)

In the Menu page, deprecated `size` props is used

## New behavior

Use `fontSize` props instead of `size`.

## Is this a breaking change (Yes/No):

No

## Additional Information
None