### PR TITLE
Add support for CSS variable parsing with `$` symbol

### DIFF
--- a/.changeset/two-fishes-juggle.md
+++ b/.changeset/two-fishes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": minor
+---
+
+Enabled access to CSS variables from CSS string values using the `$` symbol.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -13,6 +13,7 @@ import {
   filterUndefined,
 } from "@yamada-ui/utils"
 import type * as CSS from "csstype"
+import { DEFAULT_VAR_PREFIX } from "./constant"
 import type { CSSObjectOrFunc, CSSUIObject, ColorMode } from "./css"
 import type { ThemeToken } from "./theme"
 import type { StyledTheme } from "./theme.types"
@@ -345,7 +346,8 @@ export type Transforms = keyof typeof transforms
 export const transforms = {
   var: (values: any[], theme: StyledTheme) =>
     values.reduce<Dict>((prev, { __prefix, name, token, value }) => {
-      const prefix = __prefix ?? theme.__config.var?.prefix ?? "ui"
+      const prefix =
+        __prefix ?? theme.__config.var?.prefix ?? DEFAULT_VAR_PREFIX
 
       name = `--${prefix}-${name}`
 

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_VAR_PREFIX = "ui"

--- a/packages/core/src/css/css.ts
+++ b/packages/core/src/css/css.ts
@@ -1,6 +1,7 @@
 import type { Dict } from "@yamada-ui/utils"
-import { isArray, isObject, merge, runIfFunc } from "@yamada-ui/utils"
+import { isArray, isObject, isString, merge, runIfFunc } from "@yamada-ui/utils"
 import type { ConfigProps } from "../config"
+import { DEFAULT_VAR_PREFIX } from "../constant"
 import { pseudos } from "../pseudos"
 import { processSkipProperties, styles } from "../styles"
 import type { StyledTheme } from "../theme.types"
@@ -69,6 +70,24 @@ const expandCSS =
     return computedCSS
   }
 
+const parseVar = (value: any, theme: StyledTheme) => {
+  if (isArray(value) || isObject(value)) {
+    return value
+  } else if (isString(value)) {
+    const prefix = theme.__config?.var?.prefix ?? DEFAULT_VAR_PREFIX
+
+    return value.replace(/\$([^,)/\s]+)/g, (_, value) => {
+      if (isObject(theme.__cssMap) && value in theme.__cssMap) {
+        return theme.__cssMap[value].ref
+      } else {
+        return `var(--${prefix}-${value})`
+      }
+    })
+  } else {
+    return value
+  }
+}
+
 const getCSS = ({
   theme,
   styles = {},
@@ -93,6 +112,7 @@ const getCSS = ({
       if (disableStyleProp?.(prop)) continue
 
       value = runIfFunc(value, theme)
+      value = parseVar(value, theme)
 
       if (value == null) continue
 

--- a/packages/core/src/css/var.ts
+++ b/packages/core/src/css/var.ts
@@ -1,6 +1,7 @@
 import type { Dict } from "@yamada-ui/utils"
 import { escape, merge, calc, isArray, isUndefined } from "@yamada-ui/utils"
 import { generateAnimation, generateGradient } from "../config"
+import { DEFAULT_VAR_PREFIX } from "../constant"
 import { pseudos } from "../pseudos"
 import type { VarTokens } from "../theme"
 import type { CSSMap, StyledTheme } from "../theme.types"
@@ -25,7 +26,7 @@ const tokenToVar = (token: string, prefix: string): Var => {
 }
 
 export const createVars =
-  (tokens: VarTokens, prefix: string = "ui") =>
+  (tokens: VarTokens, prefix: string = DEFAULT_VAR_PREFIX) =>
   ({
     baseTokens,
     cssMap = {},


### PR DESCRIPTION
Closes #2548

## Description

Add support for CSS variable parsing with `$` symbol.

## Is this a breaking change (Yes/No):

No