### PR TITLE
fix: active year's button after click on month-picker's header

### DIFF
--- a/packages/components/calendar/src/use-month-picker.ts
+++ b/packages/components/calendar/src/use-month-picker.ts
@@ -83,6 +83,8 @@ export const useMonthPicker = ({
     defaultValue: defaultType,
     onChange: onChangeTypeProp,
   })
+  const [isClickOnYearListAlready, setIsClickOnYearListAlready] =
+    useState<boolean>(false)
 
   const {
     inputRef,
@@ -111,11 +113,26 @@ export const useMonthPicker = ({
     onChangeType: (type, year, month) => {
       if (type !== "date") {
         setType(type)
+
+        if (year) {
+          setIsClickOnYearListAlready(true)
+
+          if (isClickOnYearListAlready) {
+            const prevMonth = value?.getMonth()
+
+            const currentValue: Date = new Date(year, prevMonth || 0)
+            const inputValue = dateToString(currentValue)
+
+            setValue(currentValue)
+            setInputValue(inputValue)
+          }
+        }
       } else {
         let value: Date | undefined = undefined
 
-        if (typeof year === "number" && typeof month === "number")
+        if (typeof year === "number" && typeof month === "number") {
           value = new Date(year, month)
+        }
 
         const inputValue = dateToString(value)
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes  https://github.com/yamada-ui/yamada-ui/issues/2425

## Description

Active year button  after click on month-picker's header .

## Current behavior (updates)

Currently , Year picker is not active after clicking .

## New behavior

After click on year picker , the year picker button will be actived . 

Also if we don't have the previous month value ,it will be set as January . Otherwise will be set the choosen month value .  

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information


https://github.com/user-attachments/assets/98a0572c-7a59-4f4c-b36d-cc5f830c2e0b



