### PR TITLE
Remove 'size' from CarouselItem props

### DIFF
--- a/docs/pages/examples/music/content.tsx
+++ b/docs/pages/examples/music/content.tsx
@@ -24,7 +24,7 @@ import type { StackProps } from "@yamada-ui/react"
 import { memo, useState } from "react"
 import type { Dispatch, FC, ReactNode, SetStateAction } from "react"
 
-type CarouselItem = Omit<ImageProps, "alt"> & {
+type CarouselItem = Omit<ImageProps, "alt" | "size"> & {
   title: string
   description: string
 }


### PR DESCRIPTION
## Description

Remove 'size' from CarouselItem props.

```
Run pnpm docs:content

> yamada-ui@1.0.0 docs:content /home/runner/work/yamada-ui/yamada-ui
> pnpm --prefix docs gen:content


> yamada-docs@1.0.0 gen:content /home/runner/work/yamada-ui/yamada-ui/docs
> tsx scripts/mdx/builder

generated 967 files

> yamada-ui@1.0.0 docs:typecheck /home/runner/work/yamada-ui/yamada-ui
> pnpm --prefix docs typecheck


> yamada-docs@1.0.0 typecheck /home/runner/work/yamada-ui/yamada-ui/docs
> tsc --noEmit

Error: pages/examples/music/content.tsx(334,44): error TS2322: Type 'UIValue<string>' is not assignable to type '(UIValue<string> & ("sm" | "md")) | undefined'.
  Type 'string' is not assignable to type '(UIValue<string> & ("sm" | "md")) | undefined'.
 ELIFECYCLE  Command failed with exit code 2.
 ELIFECYCLE  Command failed with exit code 2.
Error: Process completed with exit code 2.
```

## Is this a breaking change (Yes/No):

No