### PR TITLE
Removed `changeset-release/docs` branch trigger

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - documentation
-      - changeset-release/docs
       - v*
 
 jobs:


### PR DESCRIPTION
## Description

Removed `changeset-release/docs` branch trigger.

Pull requests directed to `changeset-release/docs` will not be created and are not required.

## Is this a breaking change (Yes/No):

No