### PR TITLE
refactor(button-group): remove unnecessary marginBlockEnd property

### DIFF
--- a/.changeset/little-meals-listen.md
+++ b/.changeset/little-meals-listen.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/button": patch
+---
+
+Fixed Button Group Component Style

--- a/packages/components/button/src/button-group.tsx
+++ b/packages/components/button/src/button-group.tsx
@@ -71,7 +71,7 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">(
     if (isAttached) {
       Object.assign(css, {
         "> *:first-of-type:not(:last-of-type)": isColumn
-          ? { borderBottomRadius: 0, marginBlockEnd: "-1px" }
+          ? { borderBottomRadius: 0 }
           : { borderRightRadius: 0, marginInlineEnd: "-1px" },
         "> *:not(:first-of-type):not(:last-of-type)": isColumn
           ? { borderRadius: 0, marginBlockStart: "-1px" }

--- a/stories/components/forms/button.stories.tsx
+++ b/stories/components/forms/button.stories.tsx
@@ -503,6 +503,12 @@ export const buttonGroup: Story = () => {
         <Button>Button</Button>
         <Button>Button</Button>
       </ButtonGroup>
+
+      <ButtonGroup isAttached variant="outline">
+        <Button>Button</Button>
+        <Button>Button</Button>
+        <Button>Button</Button>
+      </ButtonGroup>
     </>
   )
 }


### PR DESCRIPTION
<!---

-->

Closes #2670 

## Description

The issue where Button components arranged vertically in a column had overlapping outlines has been resolved. By removing the `marginBlockEnd: -1px` property from the `button-group.tsx` file, the problem was fixed without disrupting the overall style and layout of the buttons.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):　No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
