### PR TITLE
docs: replace `Menu` with `Popover` in `Popover`

### DIFF
--- a/docs/contents/components/overlay/popover/index.ja.mdx
+++ b/docs/contents/components/overlay/popover/index.ja.mdx
@@ -62,7 +62,7 @@ import {
 `children`には、`isOpen`や`onClose`などのメソッドが提供されます。これを利用して、内部状態にアクセスすることができます。
 
 ```tsx
-<Menu>
+<Popover>
   {({ isOpen }) => (
     <>
       <PopoverTrigger>
@@ -76,7 +76,7 @@ import {
       </PopoverContent>
     </>
   )}
-</Menu>
+</Popover>
 ```
 
 ### 別の要素を参照して表示する

--- a/docs/contents/components/overlay/popover/index.mdx
+++ b/docs/contents/components/overlay/popover/index.mdx
@@ -62,7 +62,7 @@ If the `children` of `PopoverTrigger` or `PopoverAnchor` are function components
 The `children` are provided with methods such as `isOpen` and `onClose`. You can use these to access the internal state.
 
 ```tsx
-<Menu>
+<Popover>
   {({ isOpen }) => (
     <>
       <PopoverTrigger>
@@ -76,7 +76,7 @@ The `children` are provided with methods such as `isOpen` and `onClose`. You can
       </PopoverContent>
     </>
   )}
-</Menu>
+</Popover>
 ```
 
 ### Displaying Based on a Different Element


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2666 <!-- Github issue # here -->

## Description
I have replaced `Menu` with `Popover` in the `Popover` docs.
<!-- Add a brief description. -->


## Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->


