### PR TITLE
test: add tests for popover animation

### DIFF
--- a/packages/components/popover/tests/popover.test.tsx
+++ b/packages/components/popover/tests/popover.test.tsx
@@ -155,4 +155,50 @@ describe("<Popover />", () => {
     await waitFor(() => expect(closeButton).not.toBeVisible())
     await waitFor(() => expect(body).not.toBeVisible())
   })
+
+  test.each<{
+    animation: "scale" | "top" | "left" | "bottom" | "right"
+    transform: string
+  }>([
+    {
+      animation: "scale",
+      transform: "scale(0.95)",
+    },
+    {
+      animation: "top",
+      transform: "translateY(-16px)",
+    },
+    {
+      animation: "left",
+      transform: "translateX(-16px)",
+    },
+    {
+      animation: "bottom",
+      transform: "translateY(16px)",
+    },
+    {
+      animation: "right",
+      transform: "translateX(16px)",
+    },
+  ])(
+    "when animation is %s, the popover should be displayed",
+    async ({ animation, transform }) => {
+      const { user, container } = render(
+        <PopoverExample animation={animation} />,
+      )
+
+      const popoverContent = container.querySelector(".ui-popover__content")
+      expect(popoverContent).toHaveStyle({
+        transform,
+        visibility: "hidden",
+      })
+
+      const triggerButton = await screen.findByRole("button", {
+        name: "Open Popover",
+      })
+      await user.click(triggerButton)
+
+      await waitFor(() => expect(popoverContent).toBeVisible())
+    },
+  )
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/2070

## Description

<!-- Add a brief description. -->
Add tests for animation for the Popover component

Target: [packages/components/popover/src/popover-content.tsx](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/popover/src/popover-content.tsx)
 - [L37](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/popover/src/popover-content.tsx#L37)
 - [L42](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/popover/src/popover-content.tsx#L42)
 - [L47](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/popover/src/popover-content.tsx#L47)
 - [L52](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/popover/src/popover-content.tsx#L52)

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
I accidentally closed the previous pull request when I deleted a repository that I had forked by mistake. I have now created a new pull request to replace the closed one. 
https://github.com/yamada-ui/yamada-ui/pull/2677