### PR TITLE
Fixed a bug where the right navigation item was not clickable

### DIFF
--- a/docs/components/navigation/table-of-contents.tsx
+++ b/docs/components/navigation/table-of-contents.tsx
@@ -129,7 +129,6 @@ export const TableOfContents = memo(
                     }}
                     transitionProperty="colors"
                     transitionDuration="normal"
-                    pointerEvents="none"
                   >
                     <Box
                       data-selected={dataAttr(isSelected)}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2684

## Description

<!-- Add a brief description. -->
Fixed a bug where the right navigation item was not clickable.
`pointerEvent` was set to `none`, which prevented the click.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Cannot click on right navigation item.
## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
The right navigation item has been modified to be clickable.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
