### PR TITLE
Removed unnecessary `tabIndex` attribute

### DIFF
--- a/.changeset/spicy-donkeys-appear.md
+++ b/.changeset/spicy-donkeys-appear.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/infinite-scroll-area": patch
+---
+
+Fixed a bug where `tabIndex` was set even though there was no need to focus.

--- a/packages/components/infinite-scroll-area/src/infinite-scroll-area.tsx
+++ b/packages/components/infinite-scroll-area/src/infinite-scroll-area.tsx
@@ -107,7 +107,6 @@ export const InfiniteScrollArea = forwardRef<InfiniteScrollAreaProps, "div">(
       <InfiniteScrollAreaProvider value={styles}>
         <ui.div
           ref={mergeRefs(rootRef, ref)}
-          tabIndex={0}
           className={cx("ui-infinite-scroll-area", className)}
           role="feed"
           aria-busy="false"


### PR DESCRIPTION
Closes #2701

## Description

Removed unnecessary `tabIndex` attribute.

## Is this a breaking change (Yes/No):

No