### PR TITLE
Corrected `onError` and `onLoad` handling in Image component

### DIFF
--- a/.changeset/wicked-emus-try.md
+++ b/.changeset/wicked-emus-try.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/image": patch
+---
+
+Fixed a bug where `onError` and `onLoad` were not set correctly to the element.

--- a/packages/components/image/src/image.tsx
+++ b/packages/components/image/src/image.tsx
@@ -5,7 +5,7 @@ import {
   useComponentStyle,
   omitThemeProps,
 } from "@yamada-ui/core"
-import { cx, omitObject } from "@yamada-ui/utils"
+import { cx } from "@yamada-ui/utils"
 import type { ReactElement } from "react"
 import { isValidElement, useMemo } from "react"
 import type { UseImageProps } from "./use-image"
@@ -102,7 +102,7 @@ export const Image = forwardRef<ImageProps, "img">((props, ref) => {
       referrerPolicy={referrerPolicy}
       className={cx("ui-image", className)}
       __css={css}
-      {...(ignoreFallback ? rest : omitObject(rest, ["onError", "onLoad"]))}
+      {...(ignoreFallback ? { ...rest, onError, onLoad } : rest)}
     />
   )
 })


### PR DESCRIPTION
Closes #2725

## Description

Corrected `onError` and `onLoad` handling in Image component.

## Is this a breaking change (Yes/No):

No