### PR TITLE
(fix) : changed the color used in `DropzoneAccept` and `Dropzone` to …

### DIFF
--- a/docs/contents/components/forms/dropzone/index.ja.mdx
+++ b/docs/contents/components/forms/dropzone/index.ja.mdx
@@ -163,7 +163,7 @@ import {
 <Dropzone accept={IMAGE_ACCEPT_TYPE} maxSize={3 * 1024 ** 2}>
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>
@@ -207,7 +207,7 @@ import {
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>
@@ -240,7 +240,7 @@ import {
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>
@@ -273,7 +273,7 @@ import {
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>

--- a/docs/contents/components/forms/dropzone/index.mdx
+++ b/docs/contents/components/forms/dropzone/index.mdx
@@ -163,7 +163,7 @@ To control the display based on whether the file is accepted or rejected, use `D
 <Dropzone accept={IMAGE_ACCEPT_TYPE} maxSize={3 * 1024 ** 2}>
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>
@@ -207,7 +207,7 @@ Please note that it is always called regardless of whether the dropped file is a
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>
@@ -240,7 +240,7 @@ To handle only accepted files, use `onDropAccepted`.
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>
@@ -273,7 +273,7 @@ To handle only rejected files, use `onDropRejected`.
 >
   <HStack color={["blackAlpha.500", "whiteAlpha.500"]}>
     <DropzoneAccept>
-      <Upload fontSize="6xl" color="primary" />
+      <Upload fontSize="6xl" color="success" />
     </DropzoneAccept>
 
     <DropzoneReject>


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/2796

## Description
Colors used in `DropzoneAccept` in `Dropzone` are wrong.

The correct name is `success`.

<!-- Add a brief description. -->

## Current behavior (updates)

It is currently using `primary` which is wrong.

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

I've changed it from `primary` to `success`

