### PR TITLE
Fixed outline display on focus for menu elements

### DIFF
--- a/.changeset/warm-socks-live.md
+++ b/.changeset/warm-socks-live.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/popover": patch
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where the outline was displayed when `Menu` or `ContextMenu` was focused.

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -125,6 +125,7 @@ export const PopoverContent = motionForwardRef<PopoverContentProps, "section">(
           style: { visibility: isOpen ? "visible" : "hidden" },
         })}
         className="ui-popover"
+        outline="none"
         width={width}
         minWidth={minWidth}
         maxWidth={maxWidth}

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -17,6 +17,7 @@ export const Menu: ComponentMultiStyle<"Menu"> = {
       zIndex: "guldo",
     },
     list: {
+      outline: "none",
       py: "2",
     },
     item: {


### PR DESCRIPTION
Closes #2837

## Description

Fixed outline display on focus for menu elements.

## Is this a breaking change (Yes/No):

No