### PR TITLE
fix: set display-name in `textarea` component

### DIFF
--- a/.changeset/curvy-sloths-sing.md
+++ b/.changeset/curvy-sloths-sing.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/textarea": patch
+---
+
+Set `displayName` for easier debugging.

--- a/packages/components/textarea/src/textarea.tsx
+++ b/packages/components/textarea/src/textarea.tsx
@@ -138,3 +138,6 @@ export const Textarea = forwardRef<TextareaProps, "textarea">((props, ref) => {
     />
   )
 })
+
+Textarea.displayName = "Textarea"
+Textarea.__ui__ = "Textarea"


### PR DESCRIPTION
Closed #2911

## Description

The component "@yamada-ui/textarea" uses forwardRef, but displayName is not set, making it difficult to see the display in [React Developer Tools](https://github.com/facebook/react/tree/main/packages/react-devtools).

## New behavior

Set displayName.

## Is this a breaking change (Yes/No):

No
