### PR TITLE
fix: add displayName and __ui__ to tooltip component

### DIFF
--- a/.changeset/unlucky-balloons-cheer.md
+++ b/.changeset/unlucky-balloons-cheer.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/tooltip": patch
+---
+
+add displayName and **ui** to tooltip component

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -411,3 +411,6 @@ export const Tooltip = motionForwardRef<TooltipProps, "div">(
     )
   },
 )
+
+Tooltip.displayName = "Tooltip"
+Tooltip.__ui__ = "Tooltip"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2913

## Description

add displayName and ui to tooltip component.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
