### PR TITLE
refactor: update alpha-slider accessibility

### DIFF
--- a/.changeset/blue-kids-worry.md
+++ b/.changeset/blue-kids-worry.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": minor
+---
+
+add aria-valuetext property to AlphaSlider

--- a/packages/components/color-picker/src/use-color-slider.ts
+++ b/packages/components/color-picker/src/use-color-slider.ts
@@ -103,6 +103,7 @@ export const useColorSlider = ({
     onChangeEnd: onChangeEndProp,
     thumbColor,
     style: styleProp,
+    "aria-valuetext": ariaValueText,
     ...rest
   } = useFormControlProps(props)
   const [
@@ -355,6 +356,7 @@ export const useColorSlider = ({
         "aria-valuenow": value,
         "aria-valuemin": min,
         "aria-valuemax": max,
+        "aria-valuetext": ariaValueText ?? value.toString(),
         "data-active": dataAttr(isDragging && focusThumbOnChange),
         onKeyDown: handlerAll(props.onKeyDown, onKeyDown),
         onFocus: handlerAll(props.onFocus, onFocusProp),
@@ -377,6 +379,7 @@ export const useColorSlider = ({
       onKeyDown,
       onFocusProp,
       onBlurProp,
+      ariaValueText,
     ],
   )
 


### PR DESCRIPTION
Closes #2084 

## Description

Add aria-valuetext to AlphaSlider to eliminate accessibility issues.
This response adds an aria-valuetext attribute to AplhaSlider to provide the current value to the user.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
