### PR TITLE
feat: set display name and UI for scroll-area

### DIFF
--- a/.changeset/loud-toys-clean.md
+++ b/.changeset/loud-toys-clean.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/scroll-area": patch
+---
+
+Set `displayName` for `scroll-area` component to improve debugging

--- a/packages/components/scroll-area/src/scroll-area.tsx
+++ b/packages/components/scroll-area/src/scroll-area.tsx
@@ -209,6 +209,8 @@ export const ScrollArea = forwardRef<ScrollAreaProps, "div">((props, ref) => {
     )
   }
 })
+ScrollArea.displayName = "ScrollArea"
+ScrollArea.__ui__ = "ScrollArea"
 
 type InternalScrollAreaProps = HTMLUIProps & Pick<ScrollAreaProps, "innerProps">
 
@@ -232,3 +234,6 @@ const InternalScrollArea = forwardRef<InternalScrollAreaProps, "div">(
     )
   },
 )
+
+InternalScrollArea.displayName = "InternalScrollArea"
+InternalScrollArea.__ui__ = "InternalScrollArea"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2899 

## Description

Set `displayName` and `__ui__`. 

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
