### PR TITLE
feat: set display name and UI for focus-lock

### DIFF
--- a/.changeset/nasty-cobras-divide.md
+++ b/.changeset/nasty-cobras-divide.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/focus-lock": patch
+---
+
+Set `displayName` and `__ui__` after each component definition, and add import `FC` from `@yamada-ui/core`.

--- a/packages/components/focus-lock/src/focus-lock.tsx
+++ b/packages/components/focus-lock/src/focus-lock.tsx
@@ -1,6 +1,7 @@
 import type { FocusableElement } from "@yamada-ui/utils"
 import { getAllFocusable, interopDefault } from "@yamada-ui/utils"
-import type { FC, ReactNode, RefObject } from "react"
+import type { FC } from "@yamada-ui/core"
+import type { ReactNode, RefObject } from "react"
 import { useCallback } from "react"
 import ReactFocusLock from "react-focus-lock"
 
@@ -104,3 +105,6 @@ export const FocusLock: FC<FocusLockProps> = ({
     </InternalFocusLock>
   )
 }
+
+FocusLock.displayName = "FocusLock"
+FocusLock.__ui__ = "FocusLock"

--- a/packages/components/focus-lock/src/focus-lock.tsx
+++ b/packages/components/focus-lock/src/focus-lock.tsx
@@ -1,6 +1,6 @@
+import type { FC } from "@yamada-ui/core"
 import type { FocusableElement } from "@yamada-ui/utils"
 import { getAllFocusable, interopDefault } from "@yamada-ui/utils"
-import type { FC } from "@yamada-ui/core"
 import type { ReactNode, RefObject } from "react"
 import { useCallback } from "react"
 import ReactFocusLock from "react-focus-lock"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2866 <!-- Github issue # here -->

## Description

Set `displayName` and `__ui__` after focus-lock and add import from `@yamada-ui/core`