### PR TITLE
fix: set displayname and __ui__ to checkbox

### DIFF
--- a/.changeset/chilly-spies-approve.md
+++ b/.changeset/chilly-spies-approve.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/checkbox": patch
+---
+
+Set displayname and **ui** after each component definition

--- a/packages/components/checkbox/src/checkbox-group.tsx
+++ b/packages/components/checkbox/src/checkbox-group.tsx
@@ -214,3 +214,4 @@ export const CheckboxGroup = forwardRef(
 } & ComponentArgs
 
 CheckboxGroup.displayName = "CheckboxGroup"
+CheckboxGroup.__ui__ = "CheckboxGroup"

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -1,3 +1,4 @@
+import type { FC } from "@yamada-ui/core"
 import type {
   HTMLUIProps,
   ThemeProps,
@@ -30,7 +31,6 @@ import type {
   ChangeEvent,
   ChangeEventHandler,
   CSSProperties,
-  FC,
   FocusEventHandler,
   InputHTMLAttributes,
   KeyboardEvent,
@@ -488,6 +488,7 @@ export const Checkbox = forwardRef(
 } & ComponentArgs
 
 Checkbox.displayName = "Checkbox"
+Checkbox.__ui__ = "Checkbox"
 
 export type CheckboxIconProps = MotionProps<"svg"> &
   FormControlOptions & {
@@ -553,6 +554,9 @@ export const CheckboxIcon: FC<CheckboxIconProps> = ({
   )
 }
 
+CheckboxIcon.displayName = "CheckboxIcon"
+CheckboxIcon.__ui__ = "CheckboxIcon"
+
 const CheckIcon: FC<MotionProps<"svg">> = (props) => {
   return (
     <motion.svg
@@ -582,6 +586,9 @@ const CheckIcon: FC<MotionProps<"svg">> = (props) => {
   )
 }
 
+CheckIcon.displayName = "CheckIcon"
+CheckIcon.__ui__ = "CheckIcon"
+
 const IndeterminateIcon: FC<MotionProps<"svg">> = (props) => {
   return (
     <motion.svg
@@ -608,3 +615,6 @@ const IndeterminateIcon: FC<MotionProps<"svg">> = (props) => {
     </motion.svg>
   )
 }
+
+IndeterminateIcon.displayName = "IndeterminateIcon"
+IndeterminateIcon.__ui__ = "IndeterminateIcon"

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -1,5 +1,5 @@
-import type { FC } from "@yamada-ui/core"
 import type {
+  FC,
   HTMLUIProps,
   ThemeProps,
   ComponentArgs,


### PR DESCRIPTION
Closes #2859 

## Description

Set displayName and __ui__ after each component for checkbox

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
