### PR TITLE
refactor: Update HueSlider accessibility 

### DIFF
--- a/.changeset/famous-melons-call.md
+++ b/.changeset/famous-melons-call.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+Added `aria-valuetext` to `AlphaSlider` and `HueSlider`.

--- a/packages/components/color-picker/src/alpha-slider.tsx
+++ b/packages/components/color-picker/src/alpha-slider.tsx
@@ -114,7 +114,7 @@ interface AlphaSliderOptions {
 
 export interface AlphaSliderProps
   extends ThemeProps<"AlphaSlider">,
-    Partial<Omit<UseColorSliderProps, "color">>,
+    Partial<Omit<UseColorSliderProps, "channel" | "color">>,
     AlphaSliderOptions {}
 
 /**
@@ -145,6 +145,7 @@ export const AlphaSlider = forwardRef<AlphaSliderProps, "input">(
         step: 0.01,
         thumbColor: "transparent",
         ...computedProps,
+        channel: "alpha",
       })
 
     const css: CSSUIObject = {

--- a/packages/components/color-picker/src/hue-slider.tsx
+++ b/packages/components/color-picker/src/hue-slider.tsx
@@ -90,7 +90,7 @@ interface HueSliderOptions {
 
 export interface HueSliderProps
   extends ThemeProps<"HueSlider">,
-    Partial<UseColorSliderProps>,
+    Partial<Omit<UseColorSliderProps, "channel">>,
     HueSliderOptions {}
 
 /**
@@ -113,7 +113,7 @@ export const HueSlider = forwardRef<HueSliderProps, "input">((props, ref) => {
     ...computedProps
   } = omitThemeProps(mergedProps)
   const { getContainerProps, getInputProps, getThumbProps, getTrackProps } =
-    useColorSlider({ max, min, step: 1, ...computedProps })
+    useColorSlider({ max, min, step: 1, ...computedProps, channel: "hue" })
 
   const css: CSSUIObject = {
     position: "relative",

--- a/packages/components/color-picker/src/use-color-slider.ts
+++ b/packages/components/color-picker/src/use-color-slider.ts
@@ -23,6 +23,8 @@ import {
 } from "@yamada-ui/utils"
 import { useCallback, useRef, useState } from "react"
 
+type ColorSliderChannel = "alpha" | "hue"
+
 interface UseColorSliderOptions {
   /**
    * The maximum allowed value of the slider. Cannot be less than min.
@@ -41,6 +43,10 @@ interface UseColorSliderOptions {
    * This is particularly useful in forms.
    */
   name?: string
+  /**
+   * The channel of the slider.
+   */
+  channel?: ColorSliderChannel
   /**
    * The initial value of the slider.
    */
@@ -94,6 +100,7 @@ export const useColorSlider = ({
     id,
     name,
     style: styleProp,
+    channel = "hue",
     defaultValue,
     max,
     min = 0,
@@ -354,6 +361,7 @@ export const useColorSlider = ({
         "aria-valuemax": max,
         "aria-valuemin": min,
         "aria-valuenow": value,
+        "aria-valuetext": getAriaValueText(channel, value),
         "data-active": dataAttr(isDragging && focusThumbOnChange),
         role: "slider",
         tabIndex: isInteractive && focusThumbOnChange ? 0 : undefined,
@@ -369,14 +377,15 @@ export const useColorSlider = ({
       value,
       formControlProps,
       ariaReadonly,
-      isInteractive,
-      focusThumbOnChange,
-      min,
       max,
+      min,
+      channel,
       isDragging,
-      onKeyDown,
-      onFocusProp,
+      focusThumbOnChange,
+      isInteractive,
       onBlurProp,
+      onFocusProp,
+      onKeyDown,
     ],
   )
 
@@ -390,3 +399,23 @@ export const useColorSlider = ({
 }
 
 export type UseColorSliderReturn = ReturnType<typeof useColorSlider>
+
+export const getAriaValueText = (
+  channel: ColorSliderChannel,
+  value: number,
+) => {
+  if (channel === "hue") {
+    return `${value}°, ${getColorName(value)}`
+  } else {
+    return `${value * 100}%`
+  }
+}
+
+const getColorName = (hue: number): string => {
+  if (hue < 30 || hue >= 330) return "Red"
+  if (hue < 90) return "Yellow"
+  if (hue < 150) return "Green"
+  if (hue < 210) return "Cyan"
+  if (hue < 270) return "Blue"
+  return "Magenta"
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2085 

## Description
Add aria-valuetext to hueSlider to eliminate accessibility issues.
In implementing aria-textvalue, we implemented the colorName function to get the name of the color.



## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
