### PR TITLE
Feat/set display name and UI for segmented control

### DIFF
--- a/.changeset/honest-bulldogs-end.md
+++ b/.changeset/honest-bulldogs-end.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/segmented-control": patch
+---
+
+Set `displayName` and `__ui__` after each component definition.

--- a/packages/components/segmented-control/src/segmented-control.tsx
+++ b/packages/components/segmented-control/src/segmented-control.tsx
@@ -9,6 +9,7 @@ import type {
 import {
   ui,
   forwardRef,
+  FC,
   useComponentMultiStyle,
   omitThemeProps,
 } from "@yamada-ui/core"
@@ -31,7 +32,6 @@ import {
 import type {
   ChangeEvent,
   ChangeEventHandler,
-  FC,
   FocusEventHandler,
   ReactElement,
 } from "react"
@@ -375,6 +375,9 @@ export const SegmentedControl = forwardRef<SegmentedControlProps, "div">(
   },
 )
 
+SegmentedControl.displayName = "SegmentedControl"
+SegmentedControl.__ui__ = "SegmentedControl"
+
 interface SegmentedControlButtonOptions {
   /**
    * The value of the segmented control button.
@@ -463,6 +466,7 @@ export const SegmentedControlButton = forwardRef<
 )
 
 SegmentedControlButton.displayName = "SegmentedControlButton"
+SegmentedControlButton.__ui__ = "SegmentedControlButton"
 
 interface SegmentedControlCursorProps extends MotionProps {
   className?: string
@@ -498,3 +502,6 @@ const SegmentedControlCursor: FC<SegmentedControlCursorProps> = ({
     />
   )
 }
+
+SegmentedControlCursor.displayName = "SegmentedControlCursor"
+SegmentedControlCursor.__ui__ = "SegmentedControlCursor"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2900 <!-- Github issue # here -->

## Description

Set `displayName` and `__ui__` for the `@yamada-ui/segmented-control` component to make debugging easier.
This change improves the ability to identify the component name in development tools.