### PR TITLE
fix(number-input): add displayName and __ui__ properties to improve d…

### DIFF
--- a/.changeset/bright-toes-repeat.md
+++ b/.changeset/bright-toes-repeat.md
@@ -1,5 +1,5 @@
 ---
-"@yamada-ui/number-input": minor
+"@yamada-ui/number-input": patch
 ---
 
 Added displayName and ui properties to @yamada-ui/number-input for improved debugging and internal use.

--- a/.changeset/bright-toes-repeat.md
+++ b/.changeset/bright-toes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/number-input": minor
+---
+
+Added displayName and ui properties to @yamada-ui/number-input for improved debugging and internal use.

--- a/.changeset/bright-toes-repeat.md
+++ b/.changeset/bright-toes-repeat.md
@@ -1,5 +1,0 @@
----
-"@yamada-ui/number-input": patch
----
-
-Added displayName and ui properties to @yamada-ui/number-input for improved debugging and internal use.

--- a/.changeset/neat-apricots-hammer.md
+++ b/.changeset/neat-apricots-hammer.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/number-input": patch
+---
+
+Added displayName and ui properties to @yamada-ui/number-input for improved debugging and internal use.

--- a/packages/components/number-input/src/number-input.tsx
+++ b/packages/components/number-input/src/number-input.tsx
@@ -780,6 +780,9 @@ const NumberInputField = forwardRef<NumberInputFieldProps, "input">(
   },
 )
 
+NumberInputField.displayName = "NumberInputField"
+NumberInputField.__ui__ = "NumberInputField"
+
 type NumberInputAddonProps = HTMLUIProps
 
 const NumberInputAddon = forwardRef<NumberInputAddonProps, "div">(
@@ -809,6 +812,9 @@ const NumberInputAddon = forwardRef<NumberInputAddonProps, "div">(
     )
   },
 )
+
+NumberInputAddon.displayName = "NumberInputAddon"
+NumberInputAddon.__ui__ = "NumberInputAddon"
 
 const Stepper = ui("button", {
   baseStyle: {
@@ -845,6 +851,9 @@ const NumberIncrementStepper = forwardRef<
   )
 })
 
+NumberIncrementStepper.displayName = "NumberIncrementStepper"
+NumberIncrementStepper.__ui__ = "NumberIncrementStepper"
+
 type NumberDecrementStepperProps = HTMLUIProps<"button">
 
 const NumberDecrementStepper = forwardRef<
@@ -865,3 +874,6 @@ const NumberDecrementStepper = forwardRef<
     </Stepper>
   )
 })
+
+NumberDecrementStepper.displayName = "NumberDecrementStepper"
+NumberDecrementStepper.__ui__ = "NumberDecrementStepper"

--- a/packages/components/number-input/src/number-input.tsx
+++ b/packages/components/number-input/src/number-input.tsx
@@ -752,6 +752,9 @@ export const NumberInput = forwardRef<NumberInputProps, "input">(
   },
 )
 
+NumberInput.displayName = "NumberInput"
+NumberInput.__ui__ = "NumberInput"
+
 type NumberInputFieldProps = Omit<
   HTMLUIProps<"input">,
   "disabled" | "required" | "readOnly" | "size"


### PR DESCRIPTION
### Description

Added `displayName` and `__ui__` properties to the `@yamada-ui/number-input` component to improve debugging in React Developer Tools and ensure proper internal usage within Yamada UI.

### Current behavior (updates)

Currently, the `@yamada-ui/number-input` component does not have `displayName` or `__ui__` set, making it difficult to identify in React Developer Tools.

### New behavior

With this change, the `@yamada-ui/number-input` component now has both `displayName` and `__ui__` set, making it easier to identify in React Developer Tools and improving internal management within Yamada UI.

### Is this a breaking change (Yes/No):

**No**

### Additional Information

There are no breaking changes, so this update should not affect existing Yamada UI users.
