### PR TITLE
Add `testing-library/no-wait-for-multiple-assertions` to ESLint rules

### DIFF
--- a/.eslint/testing-library.ts
+++ b/.eslint/testing-library.ts
@@ -15,5 +15,6 @@ export const testingLibraryConfig: Linter.Config = {
     "testing-library/no-promise-in-fire-event": "error",
     "testing-library/prefer-find-by": "error",
     "testing-library/no-await-sync-queries": "error",
+    "testing-library/no-wait-for-multiple-assertions": "error",
   },
 }

--- a/packages/components/file-button/tests/file-button.test.tsx
+++ b/packages/components/file-button/tests/file-button.test.tsx
@@ -110,23 +110,23 @@ describe("<FileButton />", () => {
 
     await waitFor(() => {
       expect(fileCount).toHaveTextContent("files: 1")
-      expect(handleFileChangeMock).toHaveBeenCalledWith([file1])
     })
+    expect(handleFileChangeMock).toHaveBeenCalledWith([file1])
 
     const file2 = new File(["test2"], "test2.txt", { type: "text/plain" })
     fireEvent.change(fileInput, { target: { files: [file1, file2] } })
 
     await waitFor(() => {
       expect(fileCount).toHaveTextContent("files: 2")
-      expect(handleFileChangeMock).toHaveBeenCalledWith([file1, file2])
     })
+    expect(handleFileChangeMock).toHaveBeenCalledWith([file1, file2])
 
     fireEvent.change(fileInput, { target: { files: [] } })
 
     await waitFor(() => {
       expect(fileCount).toHaveTextContent("files: 0")
-      expect(handleFileChangeMock).toHaveBeenCalledWith([])
     })
+    expect(handleFileChangeMock).toHaveBeenCalledWith([])
 
     expect(handleFileChangeMock).toHaveBeenCalledTimes(3)
   })

--- a/packages/components/pin-input/tests/pin-input.test.tsx
+++ b/packages/components/pin-input/tests/pin-input.test.tsx
@@ -60,8 +60,8 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(handleChange).toHaveBeenCalledWith("12")
-      expect(handleComplete).toHaveBeenCalledWith("12")
     })
+    expect(handleComplete).toHaveBeenCalledWith("12")
   })
 
   test('input type should be "password" when mask is true', () => {
@@ -134,8 +134,8 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(document.activeElement).toBe(firstInput)
-      expect(firstInput.placeholder).toBe("")
     })
+    expect(firstInput.placeholder).toBe("")
 
     await act(async () => {
       await user.click(secondInput)
@@ -143,9 +143,9 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(firstInput.placeholder).toBe("○")
-      expect(document.activeElement).toBe(secondInput)
-      expect(secondInput.placeholder).toBe("")
     })
+    expect(document.activeElement).toBe(secondInput)
+    expect(secondInput.placeholder).toBe("")
   })
 
   test("focus moves to previous input on backspace if current input is empty and manageFocus is true", async () => {
@@ -163,9 +163,8 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(document.activeElement).toStrictEqual(inputs[2])
-
-      expect(inputs[2]).toHaveValue("")
     })
+    expect(inputs[2]).toHaveValue("")
   })
 
   test("does not move focus on backspace if manageFocus is false", async () => {
@@ -201,9 +200,8 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(document.activeElement).toStrictEqual(thirdInput)
-
-      expect(thirdInput).toHaveValue("3")
     })
+    expect(thirdInput).toHaveValue("3")
   })
 
   test("automatically focuses the first input on mount if autoFocus is true", async () => {
@@ -281,10 +279,10 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(inputs[0]).toHaveValue("9")
-      expect(inputs[1]).toHaveValue("2")
-      expect(inputs[2]).toHaveValue("3")
-      expect(inputs[3]).toHaveValue("4")
     })
+    expect(inputs[1]).toHaveValue("2")
+    expect(inputs[2]).toHaveValue("3")
+    expect(inputs[3]).toHaveValue("4")
 
     await act(async () => {
       await user.click(inputs[2])
@@ -293,9 +291,9 @@ describe("<PinInput />", () => {
 
     await waitFor(() => {
       expect(inputs[0]).toHaveValue("9")
-      expect(inputs[1]).toHaveValue("2")
-      expect(inputs[2]).toHaveValue("")
-      expect(inputs[3]).toHaveValue("4")
     })
+    expect(inputs[1]).toHaveValue("2")
+    expect(inputs[2]).toHaveValue("")
+    expect(inputs[3]).toHaveValue("4")
   })
 })

--- a/packages/components/snacks/tests/snacks.test.tsx
+++ b/packages/components/snacks/tests/snacks.test.tsx
@@ -59,23 +59,21 @@ describe("<Snacks />", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("test-title")).toHaveClass("ui-snack__title")
-      expect(screen.queryByText("test-description")).toHaveClass(
-        "ui-snack__desc",
-      )
     })
+    expect(screen.queryByText("test-description")).toHaveClass("ui-snack__desc")
 
     fireEvent.click(updateBtn)
 
     await waitFor(() => {
       expect(screen.queryByText("test-title")).toBeNull()
-      expect(screen.queryByText("test-description")).toBeNull()
-      expect(screen.queryByText("test-title-update")).toHaveClass(
-        "ui-snack__title",
-      )
-      expect(screen.queryByText("test-description-update")).toHaveClass(
-        "ui-snack__desc",
-      )
     })
+    expect(screen.queryByText("test-description")).toBeNull()
+    expect(screen.queryByText("test-title-update")).toHaveClass(
+      "ui-snack__title",
+    )
+    expect(screen.queryByText("test-description-update")).toHaveClass(
+      "ui-snack__desc",
+    )
   })
 
   test("Snacks renders correctly when close", async () => {
@@ -89,8 +87,8 @@ describe("<Snacks />", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("test-title")).toBeNull()
-      expect(screen.queryByText("test-description")).toBeNull()
     })
+    expect(screen.queryByText("test-description")).toBeNull()
   })
 
   test("Snacks renders correctly when close all", async () => {
@@ -111,7 +109,7 @@ describe("<Snacks />", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("test-title")).toBeNull()
-      expect(screen.queryByText("test-description")).toBeNull()
     })
+    expect(screen.queryByText("test-description")).toBeNull()
   })
 })

--- a/packages/components/table/tests/table.test.tsx
+++ b/packages/components/table/tests/table.test.tsx
@@ -293,24 +293,24 @@ describe("<Tbody />", () => {
 
   test("checkbox can be clicked and toggled", async () => {
     const { user } = render(<Table columns={columns} data={data} />)
+    const checkbox = screen.getByLabelText("Select row")
     await waitFor(async () => {
-      const checkbox = screen.getByLabelText("Select row")
       expect(checkbox).not.toBeChecked()
       await user.click(checkbox)
-      expect(checkbox).toBeChecked()
     })
+    expect(checkbox).toBeChecked()
   })
 
   test("if rowsClickSelect is true, you can select a row by clicking on it", async () => {
     const { user } = render(
       <Table columns={columns} data={data} rowsClickSelect={true} />,
     )
+    const row = screen.getByRole("row", { name: /Goku/i })
     await waitFor(async () => {
-      const row = screen.getByRole("row", { name: /Goku/i })
       expect(row).not.toHaveAttribute("aria-selected")
-      await user.click(row)
-      expect(row).toHaveAttribute("aria-selected", "true")
     })
+    await user.click(row)
+    expect(row).toHaveAttribute("aria-selected", "true")
   })
 
   test("When double-clicked, the handler receives information about the clicked row", async () => {
@@ -349,13 +349,13 @@ describe("Sort", () => {
 
   test("column header click cycles through sort states", async () => {
     const { user } = render(<Table columns={columns} data={data} />)
+    const nameHeader = screen.getByText("Name")
     await waitFor(async () => {
-      const nameHeader = screen.getByText("Name")
       expect(nameHeader).toHaveAttribute("aria-sort", "none")
-      await user.click(nameHeader)
-      expect(nameHeader).toHaveAttribute("aria-sort", "ascending")
-      await user.click(nameHeader)
-      expect(nameHeader).toHaveAttribute("aria-sort", "descending")
     })
+    await user.click(nameHeader)
+    expect(nameHeader).toHaveAttribute("aria-sort", "ascending")
+    await user.click(nameHeader)
+    expect(nameHeader).toHaveAttribute("aria-sort", "descending")
   })
 })

--- a/packages/components/table/tests/table.test.tsx
+++ b/packages/components/table/tests/table.test.tsx
@@ -296,8 +296,8 @@ describe("<Tbody />", () => {
     const checkbox = screen.getByLabelText("Select row")
     await waitFor(async () => {
       expect(checkbox).not.toBeChecked()
-      await user.click(checkbox)
     })
+    await user.click(checkbox)
     expect(checkbox).toBeChecked()
   })
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/2719

## Description
We are introducing the ESLint rule testing-library/no-wait-for-multiple-assertions to automate a check that we currently perform manually during code reviews.
This rule prevents multiple assertions within a single waitFor call in our tests.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
Ran `pnpm lint` and `pnpm test` and confirmed all checks passed successfully.