### PR TITLE
refactor(color-picker): move JSDoc comments to component definitions

### DIFF
--- a/.changeset/early-gorillas-lay.md
+++ b/.changeset/early-gorillas-lay.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+move JSDoc comments to component definitions

--- a/packages/components/color-picker/src/hue-slider.tsx
+++ b/packages/components/color-picker/src/hue-slider.tsx
@@ -79,16 +79,16 @@ interface HueSliderOptions {
   trackProps?: HTMLUIProps
 }
 
-/**
- * `HueSlider` is a component used to allow the user to select a color hue.
- *
- * @see Docs https://yamada-ui.com/components/forms/hue-slider
- */
 export interface HueSliderProps
   extends ThemeProps<"HueSlider">,
     Partial<UseColorSliderProps>,
     HueSliderOptions {}
 
+/**
+ * `HueSlider` is a component used to allow the user to select a color hue.
+ *
+ * @see Docs https://yamada-ui.com/components/forms/hue-slider
+ */
 export const HueSlider = forwardRef<HueSliderProps, "input">((props, ref) => {
   const [styles, mergedProps] = useComponentMultiStyle("HueSlider", props)
   const {

--- a/packages/components/color-picker/src/saturation-slider.tsx
+++ b/packages/components/color-picker/src/saturation-slider.tsx
@@ -39,16 +39,16 @@ interface SaturationSliderOptions {
   trackProps?: HTMLUIProps
 }
 
-/**
- * `SaturationSlider` is a component used to allow the user to select a color saturation.
- *
- * @see Docs https://yamada-ui.com/components/forms/saturation-slider
- */
 export interface SaturationSliderProps
   extends ThemeProps<"SaturationSlider">,
     UseSaturationSliderProps,
     SaturationSliderOptions {}
 
+/**
+ * `SaturationSlider` is a component used to allow the user to select a color saturation.
+ *
+ * @see Docs https://yamada-ui.com/components/forms/saturation-slider
+ */
 export const SaturationSlider = forwardRef<SaturationSliderProps, "input">(
   (props, ref) => {
     const [styles, mergedProps] = useComponentMultiStyle(


### PR DESCRIPTION
Closes https://github.com/yamada-ui/yamada-ui/issues/2830

## Description

Incorrect JSDoc Comment Placement in SaturationSlider and HueSlider

<!-- Add a brief description. -->

## Current behavior (updates)

The JSDoc Comment Placement in SaturationSlider and HueSlider is at the wrong spot.

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

I have moved the JSDoc comments to the component definitions

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->