### PR TITLE
When the option `value` is not set, the value of `children` is automatically set

### DIFF
--- a/.changeset/fluffy-avocados-mix.md
+++ b/.changeset/fluffy-avocados-mix.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/autocomplete": minor
+"@yamada-ui/select": minor
+---
+
+When the option `value` is not set, the value of `children` is automatically set.

--- a/packages/components/autocomplete/src/use-autocomplete-option.ts
+++ b/packages/components/autocomplete/src/use-autocomplete-option.ts
@@ -6,6 +6,9 @@ import {
   handlerAll,
   isArray,
   isHTMLElement,
+  isNumber,
+  isString,
+  isUndefined,
   mergeRefs,
   useUpdateEffect,
 } from "@yamada-ui/utils"
@@ -84,12 +87,23 @@ export const useAutocompleteOption = (props: UseAutocompleteOptionProps) => {
 
   const values = descendants.values()
   const frontValues = values.slice(0, index)
-
   const isMulti = isArray(value)
+
+  if (isUndefined(optionValue)) {
+    if (isString(children) || isNumber(children)) {
+      optionValue = children.toString()
+    } else {
+      console.warn(
+        `${
+          !isMulti ? "Autocomplete" : "MultiAutocomplete"
+        }: Cannot infer the option value of complex children. Pass a \`value\` prop or use a plain string as children to <Option>.`,
+      )
+    }
+  }
+
   const isDuplicated = !isMulti
     ? frontValues.some(({ node }) => node.dataset.value === (optionValue ?? ""))
     : false
-
   const isSelected =
     !isDuplicated &&
     (!isMulti

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -31,6 +31,8 @@ import {
   isArray,
   isContains,
   isHTMLElement,
+  isNumber,
+  isString,
   isUndefined,
   mergeRefs,
   omitObject,
@@ -934,12 +936,33 @@ export const useSelectOption = (props: UseSelectOptionProps) => {
 
   const values = descendants.values()
   const frontValues = values.slice(0, index)
-
+  const hasPlaceholder = !!placeholder && placeholderInOptions
+  const isPlaceholder = hasPlaceholder && index === 0
   const isMulti = isArray(value)
+
+  if (!isPlaceholder && isUndefined(optionValue)) {
+    if (isString(children) || isNumber(children)) {
+      optionValue = children.toString()
+    } else {
+      console.warn(
+        `${
+          !isMulti ? "Select" : "MultiSelect"
+        }: Cannot infer the option value of complex children. Pass a \`value\` prop or use a plain string as children to <Option>.`,
+      )
+    }
+  }
+
+  if (hasPlaceholder && index > 0 && !optionValue) {
+    console.warn(
+      `${
+        !isMulti ? "Select" : "MultiSelect"
+      }: If placeholders are present, All options must be set value. If want to set an empty value, either don't set the placeholder or set 'placeholderInOptions' to false.`,
+    )
+  }
+
   const isDuplicated = !isMulti
     ? frontValues.some(({ node }) => node.dataset.value === (optionValue ?? ""))
     : false
-
   const isSelected =
     !isDuplicated &&
     (!isMulti
@@ -947,13 +970,6 @@ export const useSelectOption = (props: UseSelectOptionProps) => {
       : value.includes(optionValue ?? ""))
   const isFocused = index === focusedIndex
 
-  if (!!placeholder && index > 0 && placeholderInOptions && !optionValue) {
-    console.warn(
-      `${
-        !isMulti ? "Select" : "MultiSelect"
-      }: If placeholders are present, All options must be set value. If want to set an empty value, either don't set the placeholder or set 'placeholderInOptions' to false.`,
-    )
-  }
   const onClick = useCallback(
     (ev: MouseEvent<HTMLLIElement>) => {
       ev.preventDefault()

--- a/stories/components/forms/select.stories.tsx
+++ b/stories/components/forms/select.stories.tsx
@@ -32,7 +32,6 @@ export const basic: Story = () => {
         { label: "クリリン", value: "クリリン" },
       ],
       label: "地球人",
-      value: "",
     },
     {
       items: [


### PR DESCRIPTION
Closes #2826 
Closes #2827

## Description

When the option `value` is not set, the value of `children` is automatically set.

## Is this a breaking change (Yes/No):

No