### PR TITLE
Removed `"mono"` from SEMANTIC_COLOR_SCHEMES

### DIFF
--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -10,7 +10,6 @@ type ColorMode = "dark" | "light"
 export type ColorFormat = "hex" | "hexa" | "hsl" | "hsla" | "rgb" | "rgba"
 
 export const SEMANTIC_COLOR_SCHEMES = [
-  "mono",
   "primary",
   "secondary",
   "info",


### PR DESCRIPTION
## Description

Removed `"mono"` from SEMANTIC_COLOR_SCHEMES.

The `"mono"` value is not needed because it is not yet implemented.

## Is this a breaking change (Yes/No):

No