### PR TITLE
fix: add displayName and __ui__ to layout components

### DIFF
--- a/.changeset/soft-games-unite.md
+++ b/.changeset/soft-games-unite.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/layouts": patch
+---
+
+Added displayName and **ui** to layout components

--- a/packages/components/layouts/src/aspect-ratio.tsx
+++ b/packages/components/layouts/src/aspect-ratio.tsx
@@ -61,3 +61,6 @@ export const AspectRatio = forwardRef<AspectRatioProps, "div">(
     )
   },
 )
+
+AspectRatio.displayName = "AspectRatio"
+AspectRatio.__ui__ = "AspectRatio"

--- a/packages/components/layouts/src/box.tsx
+++ b/packages/components/layouts/src/box.tsx
@@ -9,3 +9,6 @@ export interface BoxProps extends HTMLUIProps {}
  * @see Docs https://yamada-ui.com/components/layouts/box
  */
 export const Box = ui("div")
+
+Box.displayName = "Box"
+Box.__ui__ = "Box"

--- a/packages/components/layouts/src/center.tsx
+++ b/packages/components/layouts/src/center.tsx
@@ -15,3 +15,6 @@ export const Center = ui("div", {
     justifyContent: "center",
   },
 })
+
+Center.displayName = "Center"
+Center.__ui__ = "Center"

--- a/packages/components/layouts/src/container.tsx
+++ b/packages/components/layouts/src/container.tsx
@@ -48,3 +48,6 @@ export const Container = forwardRef<ContainerProps, "section">((props, ref) => {
     />
   )
 })
+
+Container.displayName = "Container"
+Container.__ui__ = "Container"

--- a/packages/components/layouts/src/divider.tsx
+++ b/packages/components/layouts/src/divider.tsx
@@ -98,3 +98,6 @@ export const Divider = forwardRef<DividerProps, "hr">((props, ref) => {
     />
   )
 })
+
+Divider.displayName = "Divider"
+Divider.__ui__ = "Divider"

--- a/packages/components/layouts/src/flex.tsx
+++ b/packages/components/layouts/src/flex.tsx
@@ -70,6 +70,9 @@ export const Flex = forwardRef<FlexProps, "div">(
   },
 )
 
+Flex.displayName = "Flex"
+Flex.__ui__ = "Flex"
+
 /**
  * `Wrap` is a component that has `wrap` set on `Flex`. It inherits convenient style shorthand from `Flex`.
  *
@@ -78,3 +81,6 @@ export const Flex = forwardRef<FlexProps, "div">(
 export const Wrap = forwardRef<FlexProps, "div">((props, ref) => (
   <Flex ref={ref} wrap="wrap" {...props} />
 ))
+
+Wrap.displayName = "Wrap"
+Wrap.__ui__ = "Wrap"

--- a/packages/components/layouts/src/grid.tsx
+++ b/packages/components/layouts/src/grid.tsx
@@ -92,6 +92,9 @@ export const Grid = forwardRef<GridProps, "div">(
   },
 )
 
+Grid.displayName = "Grid"
+Grid.__ui__ = "Grid"
+
 const transformColumns =
   (columns: Token<number> | undefined, minWidth?: GridProps["minWidth"]) =>
   (theme: StyledTheme) => {
@@ -139,6 +142,9 @@ export const SimpleGrid = forwardRef<SimpleGridProps, "div">(
     return <Grid ref={ref} templateColumns={templateColumns} {...rest} />
   },
 )
+
+SimpleGrid.displayName = "SimpleGrid"
+SimpleGrid.__ui__ = "SimpleGrid"
 
 interface GridItemOptions {
   /**
@@ -204,3 +210,6 @@ export const GridItem = forwardRef<GridItemProps, "div">(
     return <ui.div ref={ref} __css={css} {...rest} />
   },
 )
+
+GridItem.displayName = "GridItem"
+GridItem.__ui__ = "GridItem"

--- a/packages/components/layouts/src/spacer.tsx
+++ b/packages/components/layouts/src/spacer.tsx
@@ -10,3 +10,6 @@ export const Spacer = ui("div", {
     justifySelf: "stretch",
   },
 })
+
+Spacer.displayName = "Spacer"
+Spacer.__ui__ = "Spacer"

--- a/packages/components/layouts/src/stack.tsx
+++ b/packages/components/layouts/src/stack.tsx
@@ -130,6 +130,9 @@ export const Stack = forwardRef<StackProps, "div">(
   },
 )
 
+Stack.displayName = "Stack"
+Stack.__ui__ = "Stack"
+
 /**
  * `HStack` is a component that groups elements and provides space between child elements.
  *
@@ -146,6 +149,9 @@ export const HStack = forwardRef<StackProps, "div">(
     />
   ),
 )
+
+HStack.displayName = "HStack"
+HStack.__ui__ = "HStack"
 
 /**
  * `VStack` is a component that groups elements and provides space between child elements.
@@ -164,6 +170,9 @@ export const VStack = forwardRef<StackProps, "div">(
     />
   ),
 )
+
+VStack.displayName = "VStack"
+VStack.__ui__ = "VStack"
 
 interface ZStackOptions {
   /**
@@ -364,3 +373,6 @@ export const ZStack = forwardRef<ZStackProps, "div">(
     )
   },
 )
+
+ZStack.displayName = "ZStack"
+ZStack.__ui__ = "ZStack"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2876

## Description

<!-- Add a brief description. -->
Added displayName and __ui__ to layout components 

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
