### PR TITLE
improve keyboard navigation and accessibility

### DIFF
--- a/.changeset/rich-trains-run.md
+++ b/.changeset/rich-trains-run.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/select": minor
+---
+
+improve keyboard navigation and accessibility

--- a/packages/components/select/src/use-select.tsx
+++ b/packages/components/select/src/use-select.tsx
@@ -533,16 +533,24 @@ export const useSelect = <T extends MaybeValue = string>(
       if (formControlProps.disabled || formControlProps.readOnly) return
 
       const actions: { [key: string]: Function | undefined } = {
-        ArrowDown: isFocused
-          ? () => onFocusNext()
-          : !isOpen
+        ArrowDown: ev.altKey
+          ? !isOpen
             ? funcAll(onOpen, onFocusFirstOrSelected)
-            : undefined,
-        ArrowUp: isFocused
-          ? () => onFocusPrev()
-          : !isOpen
-            ? funcAll(onOpen, onFocusLastOrSelected)
-            : undefined,
+            : undefined
+          : isFocused
+            ? () => onFocusNext()
+            : !isOpen
+              ? funcAll(onOpen, onFocusFirstOrSelected)
+              : undefined,
+        ArrowUp: ev.altKey
+          ? isOpen
+            ? onClose
+            : undefined
+          : isFocused
+            ? () => onFocusPrev()
+            : !isOpen
+              ? funcAll(onOpen, onFocusLastOrSelected)
+              : undefined,
         End: isOpen ? onFocusLast : undefined,
         Enter: isFocused
           ? onSelect
@@ -696,15 +704,15 @@ export const useSelect = <T extends MaybeValue = string>(
 
       return {
         ref: mergeRefs(fieldRef, ref),
-        "aria-activedescendant": activedescendantId,
-        "aria-controls": listId,
-        "aria-expanded": isOpen,
-        "aria-haspopup": "listbox",
         "aria-label": ariaLabel,
         role: "combobox",
         tabIndex: 0,
         ...fieldProps,
         ...props,
+        "aria-activedescendant": descendants.value(focusedIndex)?.node.id,
+        "aria-controls": listRef.current?.id,
+        "aria-expanded": isOpen,
+        "aria-haspopup": "listbox",
         "data-active": dataAttr(isOpen),
         "data-placeholder": dataAttr(
           !isMulti ? label === undefined : !label?.length,
@@ -714,9 +722,9 @@ export const useSelect = <T extends MaybeValue = string>(
       }
     },
     [
-      activedescendantId,
-      listId,
+      descendants,
       fieldProps,
+      focusedIndex,
       isOpen,
       isMulti,
       label,

--- a/packages/components/select/src/use-select.tsx
+++ b/packages/components/select/src/use-select.tsx
@@ -533,24 +533,19 @@ export const useSelect = <T extends MaybeValue = string>(
       if (formControlProps.disabled || formControlProps.readOnly) return
 
       const actions: { [key: string]: Function | undefined } = {
-        ArrowDown: ev.altKey
-          ? !isOpen
+        ArrowDown: isFocused
+          ? () => onFocusNext()
+          : !isOpen
             ? funcAll(onOpen, onFocusFirstOrSelected)
-            : undefined
-          : isFocused
-            ? () => onFocusNext()
-            : !isOpen
-              ? funcAll(onOpen, onFocusFirstOrSelected)
-              : undefined,
-        ArrowUp: ev.altKey
-          ? isOpen
+            : undefined,
+        ArrowUp:
+          ev.altKey && isOpen
             ? onClose
-            : undefined
-          : isFocused
-            ? () => onFocusPrev()
-            : !isOpen
-              ? funcAll(onOpen, onFocusLastOrSelected)
-              : undefined,
+            : isFocused
+              ? () => onFocusPrev()
+              : !isOpen
+                ? funcAll(onOpen, onFocusLastOrSelected)
+                : undefined,
         End: isOpen ? onFocusLast : undefined,
         Enter: isFocused
           ? onSelect
@@ -704,15 +699,15 @@ export const useSelect = <T extends MaybeValue = string>(
 
       return {
         ref: mergeRefs(fieldRef, ref),
+        "aria-activedescendant": activedescendantId,
+        "aria-controls": listId,
+        "aria-expanded": isOpen,
+        "aria-haspopup": "listbox",
         "aria-label": ariaLabel,
         role: "combobox",
         tabIndex: 0,
         ...fieldProps,
         ...props,
-        "aria-activedescendant": descendants.value(focusedIndex)?.node.id,
-        "aria-controls": listRef.current?.id,
-        "aria-expanded": isOpen,
-        "aria-haspopup": "listbox",
         "data-active": dataAttr(isOpen),
         "data-placeholder": dataAttr(
           !isMulti ? label === undefined : !label?.length,
@@ -722,9 +717,9 @@ export const useSelect = <T extends MaybeValue = string>(
       }
     },
     [
-      descendants,
+      activedescendantId,
+      listId,
       fieldProps,
-      focusedIndex,
       isOpen,
       isMulti,
       label,

--- a/packages/components/select/tests/select.test.tsx
+++ b/packages/components/select/tests/select.test.tsx
@@ -335,6 +335,21 @@ describe("<Select />", () => {
       expect(options[ITEMS.length - 1]).toHaveAttribute("data-focus")
     })
 
+    test("alt + ArrowUp should close the listbox", async () => {
+      const { user } = render(<Select items={ITEMS} />)
+
+      const input = await screen.findByRole("combobox")
+      expect(input).toBeInTheDocument()
+
+      await user.click(input)
+
+      const listbox = await screen.findByRole("listbox")
+      expect(listbox).toBeInTheDocument()
+
+      await user.keyboard("{Alt>}{ArrowUp}")
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    })
+
     test("arrowUp keyDown should work correctly even when defaultValue is set", async () => {
       const { user } = render(<Select defaultValue="option2" items={ITEMS} />)
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Related https://github.com/yamada-ui/yamada-ui/issues/2059

## Description

<!-- Add a brief description. -->
It is written in `multiSelect` issue, but actually relates to `select` and `multiSelect`.

- Alt + ArrowUp
If the popup has focus, returns focus to the combobox, otherwise it closes the popup.
- Alt + ArrowDown
If the popup is available but not displayed, displays the popup without moving focus.

Other accessibility support will be provided in a separate PR.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
