### PR TITLE
(create-yamada-app)next pages project specify the version in package.json as `workspace:*`

### DIFF
--- a/packages/create-yamada-app/src/templates/next/pages/next.config.mjs
+++ b/packages/create-yamada-app/src/templates/next/pages/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    externalDir: true,
+  },
 }
 
 export default nextConfig

--- a/packages/create-yamada-app/src/templates/next/pages/package.json
+++ b/packages/create-yamada-app/src/templates/next/pages/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@yamada-ui/react": "^1.5.0",
-    "@yamada-ui/lucide": "^1.4.0",
+    "@yamada-ui/react": "workspace:*",
+    "@yamada-ui/lucide": "workspace:*",
     "next": "^14.2.8",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
Closes # nothing

## Description

next pages project specify the version in package.json as "workspace:*"

## Current behavior (updates)

## New behavior

![スクリーンショット 2024-10-26 20 15 26](https://github.com/user-attachments/assets/34e2026f-b46f-492d-9419-22df8fe995e2)

![スクリーンショット 2024-10-26 20 15 06](https://github.com/user-attachments/assets/8bb449e8-a606-4c65-b138-1156104d81c9)

## Is this a breaking change (Yes/No): No

## Additional Information
