### PR TITLE
fix(colorPicker): added necessary aria attribute to ColorPicker

### DIFF
--- a/.changeset/brave-years-train.md
+++ b/.changeset/brave-years-train.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+Added `role` and `aria-controls` to `ColorPicker` component

--- a/packages/components/color-picker/src/color-picker.tsx
+++ b/packages/components/color-picker/src/color-picker.tsx
@@ -134,6 +134,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, "input">(
       ...computedProps
     } = omitThemeProps(mergedProps, ["withSwatch"])
     const {
+      id,
       eyeDropperSupported,
       value,
       getContainerProps,
@@ -189,6 +190,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, "input">(
 
             <Portal {...portalProps}>
               <PopoverContent
+                id={id}
                 className="ui-color-picker__content"
                 __css={{ ...styles.content }}
               >

--- a/packages/components/color-picker/src/use-color-picker.ts
+++ b/packages/components/color-picker/src/use-color-picker.ts
@@ -37,7 +37,7 @@ import {
   splitObject,
   useUpdateEffect,
 } from "@yamada-ui/utils"
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useId, useRef, useState } from "react"
 
 const defaultFormatInput = (value: string) => value
 
@@ -127,7 +127,8 @@ export interface UseColorPickerProps
     UseColorPickerOptions {}
 
 export const useColorPicker = (props: UseColorPickerProps) => {
-  const {
+  let {
+    id,
     allowInput = true,
     animation,
     boundary,
@@ -184,10 +185,8 @@ export const useColorPicker = (props: UseColorPickerProps) => {
   } = pickObject(rest, formControlProperties)
   const { disabled, readOnly } = formControlProps
   const [containerProps, inputProps] = splitObject(rest, layoutStyleProperties)
-
   const containerRef = useRef<HTMLDivElement>(null)
   const fieldRef = useRef<HTMLInputElement>(null)
-
   const { supported: eyeDropperSupported, onOpen: onEyeDropperOpen } =
     useEyeDropper()
   const [value, setValue] = useControllableState({
@@ -210,6 +209,9 @@ export const useColorPicker = (props: UseColorPickerProps) => {
     onClose: onCloseProp,
     onOpen: onOpenProp,
   })
+  const uuid = useId()
+
+  id ??= uuid
 
   const onOpen = useCallback(() => {
     if (disabled || readOnly) return
@@ -459,6 +461,8 @@ export const useColorPicker = (props: UseColorPickerProps) => {
       }
 
       return {
+        "aria-controls": id,
+        role: "combobox",
         tabIndex: !allowInput ? -1 : 0,
         ...formControlProps,
         ...inputProps,
@@ -470,6 +474,7 @@ export const useColorPicker = (props: UseColorPickerProps) => {
       }
     },
     [
+      id,
       inputProps,
       allowInput,
       disabled,
@@ -543,6 +548,7 @@ export const useColorPicker = (props: UseColorPickerProps) => {
   )
 
   return {
+    id,
     allowInput,
     eyeDropperSupported,
     value,

--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -51,7 +51,7 @@ describe("<ColorPicker />", () => {
   test("ColorPicker renders as disabled", () => {
     render(<ColorPicker disabled />)
 
-    const colorPicker = screen.getByRole("textbox")
+    const colorPicker = screen.getByRole("combobox")
 
     expect(colorPicker).toBeDisabled()
   })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2924

## Description

Added role and aria-controls to ColorPicker

## Current behavior (updates)

The `input` tag in the `ColorPicker` component doesn't have the `combobox` role and `aria-controls`.

## New behavior

The `input` tag in the `ColorPicker` component have the `combobox` role and `aria-controls`.

## Is this a breaking change (Yes/No):
No
