### PR TITLE
test(icon): enhance test coverage for icon

### DIFF
--- a/packages/components/icon/tests/icon.test.tsx
+++ b/packages/components/icon/tests/icon.test.tsx
@@ -1,6 +1,13 @@
-import { a11y } from "@yamada-ui/test"
+import { a11y, render } from "@yamada-ui/test"
 import { FaMarkdown } from "react-icons/fa"
-import { Icon } from "../src"
+import {
+  CheckIcon,
+  ChevronIcon,
+  CloseIcon,
+  Icon,
+  InfoIcon,
+  WarningIcon,
+} from "../src"
 
 describe("<Icon />", () => {
   test("passes a11y test", async () => {
@@ -10,4 +17,23 @@ describe("<Icon />", () => {
   test("passes a11y test given a third-party icon", async () => {
     await a11y(<Icon as={FaMarkdown} />)
   })
+
+  const iconComponents = [
+    { name: "Check", Component: CheckIcon },
+    { name: "Info", Component: InfoIcon },
+    { name: "Warning", Component: WarningIcon },
+    { name: "Close", Component: CloseIcon },
+    { name: "Chevron", Component: ChevronIcon },
+  ]
+
+  test.each(iconComponents)(
+    "passes a11y test and render the $name Icon correctly",
+    async ({ name, Component }) => {
+      const testId = `${name.toLowerCase()}Icon`
+      const { getByTestId } = render(<Component data-testid={testId} />)
+      const iconElement = getByTestId(testId)
+      expect(iconElement).toBeInTheDocument()
+      await a11y(<Component />)
+    },
+  )
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3270

## Description

Enhance test coverage for `icon` component

## Current behavior (updates)

There are not enough tests covering for `icon` component

## New behavior

Add a new test case to ensure `CheckIcon`, `InfoIcon`, `WarningIcon`, `CloseIcon`, `ChevronIcon` are rendering correctly and pass the a11y test

## Is this a breaking change (Yes/No):

No

## Additional Information
