### PR TITLE
docs(fileButton): use japanese translation on accessibility section

### DIFF
--- a/docs/contents/components/forms/file-button/accessibility.ja.mdx
+++ b/docs/contents/components/forms/file-button/accessibility.ja.mdx
@@ -7,8 +7,8 @@ tab: アクセシビリティ
 order: 3
 ---
 
-## ARIA Roles and Attributes
+## ARIAロールと属性
 
-| Component    | Roles and Attributes | Usage                        |
-| ------------ | -------------------- | ---------------------------- |
-| `FileButton` | `role="button"`      | ボタンであることを示します。 |
+| コンポーネント | ロールと属性    | 使い方                       |
+| -------------- | --------------- | ---------------------------- |
+| `FileButton`   | `role="button"` | ボタンであることを示します。 |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3103

## Description

Accessibility tab of FileButton component in ja page is written in english.
`ARIA Roles and Attributes` and table columns should be japanese.

## Current behavior (updates)

Accessibility tab of FileButton component in ja page is written in english.

## New behavior

`ARIA Roles and Attributes` and table columns are now using japanese.

![image](https://github.com/user-attachments/assets/0172906f-31f4-40b4-9636-876da7096a24)


## Is this a breaking change (Yes/No):
No

## Additional Information
