### PR TITLE
feat: enhance Icon component a11y

### DIFF
--- a/.changeset/shy-moles-own.md
+++ b/.changeset/shy-moles-own.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/icon": patch
+---
+
+Enhanced a11y in the Icon component by setting role="img" and applying aria-hidden="true" as defaults.

--- a/packages/components/icon/src/icon.tsx
+++ b/packages/components/icon/src/icon.tsx
@@ -62,6 +62,8 @@ export const Icon = forwardRef<IconProps, "svg">((props, ref) => {
       <ui.svg
         as={element}
         className={cx("ui-icon", className)}
+        aria-hidden
+        role="img"
         __css={css}
         {...rest}
       />
@@ -71,6 +73,8 @@ export const Icon = forwardRef<IconProps, "svg">((props, ref) => {
     <ui.svg
       ref={ref}
       className={cx("ui-icon", className)}
+      aria-hidden
+      role="img"
       verticalAlign="middle"
       viewBox={viewBox}
       __css={css}


### PR DESCRIPTION
Closes #3258

## Description
Enhanced a11y in the Icon component by setting role="img" and applying aria-hidden="true" as defaults.

## Is this a breaking change (Yes/No):
No
