### PR TITLE
test(rating): test coverage for custom color

### DIFF
--- a/packages/components/rating/tests/rating.test.tsx
+++ b/packages/components/rating/tests/rating.test.tsx
@@ -126,4 +126,37 @@ describe("<Rating />", () => {
     await user.click(items[4]!)
     expect(items[3]).not.toHaveAttribute("data-focus")
   })
+
+  test("should use custom color correctly", () => {
+    const getColor = (value: number) => {
+      switch (value) {
+        case 1:
+          return "red.500"
+        case 2:
+          return "orange.500"
+        case 3:
+          return "yellow.500"
+        case 4:
+          return "green.500"
+        case 5:
+          return "blue.500"
+        default:
+          return undefined
+      }
+    }
+    const { container } = render(<Rating color={getColor} />)
+    const items = container.querySelectorAll(".ui-rating__item")
+
+    const expectedColors = [
+      "red.500",
+      "orange.500",
+      "yellow.500",
+      "green.500",
+      "blue.500",
+    ]
+    expectedColors.forEach((expectedColor, index) => {
+      const item = items[index]
+      expect(item).toHaveStyle(`color: ${expectedColor}`)
+    })
+  })
 })

--- a/packages/components/rating/tests/rating.test.tsx
+++ b/packages/components/rating/tests/rating.test.tsx
@@ -144,19 +144,26 @@ describe("<Rating />", () => {
           return undefined
       }
     }
-    const { container } = render(<Rating color={getColor} />)
+    const { container } = render(<Rating color={getColor} defaultValue={5} />)
     const items = container.querySelectorAll(".ui-rating__item")
 
-    const expectedColors = [
-      "red.500",
-      "orange.500",
-      "yellow.500",
-      "green.500",
-      "blue.500",
-    ]
-    expectedColors.forEach((expectedColor, index) => {
-      const item = items[index]
-      expect(item).toHaveStyle(`color: ${expectedColor}`)
-    })
+    const styleElements = document.getElementsByTagName("style")
+    const cssText = Array.from(styleElements)
+      .map((style) => style.textContent)
+      .join("")
+
+    for (let i = 1; i < items.length; i++) {
+      expect(items[i]).toHaveAttribute("data-filled")
+
+      const emotionClass = Array.from(items[i]!.classList)[1]
+
+      const expectedColor = getColor(i)
+      const expectedVar = `var(--ui-colors-${expectedColor!.replace(".", "-")})`
+
+      const ruleExists =
+        cssText.includes(`${emotionClass}[data-filled]`) &&
+        cssText.includes(`color:${expectedVar}`)
+      expect(ruleExists).toBeTruthy()
+    }
   })
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #2358 

## Description

@yamada-ui/rating has a test coverage of less than 95%. We will enhance it to above 95%.

## Current behavior (updates)

No test cases for custom color of `<Rating />`

## New behavior

New test covers target files:

- [packages/components/rating/src/rating-item.tsx](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/rating/src/rating-item.tsx)
	- [L34](https://app.codecov.io/gh/yamada-ui/yamada-ui/blob/main/packages/components/rating/src/rating-item.tsx#L34)

## Is this a breaking change (Yes/No):

No

## Additional Information
When I test the color using `getComputedStyle`, it always retrieves an `undefined` color attribute. It seems that JSDOM does not process CSS custom properties, like `var(--ui-colors-yellow-500)`, so I had to test the CSS rules directly to see if the css rule exists and the color attributes are applying correctly.