### PR TITLE
Added `"use client"` to `Rating`

### DIFF
--- a/.changeset/itchy-bottles-allow.md
+++ b/.changeset/itchy-bottles-allow.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/rating": patch
+---
+
+Added `"use client"` to rating.

--- a/packages/components/rating/package.json
+++ b/packages/components/rating/package.json
@@ -8,6 +8,7 @@
     "react",
     "emotion",
     "component",
+    "rating",
     "ui",
     "uikit",
     "styled",
@@ -67,6 +68,10 @@
     "format": [
       "cjs",
       "esm"
-    ]
+    ],
+    "banner": {
+      "js": "\"use client\""
+    },
+    "sourcemap": true
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3325

## Description
Error occurs in Next.js 15 because `Rating` component does not have `"use client"`.
<!-- Add a brief description. -->
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

`Rating` component does not have `"use client"`.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Added `"use client"` to `Rating` component.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
