### PR TITLE
feat(components): rename props from isOpen to open

### DIFF
--- a/packages/components/color-picker/src/use-color-picker.ts
+++ b/packages/components/color-picker/src/use-color-picker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable perfectionist/sort-objects */
 import type {
   CSSUIObject,
   HTMLUIProps,
@@ -149,6 +150,7 @@ export const useColorPicker = (props: UseColorPickerProps) => {
     formatInput = defaultFormatInput,
     gutter,
     isLazy,
+    open: openProp,
     isOpen: isOpenProp,
     lazyBehavior,
     matchWidth = colorSelectorSize === "full",
@@ -200,13 +202,14 @@ export const useColorPicker = (props: UseColorPickerProps) => {
   )
   const isInputFocused = useRef<boolean>(false)
   const [inputValue, setInputValue] = useState<string>(value || "")
+  const controlledOpenProp = openProp ?? isOpenProp
   const {
     isOpen,
     onClose: onInternalClose,
     onOpen: onInternalOpen,
   } = useDisclosure({
     defaultIsOpen,
-    isOpen: isOpenProp,
+    isOpen: controlledOpenProp,
     onClose: onCloseProp,
     onOpen: onOpenProp,
   })

--- a/packages/components/color-picker/tests/color-picker.test.tsx
+++ b/packages/components/color-picker/tests/color-picker.test.tsx
@@ -56,15 +56,15 @@ describe("<ColorPicker />", () => {
     expect(colorPicker).toBeDisabled()
   })
 
-  test("ColorSelector renders initially when isOpen is specified for ColorPicker", () => {
-    const { container } = render(<ColorPicker isOpen />)
+  test("ColorSelector renders initially when open is specified for ColorPicker", () => {
+    const { container } = render(<ColorPicker open />)
 
     const popover = container.querySelectorAll(".ui-popover")
 
     expect(popover[0]).toBeVisible()
   })
 
-  test("ColorSelector does not render initially when isOpen is not specified for ColorPicker", () => {
+  test("ColorSelector does not render initially when open is not specified for ColorPicker", () => {
     const { container } = render(<ColorPicker />)
 
     const popover = container.querySelectorAll(".ui-popover")

--- a/packages/components/modal/src/drawer-content.tsx
+++ b/packages/components/modal/src/drawer-content.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable perfectionist/sort-union-types */
+/* eslint-disable perfectionist/sort-jsx-props */
 import type { CSSUIObject, ThemeProps } from "@yamada-ui/core"
 import type { MotionPanInfo } from "@yamada-ui/motion"
 import type { Merge } from "@yamada-ui/utils"
@@ -14,7 +16,7 @@ import { useDrawer, useModal } from "./modal-context"
 
 export interface DrawerContentProps
   extends Merge<
-    Omit<DrawerProps, "isOpen" | "placement" | keyof ThemeProps>,
+    Omit<DrawerProps, "open" | "isOpen" | "placement" | keyof ThemeProps>,
     Required<
       Pick<
         DrawerProps,
@@ -46,7 +48,7 @@ export const DrawerContent = motionForwardRef<DrawerContentProps, "div">(
     },
     ref,
   ) => {
-    const { describedbyId, duration, isOpen, labelledbyId, onClose } =
+    let { describedbyId, duration, isOpen, labelledbyId, open, onClose } =
       useModal()
     const styles = useDrawer()
     const placement = useValue(_placement)
@@ -191,6 +193,7 @@ export const DrawerContent = motionForwardRef<DrawerContentProps, "div">(
         dragMomentum={false}
         dragSnapToOrigin
         duration={duration}
+        open={open}
         isOpen={isOpen}
         placement={placement}
         role="dialog"

--- a/packages/components/modal/src/drawer.tsx
+++ b/packages/components/modal/src/drawer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable perfectionist/sort-objects */
 import type { CSSUIObject, ThemeProps } from "@yamada-ui/core"
 import type { SlideProps } from "@yamada-ui/transitions"
 import type { ModalProps } from "./modal"
@@ -103,6 +104,7 @@ export const Drawer = motionForwardRef<DrawerProps, "div">(
       duration = { enter: 0.4, exit: 0.3 },
       finalFocusRef,
       initialFocusRef,
+      open,
       isOpen,
       lockFocusAcrossFrames,
       restoreFocus,
@@ -139,6 +141,7 @@ export const Drawer = motionForwardRef<DrawerProps, "div">(
             duration,
             finalFocusRef,
             initialFocusRef,
+            open,
             isOpen,
             lockFocusAcrossFrames,
             restoreFocus,

--- a/packages/components/modal/src/modal.tsx
+++ b/packages/components/modal/src/modal.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable perfectionist/sort-objects */
+/* eslint-disable perfectionist/sort-interfaces */
 import type {
   CSSUIObject,
   CSSUIProps,
@@ -37,7 +39,13 @@ export interface ModalOptions
   /**
    * If `true`, the open will be opened.
    */
-  isOpen: boolean
+  open: boolean
+  /**
+   * If `true`, the open will be opened.
+   *
+   * @deprecated Use `open` instead.
+   */
+  isOpen?: boolean
   /**
    * Handle zoom or pinch gestures on iOS devices when scroll locking is enabled.
    *
@@ -155,7 +163,7 @@ export const Modal = motionForwardRef<ModalProps, "section">(
       size,
       ...props,
     })
-    const {
+    let {
       className,
       allowPinchZoom = false,
       animation = "scale",
@@ -167,6 +175,7 @@ export const Modal = motionForwardRef<ModalProps, "section">(
       duration,
       finalFocusRef,
       initialFocusRef,
+      open,
       isOpen,
       lockFocusAcrossFrames = true,
       outside = "fallback(4, 1rem)",
@@ -243,6 +252,7 @@ export const Modal = motionForwardRef<ModalProps, "section">(
           closeOnOverlay,
           describedbyId,
           duration,
+          open,
           isOpen,
           labelledbyId,
           scrollBehavior,
@@ -253,7 +263,7 @@ export const Modal = motionForwardRef<ModalProps, "section">(
         }}
       >
         <AnimatePresence onExitComplete={onCloseComplete}>
-          {isOpen ? (
+          {open ? (
             <Portal {...portalProps}>
               <FocusLock
                 autoFocus={autoFocus}

--- a/packages/components/modal/tests/dialog.test.tsx
+++ b/packages/components/modal/tests/dialog.test.tsx
@@ -17,7 +17,7 @@ describe("<Dialog />", () => {
           cancel={{
             children: "dialog-cancel",
           }}
-          isOpen={isOpen}
+          open={isOpen}
           other={{
             children: "dialog-other",
           }}
@@ -51,7 +51,7 @@ describe("<Dialog />", () => {
           cancel={{
             children: "dialog-cancel",
           }}
-          isOpen={isOpen}
+          open={isOpen}
           other={{
             children: "dialog-other",
           }}

--- a/packages/components/modal/tests/drawer.test.tsx
+++ b/packages/components/modal/tests/drawer.test.tsx
@@ -23,7 +23,7 @@ describe("<Drawer />", () => {
 
         <Drawer
           data-testid="Drawer"
-          isOpen={isOpen}
+          open={isOpen}
           onClose={() => setIsOpen(false)}
         >
           <DrawerOverlay
@@ -75,7 +75,7 @@ describe("<Drawer />", () => {
         <Drawer
           data-testid="Drawer"
           closeOnDrag
-          isOpen={isOpen}
+          open={isOpen}
           placement={placement}
           onClose={() => setIsOpen(false)}
         >
@@ -106,7 +106,7 @@ describe("<Drawer />", () => {
     expectedStyle: ExpectedStyle,
   ) => {
     const { findByTestId, user } = render(
-      <DrawerPlacementExample isOpen={false} placement={placement} />,
+      <DrawerPlacementExample open={false} placement={placement} />,
     )
 
     const openDrawerButton = await findByTestId("OpenDrawer")
@@ -176,7 +176,7 @@ describe("<Drawer />", () => {
 
         <Drawer
           data-testid="Drawer"
-          isOpen={isOpen}
+          open={isOpen}
           withCloseButton={withCloseButton}
           onClose={() => setIsOpen(false)}
         >

--- a/packages/components/modal/tests/modal.test.tsx
+++ b/packages/components/modal/tests/modal.test.tsx
@@ -26,7 +26,7 @@ describe("<Modal />", () => {
 
         <Modal
           aria-labelledby={modalHeaderId}
-          isOpen={isOpen}
+          open={isOpen}
           placement={placement}
           onClose={() => setIsOpen(false)}
         >
@@ -53,7 +53,7 @@ describe("<Modal />", () => {
         </button>
         <Modal
           data-testid="Modal"
-          isOpen={isOpen}
+          open={isOpen}
           onClose={() => setIsOpen(false)}
         >
           <ModalCloseButton data-testid="ModalCloseButton" />
@@ -119,7 +119,7 @@ describe("<Modal />", () => {
 
           <Modal
             aria-labelledby={primaryModalHeaderId}
-            isOpen={isPrimaryOpen}
+            open={isPrimaryOpen}
             onClose={() => setIsPrimaryOpen(false)}
           >
             <ModalHeader id={primaryModalHeaderId}>Modal Header</ModalHeader>
@@ -138,7 +138,7 @@ describe("<Modal />", () => {
             <Modal
               size="sm"
               aria-labelledby={secondaryModalHeaderId}
-              isOpen={isSecondaryOpen}
+              open={isSecondaryOpen}
               onClose={() => setIsSecondaryOpen(false)}
             >
               <ModalHeader id={secondaryModalHeaderId}>
@@ -320,7 +320,7 @@ describe("<Modal />", () => {
           aria-labelledby={modalHeaderId}
           animation={animation}
           duration={duration}
-          isOpen={isOpen}
+          open={isOpen}
           onClose={() => setIsOpen(false)}
         >
           <ModalHeader id={modalHeaderId}>Modal Header</ModalHeader>

--- a/packages/components/motion/src/motion.types.ts
+++ b/packages/components/motion/src/motion.types.ts
@@ -277,8 +277,14 @@ export interface MotionTransitionProps {
 export type WithTransitionProps<Y extends object> = {
   /**
    * Show the component. triggers when enter or exit states.
+   *
+   * @deprecated Use `open` instead.
    */
   isOpen?: boolean
+  /**
+   * Show the component. triggers when enter or exit states.
+   */
+  open?: boolean
   /**
    * If `true`, the element will unmount when `isOpen={false}` and animation is done.
    */

--- a/packages/components/popover/src/popover.tsx
+++ b/packages/components/popover/src/popover.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable perfectionist/sort-objects */
+/* eslint-disable perfectionist/sort-union-types */
+/* eslint-disable perfectionist/sort-interfaces */
 import type {
   CSSUIObject,
   FC,
@@ -37,7 +40,7 @@ export type PopoverProperty = (typeof popoverProperties)[number]
 
 export const popoverProperties = [
   ...popperProperties,
-  "isOpen",
+  "open",
   "defaultIsOpen",
   "onOpen",
   "onClose",
@@ -125,6 +128,13 @@ interface PopoverOptions {
   isLazy?: boolean
   /**
    * If `true`, the popover will be opened.
+   *
+   */
+  open?: boolean
+  /**
+   * If `true`, the popover will be opened.
+   *
+   * @deprecated Use `open` instead
    */
   isOpen?: boolean
   /**
@@ -180,7 +190,7 @@ export interface PopoverProps
 interface PopoverContext
   extends Pick<
     PopoverOptions,
-    "animation" | "closeOnButton" | "duration" | "isOpen" | "onClose"
+    "animation" | "closeOnButton" | "duration" | "open" | "isOpen" | "onClose"
   > {
   id: string
   describedbyId: string
@@ -221,6 +231,8 @@ export const Popover: FC<PopoverProps> = (props) => {
     isLazy,
     lazyBehavior = "unmount",
     openDelay = 200,
+    open: openProp,
+    isOpen: isOpenProp,
     relatedRef,
     restoreFocus = true,
     trigger = "click",
@@ -229,7 +241,11 @@ export const Popover: FC<PopoverProps> = (props) => {
   const id = useId()
   const labelledbyId = useId()
   const describedbyId = useId()
-  const { isOpen, onClose, onOpen, onToggle } = useDisclosure(mergedProps)
+  const controlledOpen = openProp ?? isOpenProp
+  const { isOpen, onClose, onOpen, onToggle } = useDisclosure({
+    ...mergedProps,
+    isOpen: controlledOpen,
+  })
   const anchorRef = useRef<HTMLElement>(null)
   const triggerRef = useRef<HTMLElement>(null)
   const popoverRef = useRef<HTMLElement>(null)

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable perfectionist/sort-interfaces */
+/* eslint-disable perfectionist/sort-objects */
 import type {
   CSSUIObject,
   CSSUIProps,
@@ -92,6 +94,12 @@ interface TooltipOptions {
   /**
    * If `true`, the tooltip will be shown.
    */
+  open?: boolean
+  /**
+   * If `true`, the tooltip will be shown.
+   *
+   * @deprecated Use `open` instead.
+   */
   isOpen?: boolean
   /**
    * The label of the tooltip.
@@ -181,7 +189,7 @@ export const Tooltip = motionForwardRef<TooltipProps, "div">(
       "Tooltip",
       props,
     )
-    const {
+    let {
       className,
       animation,
       children,
@@ -195,6 +203,7 @@ export const Tooltip = motionForwardRef<TooltipProps, "div">(
       duration,
       gutter,
       isDisabled,
+      open: openProp,
       isOpen: isOpenProp,
       label,
       modifiers,
@@ -209,9 +218,10 @@ export const Tooltip = motionForwardRef<TooltipProps, "div">(
     const effectiveCloseOnPointerDown = closeOnPointerDown || closeOnMouseDown
 
     const id = useId()
+    const controlledOpenProp = openProp ?? isOpenProp
     const { isOpen, onClose, onOpen } = useDisclosure({
       defaultIsOpen: defaultIsOpenProp,
-      isOpen: isOpenProp,
+      isOpen: controlledOpenProp,
       onClose: onCloseProp,
       onOpen: onOpenProp,
     })

--- a/packages/components/tooltip/tests/tooltip.test.tsx
+++ b/packages/components/tooltip/tests/tooltip.test.tsx
@@ -70,7 +70,7 @@ describe("<Tooltip />", () => {
 
   test("should always display", async () => {
     render(
-      <Tooltip isOpen label="Tooltip hover">
+      <Tooltip label="Tooltip hover" open>
         <span>Hover</span>
       </Tooltip>,
     )
@@ -118,9 +118,9 @@ describe("<Tooltip />", () => {
     expect(queryTooltip()).toBeNull()
   })
 
-  test("When `isOpen` is true, the tooltip should be displayed", async () => {
+  test("When `open` is true, the tooltip should be displayed", async () => {
     const { user } = render(
-      <Tooltip isOpen label="Tooltip hover">
+      <Tooltip label="Tooltip hover" open>
         <span>Hover</span>
       </Tooltip>,
     )

--- a/packages/components/transitions/src/collapse.tsx
+++ b/packages/components/transitions/src/collapse.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable perfectionist/sort-objects */
 import type { CSSUIObject, ThemeProps } from "@yamada-ui/core"
 import type {
   MotionProps,
@@ -99,6 +100,7 @@ export const Collapse = motionForwardRef<CollapseProps, "div">((props, ref) => {
     delay,
     duration,
     endingHeight,
+    open,
     isOpen,
     startingHeight,
     transition: transitionProp,
@@ -115,9 +117,11 @@ export const Collapse = motionForwardRef<CollapseProps, "div">((props, ref) => {
     if (isBrowser) setMounted(true)
   }, [])
 
-  const animate = isOpen || unmountOnExit ? "enter" : "exit"
+  open ??= isOpen
 
-  isOpen = unmountOnExit ? isOpen : true
+  const animate = open || unmountOnExit ? "enter" : "exit"
+
+  open = unmountOnExit ? open : true
 
   const transition = useMemo(() => {
     if (!mounted) {
@@ -167,7 +171,7 @@ export const Collapse = motionForwardRef<CollapseProps, "div">((props, ref) => {
 
   return (
     <AnimatePresence custom={custom} initial={false}>
-      {isOpen ? (
+      {open ? (
         <motion.div
           ref={ref}
           className={cx("ui-collapse", className)}

--- a/packages/components/transitions/src/fade.tsx
+++ b/packages/components/transitions/src/fade.tsx
@@ -53,21 +53,24 @@ export const Fade = motionForwardRef<FadeProps, "div">((props, ref) => {
     delay,
     duration,
     isOpen,
+    open,
     transition,
     transitionEnd,
     unmountOnExit,
     ...rest
   } = omitThemeProps(mergedProps)
 
-  const animate = isOpen || unmountOnExit ? "enter" : "exit"
+  open ??= isOpen
+
+  const animate = open || unmountOnExit ? "enter" : "exit"
 
   const custom = { delay, duration, transition, transitionEnd }
 
-  isOpen = unmountOnExit ? isOpen && unmountOnExit : true
+  open = unmountOnExit ? open && unmountOnExit : true
 
   return (
     <AnimatePresence custom={custom}>
-      {isOpen ? (
+      {open ? (
         <motion.div
           ref={ref}
           className={cx("ui-fade", className)}

--- a/packages/components/transitions/src/scale-fade.tsx
+++ b/packages/components/transitions/src/scale-fade.tsx
@@ -81,6 +81,7 @@ export const ScaleFade = motionForwardRef<ScaleFadeProps, "div">(
       delay,
       duration,
       isOpen,
+      open,
       reverse,
       scale,
       transition,
@@ -88,7 +89,9 @@ export const ScaleFade = motionForwardRef<ScaleFadeProps, "div">(
       unmountOnExit,
       ...rest
     } = omitThemeProps(mergedProps)
-    const animate = isOpen || unmountOnExit ? "enter" : "exit"
+    const animate = open || unmountOnExit ? "enter" : "exit"
+
+    open ??= isOpen
 
     const custom = {
       delay,
@@ -99,11 +102,11 @@ export const ScaleFade = motionForwardRef<ScaleFadeProps, "div">(
       transitionEnd,
     }
 
-    isOpen = unmountOnExit ? isOpen && unmountOnExit : true
+    open = unmountOnExit ? open && unmountOnExit : true
 
     return (
       <AnimatePresence custom={custom}>
-        {isOpen ? (
+        {open ? (
           <motion.div
             ref={ref}
             className={cx("ui-scale-fade", className)}

--- a/packages/components/transitions/src/slide-fade.tsx
+++ b/packages/components/transitions/src/slide-fade.tsx
@@ -108,6 +108,7 @@ export const SlideFade = motionForwardRef<SlideFadeProps, "div">(
       isOpen,
       offsetX: _offsetX,
       offsetY: _offsetY,
+      open,
       reverse,
       transition,
       transitionEnd,
@@ -115,7 +116,9 @@ export const SlideFade = motionForwardRef<SlideFadeProps, "div">(
       ...rest
     } = omitThemeProps(mergedProps)
 
-    const animate = isOpen || unmountOnExit ? "enter" : "exit"
+    open ??= isOpen
+
+    const animate = open || unmountOnExit ? "enter" : "exit"
 
     const offsetX = useValue(_offsetX)
     const offsetY = useValue(_offsetY)
@@ -130,11 +133,11 @@ export const SlideFade = motionForwardRef<SlideFadeProps, "div">(
       transitionEnd,
     }
 
-    isOpen = unmountOnExit ? isOpen && unmountOnExit : true
+    open = unmountOnExit ? open && unmountOnExit : true
 
     return (
       <AnimatePresence custom={custom}>
-        {isOpen ? (
+        {open ? (
           <motion.div
             ref={ref}
             className={cx("ui-slide-fade", className)}

--- a/packages/components/transitions/src/slide.tsx
+++ b/packages/components/transitions/src/slide.tsx
@@ -94,6 +94,7 @@ export const Slide = motionForwardRef<SlideProps, "div">((props, ref) => {
     delay,
     duration = { enter: 0.4, exit: 0.3 },
     isOpen,
+    open,
     placement: _placement,
     transition,
     transitionEnd,
@@ -102,13 +103,15 @@ export const Slide = motionForwardRef<SlideProps, "div">((props, ref) => {
     ...rest
   } = omitThemeProps(mergedProps)
 
-  const animate = isOpen || unmountOnExit ? "enter" : "exit"
+  open ??= isOpen
+
+  const animate = open || unmountOnExit ? "enter" : "exit"
 
   const placement = useValue(_placement)
 
   const custom = { delay, duration, placement, transition, transitionEnd }
 
-  isOpen = unmountOnExit ? isOpen && unmountOnExit : true
+  open = unmountOnExit ? open && unmountOnExit : true
 
   const { position } = getSlideProps(placement)
 
@@ -120,7 +123,7 @@ export const Slide = motionForwardRef<SlideProps, "div">((props, ref) => {
 
   return (
     <AnimatePresence custom={custom}>
-      {isOpen ? (
+      {open ? (
         <motion.div
           ref={ref}
           className={cx("ui-slide", className)}

--- a/packages/components/transitions/tests/collapse.test.tsx
+++ b/packages/components/transitions/tests/collapse.test.tsx
@@ -7,14 +7,14 @@ describe("<Collapse />", () => {
     await a11y(<Collapse />)
   })
 
-  test("toggles visibility on isOpen change", async () => {
+  test("toggles visibility on open change", async () => {
     const TestComponent = () => {
       const [isOpen, setIsOpen] = useState(false)
 
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <Collapse isOpen={isOpen}>Collapse</Collapse>
+          <Collapse open={isOpen}>Collapse</Collapse>
         </>
       )
     }
@@ -33,7 +33,7 @@ describe("<Collapse />", () => {
   })
 
   test("animationOpacity set to true by default", async () => {
-    render(<Collapse isOpen>Collapse</Collapse>)
+    render(<Collapse open>Collapse</Collapse>)
 
     const collapse = await screen.findByText("Collapse")
 
@@ -42,7 +42,7 @@ describe("<Collapse />", () => {
 
   test("no opacity when animationOpacity set to false", async () => {
     render(
-      <Collapse animationOpacity={false} isOpen>
+      <Collapse animationOpacity={false} open>
         Collapse
       </Collapse>,
     )
@@ -52,14 +52,14 @@ describe("<Collapse />", () => {
     await waitFor(() => expect(collapse).not.toHaveStyle({ opacity: "1" }))
   })
 
-  test("height changes correctly after isOpen set to true", async () => {
+  test("height changes correctly after open set to true", async () => {
     const TestComponent = () => {
       const [isOpen, setIsOpen] = useState(false)
 
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <Collapse endingHeight={200} isOpen={isOpen} startingHeight={50}>
+          <Collapse endingHeight={200} open={isOpen} startingHeight={50}>
             Collapse
           </Collapse>
         </>
@@ -83,7 +83,7 @@ describe("<Collapse />", () => {
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <Collapse isOpen={isOpen} unmountOnExit>
+          <Collapse open={isOpen} unmountOnExit>
             Collapse
           </Collapse>
         </>

--- a/packages/components/transitions/tests/fade.test.tsx
+++ b/packages/components/transitions/tests/fade.test.tsx
@@ -7,14 +7,14 @@ describe("<Fade />", () => {
     await a11y(<Fade />)
   })
 
-  test("toggles visibility on isOpen change", async () => {
+  test("toggles visibility on open change", async () => {
     const TestComponent = () => {
       const [isOpen, setIsOpen] = useState(false)
 
       return (
         <>
           <button onClick={() => setIsOpen(!isOpen)}>button</button>
-          <Fade isOpen={isOpen}>Fade</Fade>
+          <Fade open={isOpen}>Fade</Fade>
         </>
       )
     }
@@ -39,7 +39,7 @@ describe("<Fade />", () => {
       return (
         <>
           <button onClick={() => setIsOpen(!isOpen)}>button</button>
-          <Fade isOpen={isOpen} unmountOnExit>
+          <Fade open={isOpen} unmountOnExit>
             Fade
           </Fade>
         </>

--- a/packages/components/transitions/tests/scale-fade.test.tsx
+++ b/packages/components/transitions/tests/scale-fade.test.tsx
@@ -7,14 +7,14 @@ describe("<ScaleFade />", () => {
     await a11y(<ScaleFade />)
   })
 
-  test("toggles visibility on isOpen change", async () => {
+  test("toggles visibility on open change", async () => {
     const TestComponent = () => {
       const [isOpen, setIsOpen] = useState(false)
 
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <ScaleFade isOpen={isOpen}>ScaleFade</ScaleFade>
+          <ScaleFade open={isOpen}>ScaleFade</ScaleFade>
         </>
       )
     }
@@ -39,7 +39,7 @@ describe("<ScaleFade />", () => {
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <ScaleFade isOpen={isOpen} unmountOnExit>
+          <ScaleFade open={isOpen} unmountOnExit>
             ScaleFade
           </ScaleFade>
         </>

--- a/packages/components/transitions/tests/slide-fade.test.tsx
+++ b/packages/components/transitions/tests/slide-fade.test.tsx
@@ -14,7 +14,7 @@ describe("<SlideFade />", () => {
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <SlideFade isOpen={isOpen}>SlideFade</SlideFade>
+          <SlideFade open={isOpen}>SlideFade</SlideFade>
         </>
       )
     }
@@ -39,7 +39,7 @@ describe("<SlideFade />", () => {
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <SlideFade initial="initial" isOpen={isOpen}>
+          <SlideFade initial="initial" open={isOpen}>
             SlideFade
           </SlideFade>
         </>
@@ -96,7 +96,7 @@ describe("<SlideFade />", () => {
       return (
         <>
           <button onClick={() => setIsOpen((prev) => !prev)}>button</button>
-          <SlideFade isOpen={isOpen} unmountOnExit>
+          <SlideFade open={isOpen} unmountOnExit>
             SlideFade
           </SlideFade>
         </>

--- a/packages/components/transitions/tests/slide.test.tsx
+++ b/packages/components/transitions/tests/slide.test.tsx
@@ -8,7 +8,7 @@ describe("<Slide />", () => {
   })
 
   test("applies default styles correctly", async () => {
-    render(<Slide isOpen>Slide</Slide>)
+    render(<Slide open>Slide</Slide>)
 
     const slide = await screen.findByText("Slide")
 
@@ -19,7 +19,7 @@ describe("<Slide />", () => {
 
   test("applies styles correctly for top placement", async () => {
     render(
-      <Slide isOpen placement="top">
+      <Slide open placement="top">
         Slide
       </Slide>,
     )
@@ -33,7 +33,7 @@ describe("<Slide />", () => {
 
   test("applies styles correctly for left placement", async () => {
     render(
-      <Slide isOpen placement="left">
+      <Slide open placement="left">
         Slide
       </Slide>,
     )
@@ -47,7 +47,7 @@ describe("<Slide />", () => {
 
   test("applies styles correctly for right placement", async () => {
     render(
-      <Slide isOpen placement="right">
+      <Slide open placement="right">
         Slide
       </Slide>,
     )
@@ -61,7 +61,7 @@ describe("<Slide />", () => {
 
   test("applies styles correctly for bottom placement", async () => {
     render(
-      <Slide isOpen placement="bottom">
+      <Slide open placement="bottom">
         Slide
       </Slide>,
     )
@@ -78,7 +78,7 @@ describe("<Slide />", () => {
       return (
         <>
           <button onClick={() => setIsOpen(!isOpen)}>button</button>
-          <Slide isOpen={isOpen} unmountOnExit>
+          <Slide open={isOpen} unmountOnExit>
             Slide
           </Slide>
         </>

--- a/stories/components.tsx
+++ b/stories/components.tsx
@@ -175,7 +175,7 @@ const PropControlItem = <K extends PropControlComponent>({
             onMouseLeave={onClose}
             {...(rest as SliderProps)}
           >
-            <Tooltip isOpen={isOpen} label={rest.value} placement="top">
+            <Tooltip label={rest.value} open={isOpen} placement="top">
               <SliderThumb />
             </Tooltip>
           </Slider>

--- a/stories/components/data-display/area-chart.stories.tsx
+++ b/stories/components/data-display/area-chart.stories.tsx
@@ -437,7 +437,7 @@ export const withSplit: Story = () => {
           onMouseEnter={on}
           onMouseLeave={off}
         >
-          <Tooltip isOpen={isOpen} label={splitOffset} placement="top">
+          <Tooltip label={splitOffset} open={isOpen} placement="top">
             <SliderThumb />
           </Tooltip>
         </Slider>

--- a/stories/components/forms/range-slider.stories.tsx
+++ b/stories/components/forms/range-slider.stories.tsx
@@ -246,11 +246,11 @@ export const withTooltip: Story = () => {
         75%
       </RangeSliderMark>
 
-      <Tooltip isOpen={isOpen} label={`${value[0]}%`} placement="top">
+      <Tooltip label={`${value[0]}%`} open={isOpen} placement="top">
         <RangeSliderStartThumb />
       </Tooltip>
 
-      <Tooltip isOpen={isOpen} label={`${value[1]}%`} placement="top">
+      <Tooltip label={`${value[1]}%`} open={isOpen} placement="top">
         <RangeSliderEndThumb />
       </Tooltip>
     </RangeSlider>

--- a/stories/components/forms/slider.stories.tsx
+++ b/stories/components/forms/slider.stories.tsx
@@ -186,7 +186,7 @@ export const withTooltip: Story = () => {
         75%
       </SliderMark>
 
-      <Tooltip isOpen={isOpen} label={`${value}%`} placement="top">
+      <Tooltip label={`${value}%`} open={isOpen} placement="top">
         <SliderThumb />
       </Tooltip>
     </Slider>

--- a/stories/components/overlay/dialog.stories.tsx
+++ b/stories/components/overlay/dialog.stories.tsx
@@ -36,7 +36,7 @@ export const basic: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -60,7 +60,7 @@ export const withDuration: Story = () => {
         cancel="わけない"
         duration={0.4}
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -80,7 +80,7 @@ export const customDialog: Story = () => {
     <>
       <Button onClick={onOpen}>Open Dialog</Button>
 
-      <Dialog isOpen={isOpen} onClose={onClose}>
+      <Dialog open={isOpen} onClose={onClose}>
         <DialogHeader>孫悟空</DialogHeader>
 
         <DialogBody>
@@ -111,7 +111,7 @@ export const customHeader: Story = () => {
       <Dialog
         cancel="わけない"
         header={<Text color="orange.500">孫悟空</Text>}
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -146,7 +146,7 @@ export const customFooter: Story = () => {
           </>
         }
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         onClose={onClose}
       >
         だ…大地よ海よ　そして生きているすべての　みんな…
@@ -170,7 +170,7 @@ export const customButton: Story = () => {
           children: "わけない",
         }}
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         other={{
           colorScheme: "orange",
           variant: "outline",
@@ -203,7 +203,7 @@ export const useOtherButton: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         other="どちらでもよい"
         success="わける"
         onCancel={onClose}
@@ -275,7 +275,7 @@ export const withSize: Story = () => {
         size={size}
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -380,7 +380,7 @@ export const withPlacement: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         placement={placement}
         success="わける"
         onCancel={onClose}
@@ -451,7 +451,7 @@ export const withAnimation: Story = () => {
         animation={animation}
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -474,7 +474,7 @@ export const disabledCloseButton: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onSuccess={onClose}
@@ -496,7 +496,7 @@ export const customCloseButton: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -523,7 +523,7 @@ export const disabledOverlay: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         withOverlay={false}
         onCancel={onClose}
@@ -547,7 +547,7 @@ export const customOverlay: Story = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -621,7 +621,7 @@ export const scrollOnMount: Story = () => {
         blockScrollOnMount={false}
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}

--- a/stories/components/overlay/drawer.stories.tsx
+++ b/stories/components/overlay/drawer.stories.tsx
@@ -33,7 +33,7 @@ export const basic: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer isOpen={isOpen} onClose={onClose}>
+      <Drawer open={isOpen} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -59,7 +59,7 @@ export const withDuration: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer duration={0.7} isOpen={isOpen} onClose={onClose}>
+      <Drawer duration={0.7} open={isOpen} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -131,7 +131,7 @@ export const withSize: Story = () => {
         </Button>
       </Wrap>
 
-      <Drawer size={size} isOpen={isOpen} onClose={onClose}>
+      <Drawer size={size} open={isOpen} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -194,7 +194,7 @@ export const withPosition: Story = () => {
         </Button>
       </Wrap>
 
-      <Drawer isOpen={isOpen} placement={placement} onClose={onClose}>
+      <Drawer open={isOpen} placement={placement} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -220,7 +220,7 @@ export const withFullHeight: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer isFullHeight isOpen={isOpen} placement="bottom" onClose={onClose}>
+      <Drawer isFullHeight open={isOpen} placement="bottom" onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -283,12 +283,7 @@ export const withCloseOnDrag: Story = () => {
         </Button>
       </Wrap>
 
-      <Drawer
-        closeOnDrag
-        isOpen={isOpen}
-        placement={placement}
-        onClose={onClose}
-      >
+      <Drawer closeOnDrag open={isOpen} placement={placement} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -316,7 +311,7 @@ export const hiddenDragBar: Story = () => {
 
       <Drawer
         closeOnDrag
-        isOpen={isOpen}
+        open={isOpen}
         placement="bottom"
         withCloseButton
         withDragBar={false}
@@ -347,7 +342,7 @@ export const disabledCloseButton: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer isOpen={isOpen}>
+      <Drawer open={isOpen}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -373,7 +368,7 @@ export const customCloseButton: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer isOpen={isOpen} onClose={onClose}>
+      <Drawer open={isOpen} onClose={onClose}>
         <DrawerCloseButton color="gray.400" />
 
         <DrawerHeader>ドラゴンボール</DrawerHeader>
@@ -401,7 +396,7 @@ export const disabledOverlay: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer isOpen={isOpen} withOverlay={false} onClose={onClose}>
+      <Drawer open={isOpen} withOverlay={false} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>
@@ -427,7 +422,7 @@ export const customOverlay: Story = () => {
     <>
       <Button onClick={onOpen}>Open Drawer</Button>
 
-      <Drawer isOpen={isOpen} onClose={onClose}>
+      <Drawer open={isOpen} onClose={onClose}>
         <DrawerOverlay backdropFilter="blur(10px)" bg="blackAlpha.300" />
 
         <DrawerHeader>ドラゴンボール</DrawerHeader>
@@ -501,7 +496,7 @@ export const scrollOnMount: Story = () => {
         </Text>
       </Container>
 
-      <Drawer blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
+      <Drawer blockScrollOnMount={false} open={isOpen} onClose={onClose}>
         <DrawerHeader>ドラゴンボール</DrawerHeader>
 
         <DrawerBody>

--- a/stories/components/overlay/menu.stories.tsx
+++ b/stories/components/overlay/menu.stories.tsx
@@ -399,7 +399,7 @@ export const customControl: Story = () => {
   const { isOpen, onClose, onOpen } = useDisclosure()
 
   return (
-    <Menu isOpen={isOpen} onClose={onClose} onOpen={onOpen}>
+    <Menu open={isOpen} onClose={onClose} onOpen={onOpen}>
       <MenuButton as={Button} rightIcon={<ChevronDown fontSize="xl" />}>
         Menu
       </MenuButton>

--- a/stories/components/overlay/modal.stories.tsx
+++ b/stories/components/overlay/modal.stories.tsx
@@ -33,7 +33,7 @@ export const basic: Story = () => {
     <>
       <Button onClick={onOpen}>Open Modal</Button>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal open={isOpen} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -59,7 +59,7 @@ export const withDuration: Story = () => {
     <>
       <Button onClick={onOpen}>Open Modal</Button>
 
-      <Modal duration={0.4} isOpen={isOpen} onClose={onClose}>
+      <Modal duration={0.4} open={isOpen} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -131,7 +131,7 @@ export const withSize: Story = () => {
         </Button>
       </Wrap>
 
-      <Modal size={size} isOpen={isOpen} onClose={onClose}>
+      <Modal size={size} open={isOpen} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -239,7 +239,7 @@ export const withPlacement: Story = () => {
         </Button>
       </Wrap>
 
-      <Modal isOpen={isOpen} placement={placement} onClose={onClose}>
+      <Modal open={isOpen} placement={placement} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -311,7 +311,7 @@ export const withAnimation: Story = () => {
         </Button>
       </Wrap>
 
-      <Modal animation={animation} isOpen={isOpen} onClose={onClose}>
+      <Modal animation={animation} open={isOpen} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -338,7 +338,7 @@ export const nestedModal: Story = () => {
     <>
       <Button onClick={firstControls.onOpen}>Open Modal</Button>
 
-      <Modal isOpen={firstControls.isOpen} onClose={firstControls.onClose}>
+      <Modal open={firstControls.isOpen} onClose={firstControls.onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -357,7 +357,7 @@ export const nestedModal: Story = () => {
 
         <Modal
           size="sm"
-          isOpen={secondControls.isOpen}
+          open={secondControls.isOpen}
           onClose={secondControls.onClose}
         >
           <ModalHeader>あらすじ</ModalHeader>
@@ -385,7 +385,7 @@ export const disabledCloseButton: Story = () => {
     <>
       <Button onClick={onOpen}>Open Modal</Button>
 
-      <Modal isOpen={isOpen}>
+      <Modal open={isOpen}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -411,7 +411,7 @@ export const customCloseButton: Story = () => {
     <>
       <Button onClick={onOpen}>Open Modal</Button>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal open={isOpen} onClose={onClose}>
         <ModalCloseButton color="gray.400" />
 
         <ModalHeader>ドラゴンボール</ModalHeader>
@@ -439,7 +439,7 @@ export const disabledOverlay: Story = () => {
     <>
       <Button onClick={onOpen}>Open Modal</Button>
 
-      <Modal isOpen={isOpen} withOverlay={false} onClose={onClose}>
+      <Modal open={isOpen} withOverlay={false} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -465,7 +465,7 @@ export const customOverlay: Story = () => {
     <>
       <Button onClick={onOpen}>Open Modal</Button>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal open={isOpen} onClose={onClose}>
         <ModalOverlay backdropFilter="blur(10px)" bg="blackAlpha.300" />
 
         <ModalHeader>ドラゴンボール</ModalHeader>
@@ -513,7 +513,7 @@ export const scrollBehavior: Story = () => {
         </Button>
       </Wrap>
 
-      <Modal isOpen={isOpen} scrollBehavior={scrollBehavior} onClose={onClose}>
+      <Modal open={isOpen} scrollBehavior={scrollBehavior} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>
@@ -609,7 +609,7 @@ export const scrollOnMount: Story = () => {
         </Text>
       </Container>
 
-      <Modal blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
+      <Modal blockScrollOnMount={false} open={isOpen} onClose={onClose}>
         <ModalHeader>ドラゴンボール</ModalHeader>
 
         <ModalBody>

--- a/stories/components/overlay/popover.stories.tsx
+++ b/stories/components/overlay/popover.stories.tsx
@@ -105,7 +105,7 @@ export const controlPopover: Story = () => {
     <Center gap="md" h="calc(100vh - 16px * 2)" w="calc(100vw - 16px * 2)">
       <Button onClick={onToggle}>Open Popover</Button>
 
-      <Popover closeOnBlur={false} isOpen={isOpen} onClose={onClose}>
+      <Popover closeOnBlur={false} open={isOpen} onClose={onClose}>
         <PopoverTrigger>
           <Button colorScheme="primary">Target Popover</Button>
         </PopoverTrigger>

--- a/stories/components/overlay/tooltip.stories.tsx
+++ b/stories/components/overlay/tooltip.stories.tsx
@@ -172,7 +172,7 @@ export const withDisabled: Story = () => {
 export const alwaysOpen: Story = () => {
   return (
     <Center h="calc(100vh - 16px * 2)" w="calc(100vw - 16px * 2)">
-      <Tooltip isOpen label="へっ！きたねぇ花火だ">
+      <Tooltip label="へっ！きたねぇ花火だ" open>
         <Text>Please Hover</Text>
       </Tooltip>
     </Center>

--- a/stories/components/transitions/collapse.stories.tsx
+++ b/stories/components/transitions/collapse.stories.tsx
@@ -17,7 +17,7 @@ export const basic: Story = () => {
     <VStack align="flex-start" gap={0}>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Collapse isOpen={isOpen}>
+      <Collapse open={isOpen}>
         <Box bg="orange.500" color="white" mt="md" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -33,7 +33,7 @@ export const withDuration: Story = () => {
     <VStack align="flex-start" gap={0}>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Collapse duration={0.7} isOpen={isOpen}>
+      <Collapse duration={0.7} open={isOpen}>
         <Box bg="orange.500" color="white" mt="md" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -49,7 +49,7 @@ export const exitUnmount: Story = () => {
     <VStack align="flex-start" gap={0}>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Collapse isOpen={isOpen} unmountOnExit>
+      <Collapse open={isOpen} unmountOnExit>
         <Box bg="orange.500" color="white" mt="md" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -69,7 +69,7 @@ export const disabledOpacity: Story = () => {
     <VStack align="flex-start" gap={0}>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Collapse animationOpacity={false} isOpen={isOpen}>
+      <Collapse animationOpacity={false} open={isOpen}>
         <Box bg="orange.500" color="white" mt="md" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -89,7 +89,7 @@ export const startingHeight: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Collapse isOpen={isOpen} startingHeight={20}>
+      <Collapse open={isOpen} startingHeight={20}>
         <Box color="purple.500">
           私の戦闘力は530000です。
           <br />

--- a/stories/components/transitions/fade.stories.tsx
+++ b/stories/components/transitions/fade.stories.tsx
@@ -17,7 +17,7 @@ export const basic: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Fade isOpen={isOpen}>
+      <Fade open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -37,7 +37,7 @@ export const withDuration: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Fade duration={0.4} isOpen={isOpen}>
+      <Fade duration={0.4} open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -57,7 +57,7 @@ export const exitUnmount: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Fade isOpen={isOpen} unmountOnExit>
+      <Fade open={isOpen} unmountOnExit>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>

--- a/stories/components/transitions/scale-fade.stories.tsx
+++ b/stories/components/transitions/scale-fade.stories.tsx
@@ -17,7 +17,7 @@ export const basic: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <ScaleFade isOpen={isOpen}>
+      <ScaleFade open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -37,7 +37,7 @@ export const withScale: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <ScaleFade isOpen={isOpen} scale={0.75}>
+      <ScaleFade open={isOpen} scale={0.75}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -57,7 +57,7 @@ export const withDuration: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <ScaleFade duration={0.4} isOpen={isOpen}>
+      <ScaleFade duration={0.4} open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -77,7 +77,7 @@ export const exitUnmount: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <ScaleFade isOpen={isOpen} unmountOnExit>
+      <ScaleFade open={isOpen} unmountOnExit>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>

--- a/stories/components/transitions/slide-fide.stories.tsx
+++ b/stories/components/transitions/slide-fide.stories.tsx
@@ -17,7 +17,7 @@ export const basic: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <SlideFade isOpen={isOpen}>
+      <SlideFade open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -37,7 +37,7 @@ export const withDuration: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <SlideFade duration={0.4} isOpen={isOpen}>
+      <SlideFade duration={0.4} open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -57,7 +57,7 @@ export const withOffsetX: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <SlideFade isOpen={isOpen} offsetX={20} offsetY={0}>
+      <SlideFade offsetX={20} offsetY={0} open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -77,7 +77,7 @@ export const withOffsetY: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <SlideFade isOpen={isOpen} offsetY={-20}>
+      <SlideFade offsetY={-20} open={isOpen}>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>
@@ -97,7 +97,7 @@ export const exitUnmount: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <SlideFade isOpen={isOpen} unmountOnExit>
+      <SlideFade open={isOpen} unmountOnExit>
         <Box bg="orange.500" color="white" p="md" rounded="md" w="full">
           クリリンのことか……クリリンのことかーーーっ！！！！！
         </Box>

--- a/stories/components/transitions/slide.stories.tsx
+++ b/stories/components/transitions/slide.stories.tsx
@@ -17,7 +17,7 @@ export const basic: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Slide isOpen={isOpen} placement="bottom">
+      <Slide open={isOpen} placement="bottom">
         <VStack bg="orange.500" p="md" w="full">
           <Text color="white">
             クリリンのことか……クリリンのことかーーーっ！！！！！
@@ -39,7 +39,7 @@ export const withDuration: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Slide duration={0.7} isOpen={isOpen} placement="bottom">
+      <Slide duration={0.7} open={isOpen} placement="bottom">
         <VStack bg="orange.500" p="md" w="full">
           <Text color="white">
             クリリンのことか……クリリンのことかーーーっ！！！！！
@@ -61,7 +61,7 @@ export const withPlacement: Story = () => {
     <>
       <Button onClick={toggle}>Please Click</Button>
 
-      <Slide isOpen={isOpen} placement="left">
+      <Slide open={isOpen} placement="left">
         <VStack bg="orange.500" p="md" w="full">
           <Text color="white">
             クリリンのことか……クリリンのことかーーーっ！！！！！

--- a/stories/hooks/use-disclosure.stories.tsx
+++ b/stories/hooks/use-disclosure.stories.tsx
@@ -23,7 +23,7 @@ export const basic = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}
@@ -65,7 +65,7 @@ export const withChain = () => {
       <Dialog
         cancel="わけない"
         header="孫悟空"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={() => onClose("This is arg")}
         onClose={() => onClose("This is arg")}
@@ -104,7 +104,7 @@ export const withPromise = () => {
         size="2xl"
         cancel="わけない"
         header="ミスター・サタン"
-        isOpen={isOpen}
+        open={isOpen}
         success="わける"
         onCancel={onClose}
         onClose={onClose}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Related #3302

## Description

This pull request is to remove the `is` prefix for `isOpen` in the props

## Current behavior (updates)

Props in components were using `isOpen`

## New behavior

Props in components are now using `open`

## Is this a breaking change (Yes/No):

No

## Additional Information
Since #3302 is quite large, and this PR is only to rename `isOpen`