### PR TITLE
docs: rename isOpen to open in props

### DIFF
--- a/docs/components/forms/copy-button.tsx
+++ b/docs/components/forms/copy-button.tsx
@@ -17,8 +17,8 @@ export const CopyButton = memo(
         bg="success"
         display="inline-flex"
         h="8"
-        isOpen={hasCopied}
         label="Copied!"
+        open={hasCopied}
         placement="left"
         zIndex="auto"
       >

--- a/docs/components/forms/search.tsx
+++ b/docs/components/forms/search.tsx
@@ -109,7 +109,7 @@ export const Search = memo(
           <Kbd>{actionKey} + K</Kbd>
         </HStack>
 
-        <SearchModal isOpen={isOpen} onClose={onClose} />
+        <SearchModal open={isOpen} onClose={onClose} />
       </>
     )
   }),
@@ -134,7 +134,7 @@ export const SearchButton = memo(
           onClick={handlerAll(rest.onClick, onOpen)}
         />
 
-        <SearchModal isOpen={isOpen} onClose={onClose} />
+        <SearchModal open={isOpen} onClose={onClose} />
       </>
     )
   }),
@@ -142,237 +142,233 @@ export const SearchButton = memo(
 
 interface SearchModalProps extends ModalProps {}
 
-const SearchModal: FC<SearchModalProps> = memo(
-  ({ isOpen, onClose, ...rest }) => {
-    const [query, setQuery] = useState<string>("")
-    const [selectedIndex, setSelectedIndex] = useState<number>(0)
-    const { contents, t } = useI18n()
-    const router = useRouter()
-    const eventRef = useRef<"keyboard" | "mouse" | null>(null)
-    const directionRef = useRef<"down" | "up">("down")
-    const compositionRef = useRef<boolean>(false)
-    const containerRef = useRef<HTMLDivElement>(null)
-    const itemRefs = useRef<Map<number, RefObject<HTMLAnchorElement>>>(
-      new Map(),
-    )
+const SearchModal: FC<SearchModalProps> = memo(({ open, onClose, ...rest }) => {
+  const [query, setQuery] = useState<string>("")
+  const [selectedIndex, setSelectedIndex] = useState<number>(0)
+  const { contents, t } = useI18n()
+  const router = useRouter()
+  const eventRef = useRef<"keyboard" | "mouse" | null>(null)
+  const directionRef = useRef<"down" | "up">("down")
+  const compositionRef = useRef<boolean>(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Map<number, RefObject<HTMLAnchorElement>>>(new Map())
 
-    const hits = useMemo(() => {
-      if (query.length < 1) return []
+  const hits = useMemo(() => {
+    if (query.length < 1) return []
 
-      return matchSorter(contents, query, {
-        keys: [
-          "hierarchy.lv1",
-          "hierarchy.lv2",
-          "hierarchy.lv3",
-          "hierarchy.lv4",
-          "description",
-          "title",
-        ],
-      }).slice(0, 20)
-    }, [query, contents])
+    return matchSorter(contents, query, {
+      keys: [
+        "hierarchy.lv1",
+        "hierarchy.lv2",
+        "hierarchy.lv3",
+        "hierarchy.lv4",
+        "description",
+        "title",
+      ],
+    }).slice(0, 20)
+  }, [query, contents])
 
-    const onKeyDown = useCallback(
-      (ev: KeyboardEvent<HTMLInputElement>) => {
-        if (compositionRef.current) return
+  const onKeyDown = useCallback(
+    (ev: KeyboardEvent<HTMLInputElement>) => {
+      if (compositionRef.current) return
 
-        eventRef.current = "keyboard"
+      eventRef.current = "keyboard"
 
-        const actions: { [key: string]: Function | undefined } = {
-          ArrowDown: () => {
-            if (selectedIndex + 1 === hits.length) return
+      const actions: { [key: string]: Function | undefined } = {
+        ArrowDown: () => {
+          if (selectedIndex + 1 === hits.length) return
 
-            directionRef.current = "down"
-            setSelectedIndex(selectedIndex + 1)
-          },
-          ArrowUp: () => {
-            if (selectedIndex === 0) return
+          directionRef.current = "down"
+          setSelectedIndex(selectedIndex + 1)
+        },
+        ArrowUp: () => {
+          if (selectedIndex === 0) return
 
-            directionRef.current = "up"
-            setSelectedIndex(selectedIndex - 1)
-          },
-          End: () => {
-            directionRef.current = "down"
-            setSelectedIndex(hits.length - 1)
-          },
-          Enter: () => {
-            if (!hits.length) return
+          directionRef.current = "up"
+          setSelectedIndex(selectedIndex - 1)
+        },
+        End: () => {
+          directionRef.current = "down"
+          setSelectedIndex(hits.length - 1)
+        },
+        Enter: () => {
+          if (!hits.length) return
 
-            onClose?.()
-            router.push(hits[selectedIndex]?.slug)
-          },
-          Home: () => {
-            directionRef.current = "up"
-            setSelectedIndex(0)
-          },
-        }
+          onClose?.()
+          router.push(hits[selectedIndex]?.slug)
+        },
+        Home: () => {
+          directionRef.current = "up"
+          setSelectedIndex(0)
+        },
+      }
 
-        const action = actions[ev.key]
+      const action = actions[ev.key]
 
-        if (!action) return
+      if (!action) return
 
-        ev.preventDefault()
-        ev.stopPropagation()
+      ev.preventDefault()
+      ev.stopPropagation()
 
-        action(ev)
-      },
-      [hits, onClose, selectedIndex, router],
-    )
+      action(ev)
+    },
+    [hits, onClose, selectedIndex, router],
+  )
 
-    useEffect(() => {
-      if (isOpen) return
+  useEffect(() => {
+    if (open) return
 
-      setQuery("")
-    }, [isOpen])
+    setQuery("")
+  }, [open])
 
-    useUpdateEffect(() => {
-      setSelectedIndex(0)
-    }, [query])
+  useUpdateEffect(() => {
+    setSelectedIndex(0)
+  }, [query])
 
-    useUpdateEffect(() => {
-      if (!containerRef.current || eventRef.current === "mouse") return
+  useUpdateEffect(() => {
+    if (!containerRef.current || eventRef.current === "mouse") return
 
-      const itemRef = itemRefs.current.get(selectedIndex)
+    const itemRef = itemRefs.current.get(selectedIndex)
 
-      if (!itemRef?.current) return
+    if (!itemRef?.current) return
 
-      scrollIntoView(itemRef.current, {
-        behavior: (actions) =>
-          actions.forEach(({ el, top }) => {
-            if (directionRef.current === "down") {
-              el.scrollTop = top + 16
-            } else {
-              el.scrollTop = top - 17
-            }
-          }),
-        block: "nearest",
-        boundary: containerRef.current,
-        inline: "nearest",
-        scrollMode: "if-needed",
-      })
-    }, [selectedIndex])
+    scrollIntoView(itemRef.current, {
+      behavior: (actions) =>
+        actions.forEach(({ el, top }) => {
+          if (directionRef.current === "down") {
+            el.scrollTop = top + 16
+          } else {
+            el.scrollTop = top - 17
+          }
+        }),
+      block: "nearest",
+      boundary: containerRef.current,
+      inline: "nearest",
+      scrollMode: "if-needed",
+    })
+  }, [selectedIndex])
 
-    return (
-      <Modal
-        size="3xl"
-        isOpen={isOpen}
-        placement="top"
-        withCloseButton={false}
-        onClose={onClose}
-        {...rest}
-      >
-        <ModalHeader fontSize="md" fontWeight="normal" pb="md">
-          <HStack position="relative" w="full">
-            <ui.input
-              autoComplete="off"
-              autoCorrect="off"
-              flex="1"
-              maxLength={64}
-              pl="lg"
-              placeholder={t("component.forms.search.placeholder") as string}
-              spellCheck="false"
-              value={query}
-              onChange={(ev) => setQuery(ev.target.value)}
-              onCompositionEnd={() => {
-                compositionRef.current = false
-              }}
-              onCompositionStart={() => {
-                compositionRef.current = true
-              }}
-              onKeyDown={onKeyDown}
-            />
+  return (
+    <Modal
+      size="3xl"
+      open={open}
+      placement="top"
+      withCloseButton={false}
+      onClose={onClose}
+      {...rest}
+    >
+      <ModalHeader fontSize="md" fontWeight="normal" pb="md">
+        <HStack position="relative" w="full">
+          <ui.input
+            autoComplete="off"
+            autoCorrect="off"
+            flex="1"
+            maxLength={64}
+            pl="lg"
+            placeholder={t("component.forms.search.placeholder") as string}
+            spellCheck="false"
+            value={query}
+            onChange={(ev) => setQuery(ev.target.value)}
+            onCompositionEnd={() => {
+              compositionRef.current = false
+            }}
+            onCompositionStart={() => {
+              compositionRef.current = true
+            }}
+            onKeyDown={onKeyDown}
+          />
 
-            <SearchIcon
-              color={["blackAlpha.700", "whiteAlpha.600"]}
-              fontSize="2xl"
-              left="0"
-              pointerEvents="none"
-              position="absolute"
-              top="50%"
-              transform="translateY(-50%)"
-            />
-          </HStack>
-        </ModalHeader>
+          <SearchIcon
+            color={["blackAlpha.700", "whiteAlpha.600"]}
+            fontSize="2xl"
+            left="0"
+            pointerEvents="none"
+            position="absolute"
+            top="50%"
+            transform="translateY(-50%)"
+          />
+        </HStack>
+      </ModalHeader>
 
-        {hits.length ? (
-          <ModalBody ref={containerRef} my="0" pb="md">
-            <Divider />
+      {hits.length ? (
+        <ModalBody ref={containerRef} my="0" pb="md">
+          <Divider />
 
-            <VStack as="ul" gap="sm">
-              {hits.map(({ type, hierarchy, slug, title }, index) => {
-                const isSelected = index === selectedIndex
-                const ref = createRef<HTMLAnchorElement>()
+          <VStack as="ul" gap="sm">
+            {hits.map(({ type, hierarchy, slug, title }, index) => {
+              const isSelected = index === selectedIndex
+              const ref = createRef<HTMLAnchorElement>()
 
-                itemRefs.current.set(index, ref)
+              itemRefs.current.set(index, ref)
 
-                return (
-                  <HStack
-                    key={slug}
-                    ref={ref}
-                    as={NextLink}
-                    href={slug}
-                    data-selected={dataAttr(isSelected)}
-                    bg={["blackAlpha.50", "whiteAlpha.50"]}
-                    borderWidth="1px"
-                    gap="2"
-                    minH="16"
-                    px="md"
-                    py="sm"
-                    rounded="md"
-                    transitionDuration="normal"
-                    transitionProperty="colors"
-                    _active={{}}
-                    _focus={{ outline: "none" }}
-                    _focusVisible={{ boxShadow: "outline" }}
-                    _hover={{ boxShadow: "outline" }}
-                    _selected={{ boxShadow: "outline" }}
-                    onClick={onClose}
-                    onMouseEnter={() => {
-                      eventRef.current = "mouse"
-                      setSelectedIndex(index)
-                    }}
-                  >
-                    {type === "page" ? (
-                      <File
-                        color={["blackAlpha.700", "whiteAlpha.600"]}
-                        fontSize="2xl"
-                      />
-                    ) : (
-                      <Hash
-                        color={["blackAlpha.500", "whiteAlpha.400"]}
-                        fontSize="2xl"
-                      />
-                    )}
+              return (
+                <HStack
+                  key={slug}
+                  ref={ref}
+                  as={NextLink}
+                  href={slug}
+                  data-selected={dataAttr(isSelected)}
+                  bg={["blackAlpha.50", "whiteAlpha.50"]}
+                  borderWidth="1px"
+                  gap="2"
+                  minH="16"
+                  px="md"
+                  py="sm"
+                  rounded="md"
+                  transitionDuration="normal"
+                  transitionProperty="colors"
+                  _active={{}}
+                  _focus={{ outline: "none" }}
+                  _focusVisible={{ boxShadow: "outline" }}
+                  _hover={{ boxShadow: "outline" }}
+                  _selected={{ boxShadow: "outline" }}
+                  onClick={onClose}
+                  onMouseEnter={() => {
+                    eventRef.current = "mouse"
+                    setSelectedIndex(index)
+                  }}
+                >
+                  {type === "page" ? (
+                    <File
+                      color={["blackAlpha.700", "whiteAlpha.600"]}
+                      fontSize="2xl"
+                    />
+                  ) : (
+                    <Hash
+                      color={["blackAlpha.500", "whiteAlpha.400"]}
+                      fontSize="2xl"
+                    />
+                  )}
 
-                    <VStack gap="0">
-                      {type === "fragment" ? (
-                        <Highlight
-                          color="muted"
-                          fontSize="xs"
-                          lineClamp={1}
-                          query={query}
-                          markProps={{ variant: "text-accent" }}
-                        >
-                          {hierarchy.lv1}
-                        </Highlight>
-                      ) : null}
-
+                  <VStack gap="0">
+                    {type === "fragment" ? (
                       <Highlight
+                        color="muted"
+                        fontSize="xs"
                         lineClamp={1}
                         query={query}
                         markProps={{ variant: "text-accent" }}
                       >
-                        {title}
+                        {hierarchy.lv1}
                       </Highlight>
-                    </VStack>
-                  </HStack>
-                )
-              })}
-            </VStack>
-          </ModalBody>
-        ) : null}
-      </Modal>
-    )
-  },
-)
+                    ) : null}
+
+                    <Highlight
+                      lineClamp={1}
+                      query={query}
+                      markProps={{ variant: "text-accent" }}
+                    >
+                      {title}
+                    </Highlight>
+                  </VStack>
+                </HStack>
+              )
+            })}
+          </VStack>
+        </ModalBody>
+      ) : null}
+    </Modal>
+  )
+})
 
 SearchModal.displayName = "SearchModal"

--- a/docs/components/layouts/header.tsx
+++ b/docs/components/layouts/header.tsx
@@ -147,7 +147,7 @@ export const Header = memo(
           </HStack>
         </Center>
 
-        <MobileMenu isOpen={isOpen} onClose={onClose} />
+        <MobileMenu open={isOpen} onClose={onClose} />
       </>
     )
   }),
@@ -442,7 +442,7 @@ ColorButton.displayName = "ColorButton"
 
 interface MobileMenuProps extends DrawerProps {}
 
-const MobileMenu: FC<MobileMenuProps> = memo(({ isOpen, onClose }) => {
+const MobileMenu: FC<MobileMenuProps> = memo(({ open, onClose }) => {
   const { events } = useRouter()
   const breakpoint = useBreakpoint()
 
@@ -462,7 +462,7 @@ const MobileMenu: FC<MobileMenuProps> = memo(({ isOpen, onClose }) => {
     <Drawer
       closeOnDrag
       isFullHeight
-      isOpen={isOpen}
+      open={open}
       w="sm"
       withCloseButton={false}
       withDragBar={false}
@@ -474,7 +474,7 @@ const MobileMenu: FC<MobileMenuProps> = memo(({ isOpen, onClose }) => {
         justifyContent="flex-end"
         pt="sm"
       >
-        <ButtonGroup isMobile {...{ isOpen, onClose }} />
+        <ButtonGroup isMobile {...{ open, onClose }} />
       </DrawerHeader>
 
       <DrawerBody my="sm" position="relative">

--- a/docs/contents/components/overlay/dialog/index.ja.mdx
+++ b/docs/contents/components/overlay/dialog/index.ja.mdx
@@ -34,7 +34,7 @@ import {
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`と`onClose`を設定します。
+表示または非表示を制御するために、`open`と`onClose`を設定します。
 
 :::note
 `Dialog`は、内部的に[Modal](/components/overlay/modal)を使用しており、`Modal`を簡素化したコンポーネントです。
@@ -72,7 +72,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Dialog</Button>
 
-    <Dialog isOpen={isOpen} onClose={onClose}>
+    <Dialog open={isOpen} onClose={onClose}>
       <DialogHeader>孫悟空</DialogHeader>
 
       <DialogBody>
@@ -129,7 +129,7 @@ return (
     </Wrap>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       size={size}
       header="孫悟空"
@@ -181,7 +181,7 @@ return (
     </Wrap>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       placement={placement}
       header="孫悟空"
@@ -209,7 +209,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -255,7 +255,7 @@ return (
     </Wrap>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       scrollBehavior={scrollBehavior}
       h="xl"
@@ -308,7 +308,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -336,7 +336,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -365,7 +365,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel={{
@@ -406,7 +406,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -441,7 +441,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       header="孫悟空"
       cancel="わけない"
       onCancel={onClose}
@@ -467,7 +467,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -498,7 +498,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       withOverlay={false}
       header="孫悟空"

--- a/docs/contents/components/overlay/dialog/index.mdx
+++ b/docs/contents/components/overlay/dialog/index.mdx
@@ -34,7 +34,7 @@ import {
 
 ## Usage
 
-To control visibility, set `isOpen` and `onClose`.
+To control visibility, set `open` and `onClose`.
 
 :::note
 `Dialog` internally uses [Modal](/components/overlay/modal), and is a simplified component of `Modal`.
@@ -48,7 +48,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -72,7 +72,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Dialog</Button>
 
-    <Dialog isOpen={isOpen} onClose={onClose}>
+    <Dialog open={isOpen} onClose={onClose}>
       <DialogHeader>孫悟空</DialogHeader>
 
       <DialogBody>
@@ -129,7 +129,7 @@ return (
     </Wrap>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       size={size}
       header="孫悟空"
@@ -181,7 +181,7 @@ return (
     </Wrap>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       placement={placement}
       header="孫悟空"
@@ -209,7 +209,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -255,7 +255,7 @@ return (
     </Wrap>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       scrollBehavior={scrollBehavior}
       h="xl"
@@ -308,7 +308,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -336,7 +336,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -365,7 +365,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel={{
@@ -406,7 +406,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -441,7 +441,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       header="孫悟空"
       cancel="わけない"
       onCancel={onClose}
@@ -467,7 +467,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -498,7 +498,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       withOverlay={false}
       header="孫悟空"

--- a/docs/contents/components/overlay/dialog/props.ja.mdx
+++ b/docs/contents/components/overlay/dialog/props.ja.mdx
@@ -13,7 +13,7 @@ tab: Props
 
 <PropsCard
   id="dialog-isopen"
-  name="isOpen"
+  name="open"
   required
   type="boolean"
   description={"If `true`, the open will be opened."}

--- a/docs/contents/components/overlay/dialog/props.mdx
+++ b/docs/contents/components/overlay/dialog/props.mdx
@@ -13,7 +13,7 @@ tab: Props
 
 <PropsCard
   id="dialog-isopen"
-  name="isOpen"
+  name="open"
   required
   type="boolean"
   description={"If `true`, the open will be opened."}

--- a/docs/contents/components/overlay/drawer/accessibility.ja.mdx
+++ b/docs/contents/components/overlay/drawer/accessibility.ja.mdx
@@ -25,7 +25,7 @@ return (
       Open Drawer
     </Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>

--- a/docs/contents/components/overlay/drawer/accessibility.mdx
+++ b/docs/contents/components/overlay/drawer/accessibility.mdx
@@ -25,7 +25,7 @@ return (
       Open Drawer
     </Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>

--- a/docs/contents/components/overlay/drawer/index.ja.mdx
+++ b/docs/contents/components/overlay/drawer/index.ja.mdx
@@ -34,7 +34,7 @@ import {
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`と`onClose`を設定します。
+表示または非表示を制御するために、`open`と`onClose`を設定します。
 
 :::note
 `Drawer`は、内部的に[Modal](/components/overlay/modal)を使用しています。
@@ -47,7 +47,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -88,7 +88,7 @@ return (
       ))}
     </Wrap>
 
-    <Drawer isOpen={isOpen} onClose={onClose} size={size}>
+    <Drawer open={isOpen} onClose={onClose} size={size}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -131,7 +131,7 @@ return (
       ))}
     </Wrap>
 
-    <Drawer isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Drawer open={isOpen} onClose={onClose} placement={placement}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -160,7 +160,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} duration={0.7}>
+    <Drawer open={isOpen} onClose={onClose} duration={0.7}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -189,7 +189,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} placement="bottom" isFullHeight>
+    <Drawer open={isOpen} onClose={onClose} placement="bottom" isFullHeight>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -218,7 +218,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} blockScrollOnMount={false}>
+    <Drawer open={isOpen} onClose={onClose} blockScrollOnMount={false}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -247,7 +247,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerCloseButton color="red.500" />
 
       <DrawerHeader>ドラゴンボール</DrawerHeader>
@@ -282,7 +282,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen}>
+    <Drawer open={isOpen}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -325,7 +325,7 @@ return (
       ))}
     </Wrap>
 
-    <Drawer closeOnDrag isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Drawer closeOnDrag open={isOpen} onClose={onClose} placement={placement}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -355,7 +355,7 @@ return (
     <Button onClick={onOpen}>Open Drawer</Button>
 
     <Drawer
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       closeOnDrag
       withDragBar={false}
@@ -389,7 +389,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
 
       <DrawerHeader>ドラゴンボール</DrawerHeader>
@@ -420,7 +420,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} withOverlay={false}>
+    <Drawer open={isOpen} onClose={onClose} withOverlay={false}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>

--- a/docs/contents/components/overlay/drawer/index.mdx
+++ b/docs/contents/components/overlay/drawer/index.mdx
@@ -34,7 +34,7 @@ import {
 
 ## Usage
 
-To control the visibility, set `isOpen` and `onClose`.
+To control the visibility, set `open` and `onClose`.
 
 :::note
 `Drawer` internally uses [Modal](/components/overlay/modal).
@@ -47,7 +47,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -88,7 +88,7 @@ return (
       ))}
     </Wrap>
 
-    <Drawer isOpen={isOpen} onClose={onClose} size={size}>
+    <Drawer open={isOpen} onClose={onClose} size={size}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -131,7 +131,7 @@ return (
       ))}
     </Wrap>
 
-    <Drawer isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Drawer open={isOpen} onClose={onClose} placement={placement}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -160,7 +160,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} duration={0.7}>
+    <Drawer open={isOpen} onClose={onClose} duration={0.7}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -189,7 +189,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} placement="bottom" isFullHeight>
+    <Drawer open={isOpen} onClose={onClose} placement="bottom" isFullHeight>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -218,7 +218,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} blockScrollOnMount={false}>
+    <Drawer open={isOpen} onClose={onClose} blockScrollOnMount={false}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -247,7 +247,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerCloseButton color="red.500" />
 
       <DrawerHeader>ドラゴンボール</DrawerHeader>
@@ -282,7 +282,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen}>
+    <Drawer open={isOpen}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -325,7 +325,7 @@ return (
       ))}
     </Wrap>
 
-    <Drawer closeOnDrag isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Drawer closeOnDrag open={isOpen} onClose={onClose} placement={placement}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>
@@ -355,7 +355,7 @@ return (
     <Button onClick={onOpen}>Open Drawer</Button>
 
     <Drawer
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       closeOnDrag
       withDragBar={false}
@@ -389,7 +389,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose}>
+    <Drawer open={isOpen} onClose={onClose}>
       <DrawerOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
 
       <DrawerHeader>ドラゴンボール</DrawerHeader>
@@ -420,7 +420,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Drawer</Button>
 
-    <Drawer isOpen={isOpen} onClose={onClose} withOverlay={false}>
+    <Drawer open={isOpen} onClose={onClose} withOverlay={false}>
       <DrawerHeader>ドラゴンボール</DrawerHeader>
 
       <DrawerBody>

--- a/docs/contents/components/overlay/drawer/props.ja.mdx
+++ b/docs/contents/components/overlay/drawer/props.ja.mdx
@@ -13,7 +13,7 @@ tab: Props
 
 <PropsCard
   id="drawer-isopen"
-  name="isOpen"
+  name="open"
   required
   type="boolean"
   description={"If `true`, the open will be opened."}

--- a/docs/contents/components/overlay/drawer/props.mdx
+++ b/docs/contents/components/overlay/drawer/props.mdx
@@ -13,7 +13,7 @@ tab: Props
 
 <PropsCard
   id="drawer-isopen"
-  name="isOpen"
+  name="open"
   required
   type="boolean"
   description={"If `true`, the open will be opened."}

--- a/docs/contents/components/overlay/menu/index.ja.mdx
+++ b/docs/contents/components/overlay/menu/index.ja.mdx
@@ -435,7 +435,7 @@ return (
 const { isOpen, onOpen, onClose } = useDisclosure()
 
 return (
-  <Menu isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
+  <Menu open={isOpen} onOpen={onOpen} onClose={onClose}>
     <MenuButton as={Button} rightIcon={<ChevronDown fontSize="xl" />}>
       Menu
     </MenuButton>

--- a/docs/contents/components/overlay/menu/index.mdx
+++ b/docs/contents/components/overlay/menu/index.mdx
@@ -439,7 +439,7 @@ If you want to delay rendering until it becomes active, set `isLazy` to `true`.
 const { isOpen, onOpen, onClose } = useDisclosure()
 
 return (
-  <Menu isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
+  <Menu open={isOpen} onOpen={onOpen} onClose={onClose}>
     <MenuButton as={Button} rightIcon={<ChevronDown fontSize="xl" />}>
       Menu
     </MenuButton>

--- a/docs/contents/components/overlay/menu/props.ja.mdx
+++ b/docs/contents/components/overlay/menu/props.ja.mdx
@@ -142,7 +142,7 @@ tab: Props
 
 <PropsCard
   id="contextmenu-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />
@@ -379,7 +379,7 @@ tab: Props
 
 <PropsCard
   id="menu-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />

--- a/docs/contents/components/overlay/menu/props.mdx
+++ b/docs/contents/components/overlay/menu/props.mdx
@@ -142,7 +142,7 @@ tab: Props
 
 <PropsCard
   id="contextmenu-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />
@@ -379,7 +379,7 @@ tab: Props
 
 <PropsCard
   id="menu-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />

--- a/docs/contents/components/overlay/modal/accessibility.ja.mdx
+++ b/docs/contents/components/overlay/modal/accessibility.ja.mdx
@@ -25,7 +25,7 @@ return (
       Open Modal
     </Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>

--- a/docs/contents/components/overlay/modal/accessibility.mdx
+++ b/docs/contents/components/overlay/modal/accessibility.mdx
@@ -27,7 +27,7 @@ return (
       Open Modal
     </Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -50,11 +50,11 @@ return (
 
 When the `Modal` opens, focus is trapped within it. That is, you cannot focus on elements outside the modal unless the modal is closed.
 
-| Key             | Description                                                                                                                                                    | State                                 |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `Tab`           | Focuses the next element within the modal that is not disabled. If it's the last element, focuses the first element within the modal that is not disabled.     | `isOpen={true}`                       |
-| `Shift` + `Tab` | Focuses the previous element within the modal that is not disabled. If it's the first element, focuses the last element within the modal that is not disabled. | `isOpen={true}`                       |
-| `Escape`        | Closes the modal.                                                                                                                                              | `isOpen={true}` + `closeOnEsc={true}` |
+| Key             | Description                                                                                                                                                    | State                               |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `Tab`           | Focuses the next element within the modal that is not disabled. If it's the last element, focuses the first element within the modal that is not disabled.     | `open={true}`                       |
+| `Shift` + `Tab` | Focuses the previous element within the modal that is not disabled. If it's the first element, focuses the last element within the modal that is not disabled. | `open={true}`                       |
+| `Escape`        | Closes the modal.                                                                                                                                              | `open={true}` + `closeOnEsc={true}` |
 
 ## ARIA Roles and Attributes
 

--- a/docs/contents/components/overlay/modal/index.ja.mdx
+++ b/docs/contents/components/overlay/modal/index.ja.mdx
@@ -34,7 +34,7 @@ import {
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`と`onClose`を設定します。
+表示または非表示を制御するために、`open`と`onClose`を設定します。
 
 ```tsx functional=true
 const { isOpen, onOpen, onClose } = useDisclosure()
@@ -43,7 +43,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -97,7 +97,7 @@ return (
       ))}
     </Wrap>
 
-    <Modal isOpen={isOpen} onClose={onClose} size={size}>
+    <Modal open={isOpen} onClose={onClose} size={size}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -151,7 +151,7 @@ return (
       ))}
     </Wrap>
 
-    <Modal isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Modal open={isOpen} onClose={onClose} placement={placement}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -195,7 +195,7 @@ return (
       ))}
     </Wrap>
 
-    <Modal isOpen={isOpen} onClose={onClose} animation={animation}>
+    <Modal open={isOpen} onClose={onClose} animation={animation}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -225,7 +225,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose} duration={0.4}>
+    <Modal open={isOpen} onClose={onClose} duration={0.4}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -274,7 +274,7 @@ return (
     </Wrap>
 
     <Modal
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       scrollBehavior={scrollBehavior}
       h="xl"
@@ -332,7 +332,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose} blockScrollOnMount={false}>
+    <Modal open={isOpen} onClose={onClose} blockScrollOnMount={false}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -362,7 +362,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
 
       <ModalHeader>ドラゴンボール</ModalHeader>
@@ -394,7 +394,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose} withOverlay={false}>
+    <Modal open={isOpen} onClose={onClose} withOverlay={false}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -424,7 +424,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalCloseButton color="red.500" />
 
       <ModalHeader>ドラゴンボール</ModalHeader>
@@ -460,7 +460,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen}>
+    <Modal open={isOpen}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -489,7 +489,7 @@ return (
   <>
     <Button onClick={firstControls.onOpen}>Open Modal</Button>
 
-    <Modal isOpen={firstControls.isOpen} onClose={firstControls.onClose}>
+    <Modal open={firstControls.isOpen} onClose={firstControls.onClose}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -507,7 +507,7 @@ return (
       </ModalFooter>
 
       <Modal
-        isOpen={secondControls.isOpen}
+        open={secondControls.isOpen}
         onClose={secondControls.onClose}
         size="sm"
       >

--- a/docs/contents/components/overlay/modal/index.mdx
+++ b/docs/contents/components/overlay/modal/index.mdx
@@ -36,7 +36,7 @@ import {
 
 ## Usage
 
-To control the display or hide, set `isOpen` and `onClose`.
+To control the display or hide, set `open` and `onClose`.
 
 ```tsx functional=true
 const { isOpen, onOpen, onClose } = useDisclosure()
@@ -45,7 +45,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -99,7 +99,7 @@ return (
       ))}
     </Wrap>
 
-    <Modal isOpen={isOpen} onClose={onClose} size={size}>
+    <Modal open={isOpen} onClose={onClose} size={size}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -153,7 +153,7 @@ return (
       ))}
     </Wrap>
 
-    <Modal isOpen={isOpen} onClose={onClose} placement={placement}>
+    <Modal open={isOpen} onClose={onClose} placement={placement}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -197,7 +197,7 @@ return (
       ))}
     </Wrap>
 
-    <Modal isOpen={isOpen} onClose={onClose} animation={animation}>
+    <Modal open={isOpen} onClose={onClose} animation={animation}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -227,7 +227,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose} duration={0.4}>
+    <Modal open={isOpen} onClose={onClose} duration={0.4}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -276,7 +276,7 @@ return (
     </Wrap>
 
     <Modal
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       scrollBehavior={scrollBehavior}
       h="xl"
@@ -334,7 +334,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose} blockScrollOnMount={false}>
+    <Modal open={isOpen} onClose={onClose} blockScrollOnMount={false}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -364,7 +364,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
 
       <ModalHeader>ドラゴンボール</ModalHeader>
@@ -396,7 +396,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose} withOverlay={false}>
+    <Modal open={isOpen} onClose={onClose} withOverlay={false}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -426,7 +426,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal open={isOpen} onClose={onClose}>
       <ModalCloseButton color="red.500" />
 
       <ModalHeader>ドラゴンボール</ModalHeader>
@@ -462,7 +462,7 @@ return (
   <>
     <Button onClick={onOpen}>Open Modal</Button>
 
-    <Modal isOpen={isOpen}>
+    <Modal open={isOpen}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -491,7 +491,7 @@ return (
   <>
     <Button onClick={firstControls.onOpen}>Open Modal</Button>
 
-    <Modal isOpen={firstControls.isOpen} onClose={firstControls.onClose}>
+    <Modal open={firstControls.isOpen} onClose={firstControls.onClose}>
       <ModalHeader>ドラゴンボール</ModalHeader>
 
       <ModalBody>
@@ -509,7 +509,7 @@ return (
       </ModalFooter>
 
       <Modal
-        isOpen={secondControls.isOpen}
+        open={secondControls.isOpen}
         onClose={secondControls.onClose}
         size="sm"
       >

--- a/docs/contents/components/overlay/modal/props.ja.mdx
+++ b/docs/contents/components/overlay/modal/props.ja.mdx
@@ -13,7 +13,7 @@ tab: Props
 
 <PropsCard
   id="modal-isopen"
-  name="isOpen"
+  name="open"
   required
   type="boolean"
   description={"If `true`, the open will be opened."}

--- a/docs/contents/components/overlay/modal/props.mdx
+++ b/docs/contents/components/overlay/modal/props.mdx
@@ -15,7 +15,7 @@ tab: Props
 
 <PropsCard
   id="modal-isopen"
-  name="isOpen"
+  name="open"
   required
   type="boolean"
   description={"If `true`, the open will be opened."}

--- a/docs/contents/components/overlay/popover/index.ja.mdx
+++ b/docs/contents/components/overlay/popover/index.ja.mdx
@@ -437,7 +437,7 @@ return (
       Open Popover
     </Button>
 
-    <Popover isOpen={isOpen} onClose={onClose} closeOnBlur={false}>
+    <Popover open={isOpen} onClose={onClose} closeOnBlur={false}>
       <PopoverTrigger>
         <Button colorScheme="primary">Target Popover</Button>
       </PopoverTrigger>

--- a/docs/contents/components/overlay/popover/index.mdx
+++ b/docs/contents/components/overlay/popover/index.mdx
@@ -437,7 +437,7 @@ return (
       Open Popover
     </Button>
 
-    <Popover isOpen={isOpen} onClose={onClose} closeOnBlur={false}>
+    <Popover open={isOpen} onClose={onClose} closeOnBlur={false}>
       <PopoverTrigger>
         <Button colorScheme="primary">Target Popover</Button>
       </PopoverTrigger>

--- a/docs/contents/components/overlay/popover/props.ja.mdx
+++ b/docs/contents/components/overlay/popover/props.ja.mdx
@@ -113,7 +113,7 @@ order: 1
 
 <PropsCard
   id="combobox-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />
@@ -336,7 +336,7 @@ order: 1
 
 <PropsCard
   id="popover-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />

--- a/docs/contents/components/overlay/popover/props.mdx
+++ b/docs/contents/components/overlay/popover/props.mdx
@@ -113,7 +113,7 @@ order: 1
 
 <PropsCard
   id="combobox-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />
@@ -336,7 +336,7 @@ order: 1
 
 <PropsCard
   id="popover-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the popover will be opened."}
 />

--- a/docs/contents/components/overlay/tooltip/index.ja.mdx
+++ b/docs/contents/components/overlay/tooltip/index.ja.mdx
@@ -164,10 +164,10 @@ import { Tooltip } from "@yamada-ui/react"
 
 ### 常に表示する
 
-ツールチップを常に表示するには、`isOpen`を`true`に設定します。
+ツールチップを常に表示するには、`open`を`true`に設定します。
 
 ```tsx
-<Tooltip label="へっ！きたねぇ花火だ" isOpen>
+<Tooltip label="へっ！きたねぇ花火だ" open>
   <Text w="fit-content">Please Hover</Text>
 </Tooltip>
 ```

--- a/docs/contents/components/overlay/tooltip/index.mdx
+++ b/docs/contents/components/overlay/tooltip/index.mdx
@@ -166,10 +166,10 @@ To disable the tooltip, set `isDisabled` to `true`.
 
 ### Always Display
 
-To always display the tooltip, set `isOpen` to `true`.
+To always display the tooltip, set `open` to `true`.
 
 ```tsx
-<Tooltip label="へっ！きたねぇ花火だ" isOpen>
+<Tooltip label="へっ！きたねぇ花火だ" open>
   <Text w="fit-content">Please Hover</Text>
 </Tooltip>
 ```

--- a/docs/contents/components/overlay/tooltip/props.ja.mdx
+++ b/docs/contents/components/overlay/tooltip/props.ja.mdx
@@ -108,7 +108,7 @@ order: 1
 
 <PropsCard
   id="tooltip-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the tooltip will be shown."}
 />

--- a/docs/contents/components/overlay/tooltip/props.mdx
+++ b/docs/contents/components/overlay/tooltip/props.mdx
@@ -110,7 +110,7 @@ order: 1
 
 <PropsCard
   id="tooltip-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"If `true`, the tooltip will be shown."}
 />

--- a/docs/contents/components/transitions/collapse/index.ja.mdx
+++ b/docs/contents/components/transitions/collapse/index.ja.mdx
@@ -15,7 +15,7 @@ import { Collapse } from "@yamada-ui/react"
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`を設定します。
+表示または非表示を制御するために、`open`を設定します。
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -24,7 +24,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen}>
+    <Collapse open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -44,7 +44,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} duration={0.7}>
+    <Collapse open={isOpen} duration={0.7}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -64,7 +64,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} unmountOnExit>
+    <Collapse open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -84,7 +84,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} animationOpacity={false}>
+    <Collapse open={isOpen} animationOpacity={false}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -104,7 +104,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} startingHeight={36}>
+    <Collapse open={isOpen} startingHeight={36}>
       <Box color="purple.500" mt="md">
         私の戦闘力は530000です。
         <br />

--- a/docs/contents/components/transitions/collapse/index.mdx
+++ b/docs/contents/components/transitions/collapse/index.mdx
@@ -17,7 +17,7 @@ import { Collapse } from "@yamada-ui/react"
 
 ## Usage
 
-To control the visibility, set `isOpen`.
+To control the visibility, set `open`.
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -26,7 +26,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen}>
+    <Collapse open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -46,7 +46,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} duration={0.7}>
+    <Collapse open={isOpen} duration={0.7}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -66,7 +66,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} unmountOnExit>
+    <Collapse open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -86,7 +86,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} animationOpacity={false}>
+    <Collapse open={isOpen} animationOpacity={false}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -106,7 +106,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Collapse isOpen={isOpen} startingHeight={36}>
+    <Collapse open={isOpen} startingHeight={36}>
       <Box color="purple.500" mt="md">
         私の戦闘力は530000です。
         <br />

--- a/docs/contents/components/transitions/collapse/props.ja.mdx
+++ b/docs/contents/components/transitions/collapse/props.ja.mdx
@@ -82,7 +82,7 @@ order: 1
 
 <PropsCard
   id="collapse-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -121,7 +121,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/collapse/props.mdx
+++ b/docs/contents/components/transitions/collapse/props.mdx
@@ -84,7 +84,7 @@ order: 1
 
 <PropsCard
   id="collapse-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -123,7 +123,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/fade/index.ja.mdx
+++ b/docs/contents/components/transitions/fade/index.ja.mdx
@@ -15,7 +15,7 @@ import { Fade } from "@yamada-ui/react"
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`を設定します。
+表示または非表示を制御するために、`open`を設定します。
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -24,7 +24,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Fade isOpen={isOpen}>
+    <Fade open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -44,7 +44,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Fade isOpen={isOpen} duration={0.4}>
+    <Fade open={isOpen} duration={0.4}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -64,7 +64,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Fade isOpen={isOpen} unmountOnExit>
+    <Fade open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>

--- a/docs/contents/components/transitions/fade/index.mdx
+++ b/docs/contents/components/transitions/fade/index.mdx
@@ -15,7 +15,7 @@ import { Fade } from "@yamada-ui/react"
 
 ## Usage
 
-To control the visibility, set `isOpen`.
+To control the visibility, set `open`.
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -24,7 +24,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Fade isOpen={isOpen}>
+    <Fade open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -44,7 +44,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Fade isOpen={isOpen} duration={0.4}>
+    <Fade open={isOpen} duration={0.4}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -64,7 +64,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Fade isOpen={isOpen} unmountOnExit>
+    <Fade open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>

--- a/docs/contents/components/transitions/fade/props.ja.mdx
+++ b/docs/contents/components/transitions/fade/props.ja.mdx
@@ -59,7 +59,7 @@ order: 1
 
 <PropsCard
   id="fade-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -83,6 +83,6 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />

--- a/docs/contents/components/transitions/fade/props.mdx
+++ b/docs/contents/components/transitions/fade/props.mdx
@@ -59,7 +59,7 @@ order: 1
 
 <PropsCard
   id="fade-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -83,6 +83,6 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />

--- a/docs/contents/components/transitions/scale-fade/index.ja.mdx
+++ b/docs/contents/components/transitions/scale-fade/index.ja.mdx
@@ -15,7 +15,7 @@ import { ScaleFade } from "@yamada-ui/react"
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`を設定します。
+表示または非表示を制御するために、`open`を設定します。
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -24,7 +24,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen}>
+    <ScaleFade open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -44,7 +44,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen} scale={0.75}>
+    <ScaleFade open={isOpen} scale={0.75}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -64,7 +64,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen} duration={0.4}>
+    <ScaleFade open={isOpen} duration={0.4}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -84,7 +84,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen} unmountOnExit>
+    <ScaleFade open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>

--- a/docs/contents/components/transitions/scale-fade/index.mdx
+++ b/docs/contents/components/transitions/scale-fade/index.mdx
@@ -17,7 +17,7 @@ import { ScaleFade } from "@yamada-ui/react"
 
 ## Usage
 
-To control the visibility, set `isOpen`.
+To control the visibility, set `open`.
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -26,7 +26,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen}>
+    <ScaleFade open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -46,7 +46,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen} scale={0.75}>
+    <ScaleFade open={isOpen} scale={0.75}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -66,7 +66,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen} duration={0.4}>
+    <ScaleFade open={isOpen} duration={0.4}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -86,7 +86,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <ScaleFade isOpen={isOpen} unmountOnExit>
+    <ScaleFade open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>

--- a/docs/contents/components/transitions/scale-fade/props.ja.mdx
+++ b/docs/contents/components/transitions/scale-fade/props.ja.mdx
@@ -66,7 +66,7 @@ order: 1
 
 <PropsCard
   id="scalefade-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -113,7 +113,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/scale-fade/props.mdx
+++ b/docs/contents/components/transitions/scale-fade/props.mdx
@@ -68,7 +68,7 @@ order: 1
 
 <PropsCard
   id="scalefade-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -115,7 +115,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/slide-fade/index.ja.mdx
+++ b/docs/contents/components/transitions/slide-fade/index.ja.mdx
@@ -15,7 +15,7 @@ import { SlideFade } from "@yamada-ui/react"
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`を設定します。
+表示または非表示を制御するために、`open`を設定します。
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -24,7 +24,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen}>
+    <SlideFade open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -44,7 +44,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} duration={0.4}>
+    <SlideFade open={isOpen} duration={0.4}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -67,7 +67,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} offsetX={20} offsetY={0}>
+    <SlideFade open={isOpen} offsetX={20} offsetY={0}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -83,7 +83,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} offsetY={-20}>
+    <SlideFade open={isOpen} offsetY={-20}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -103,7 +103,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} unmountOnExit>
+    <SlideFade open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>

--- a/docs/contents/components/transitions/slide-fade/index.mdx
+++ b/docs/contents/components/transitions/slide-fade/index.mdx
@@ -17,7 +17,7 @@ import { SlideFade } from "@yamada-ui/react"
 
 ## Usage
 
-To control the visibility, set `isOpen`.
+To control the visibility, set `open`.
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -26,7 +26,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen}>
+    <SlideFade open={isOpen}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -46,7 +46,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} duration={0.4}>
+    <SlideFade open={isOpen} duration={0.4}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -69,7 +69,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} offsetX={20} offsetY={0}>
+    <SlideFade open={isOpen} offsetX={20} offsetY={0}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -85,7 +85,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} offsetY={-20}>
+    <SlideFade open={isOpen} offsetY={-20}>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>
@@ -105,7 +105,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <SlideFade isOpen={isOpen} unmountOnExit>
+    <SlideFade open={isOpen} unmountOnExit>
       <Box w="full" bg="orange.500" rounded="md" p="md" color="white" mt="md">
         クリリンのことか……クリリンのことかーーーっ！！！！！
       </Box>

--- a/docs/contents/components/transitions/slide-fade/props.ja.mdx
+++ b/docs/contents/components/transitions/slide-fade/props.ja.mdx
@@ -66,7 +66,7 @@ order: 1
 
 <PropsCard
   id="slidefade-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -123,7 +123,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/slide-fade/props.mdx
+++ b/docs/contents/components/transitions/slide-fade/props.mdx
@@ -68,7 +68,7 @@ order: 1
 
 <PropsCard
   id="slidefade-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -125,7 +125,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/slide/index.ja.mdx
+++ b/docs/contents/components/transitions/slide/index.ja.mdx
@@ -15,7 +15,7 @@ import { Slide } from "@yamada-ui/react"
 
 ## 使い方
 
-表示または非表示を制御するために、`isOpen`を設定します。
+表示または非表示を制御するために、`open`を設定します。
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -24,7 +24,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Slide isOpen={isOpen} placement="bottom">
+    <Slide open={isOpen} placement="bottom">
       <VStack w="full" bg="orange.500" p="md">
         <Text color="white">
           クリリンのことか……クリリンのことかーーーっ！！！！！
@@ -50,7 +50,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Slide isOpen={isOpen} placement="bottom" duration={0.7}>
+    <Slide open={isOpen} placement="bottom" duration={0.7}>
       <VStack w="full" bg="orange.500" p="md">
         <Text color="white">
           クリリンのことか……クリリンのことかーーーっ！！！！！
@@ -76,7 +76,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Slide isOpen={isOpen} placement="left" zIndex="sonGoku">
+    <Slide open={isOpen} placement="left" zIndex="sonGoku">
       <VStack w="full" bg="orange.500" p="md">
         <Text color="white">
           クリリンのことか……クリリンのことかーーーっ！！！！！

--- a/docs/contents/components/transitions/slide/index.mdx
+++ b/docs/contents/components/transitions/slide/index.mdx
@@ -17,7 +17,7 @@ import { Slide } from "@yamada-ui/react"
 
 ## Usage
 
-To control the visibility, set `isOpen`.
+To control the visibility, set `open`.
 
 ```tsx functional=true
 const { isOpen, onToggle } = useDisclosure()
@@ -26,7 +26,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Slide isOpen={isOpen} placement="bottom">
+    <Slide open={isOpen} placement="bottom">
       <VStack w="full" bg="orange.500" p="md">
         <Text color="white">
           クリリンのことか……クリリンのことかーーーっ！！！！！
@@ -52,7 +52,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Slide isOpen={isOpen} placement="bottom" duration={0.7}>
+    <Slide open={isOpen} placement="bottom" duration={0.7}>
       <VStack w="full" bg="orange.500" p="md">
         <Text color="white">
           クリリンのことか……クリリンのことかーーーっ！！！！！
@@ -78,7 +78,7 @@ return (
   <>
     <Button onClick={onToggle}>Please Click</Button>
 
-    <Slide isOpen={isOpen} placement="left" zIndex="sonGoku">
+    <Slide open={isOpen} placement="left" zIndex="sonGoku">
       <VStack w="full" bg="orange.500" p="md">
         <Text color="white">
           クリリンのことか……クリリンのことかーーーっ！！！！！

--- a/docs/contents/components/transitions/slide/props.ja.mdx
+++ b/docs/contents/components/transitions/slide/props.ja.mdx
@@ -66,7 +66,7 @@ order: 1
 
 <PropsCard
   id="slide-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -105,7 +105,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/components/transitions/slide/props.mdx
+++ b/docs/contents/components/transitions/slide/props.mdx
@@ -68,7 +68,7 @@ order: 1
 
 <PropsCard
   id="slide-isopen"
-  name="isOpen"
+  name="open"
   type="boolean"
   description={"Show the component. triggers when enter or exit states."}
 />
@@ -107,7 +107,7 @@ order: 1
   name="unmountOnExit"
   type="boolean"
   description={
-    "If `true`, the element will unmount when `isOpen={false}` and animation is done."
+    "If `true`, the element will unmount when `open={false}` and animation is done."
   }
 />
 

--- a/docs/contents/hooks/use-disclosure.ja.mdx
+++ b/docs/contents/hooks/use-disclosure.ja.mdx
@@ -22,7 +22,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="孫悟空"
       cancel="わけない"
@@ -56,7 +56,7 @@ return (
     <Button onClick={() => onOpen("This is arg")}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={() => onClose("This is arg")}
       header="孫悟空"
       cancel="わけない"
@@ -93,7 +93,7 @@ return (
     <Button onClick={() => onOpen("This is arg")}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={() => onClose("This is arg")}
       header="孫悟空"
       cancel="わけない"

--- a/docs/contents/hooks/use-disclosure.mdx
+++ b/docs/contents/hooks/use-disclosure.mdx
@@ -24,7 +24,7 @@ return (
     <Button onClick={onOpen}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={onClose}
       header="Son Goku"
       cancel="No way"
@@ -58,7 +58,7 @@ return (
     <Button onClick={() => onOpen("This is arg")}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={() => onClose("This is arg")}
       header="Son Goku"
       cancel="No way"
@@ -95,7 +95,7 @@ return (
     <Button onClick={() => onOpen("This is arg")}>Open Dialog</Button>
 
     <Dialog
-      isOpen={isOpen}
+      open={isOpen}
       onClose={() => onClose("This is arg")}
       header="Son Goku"
       cancel="No way"

--- a/docs/pages/examples/music/content.tsx
+++ b/docs/pages/examples/music/content.tsx
@@ -287,7 +287,7 @@ const ContentPodcasts: FC<ContentPodcastsProps> = memo(({ ...rest }) => {
         </Center>
       </ContentItem>
 
-      <Modal size="xl" isOpen={isOpen} onClose={onClose}>
+      <Modal size="xl" open={isOpen} onClose={onClose}>
         <ModalHeader>Add Podcast</ModalHeader>
 
         <ModalBody

--- a/docs/pages/examples/playground/header/delete-dialog.tsx
+++ b/docs/pages/examples/playground/header/delete-dialog.tsx
@@ -4,7 +4,7 @@ import { assignRef, Dialog, Text, useDisclosure } from "@yamada-ui/react"
 import { memo } from "react"
 
 export interface DeleteDialogProps
-  extends Omit<DialogProps, "isOpen" | "onClose"> {
+  extends Omit<DialogProps, "onClose" | "open"> {
   onOpenRef: MutableRefObject<() => void>
 }
 
@@ -19,7 +19,7 @@ export const DeleteDialog: FC<DeleteDialogProps> = memo(
         size="xl"
         cancel="Cancel"
         header="Are you absolutely sure?"
-        isOpen={isOpen}
+        open={isOpen}
         success={{ colorScheme: "danger", children: "Delete" }}
         onCancel={onClose}
         onClose={onClose}

--- a/docs/pages/examples/playground/header/filter-modal.tsx
+++ b/docs/pages/examples/playground/header/filter-modal.tsx
@@ -13,8 +13,7 @@ import {
 } from "@yamada-ui/react"
 import { memo } from "react"
 
-export interface FilterModalProps
-  extends Omit<ModalProps, "isOpen" | "onClose"> {
+export interface FilterModalProps extends Omit<ModalProps, "onClose" | "open"> {
   onOpenRef: MutableRefObject<() => void>
 }
 
@@ -25,7 +24,7 @@ export const FilterModal: FC<FilterModalProps> = memo(
     assignRef(onOpenRef, onOpen)
 
     return (
-      <Modal size="xl" isOpen={isOpen} onClose={onClose} {...rest}>
+      <Modal size="xl" open={isOpen} onClose={onClose} {...rest}>
         <ModalHeader alignItems="flex-start" flexDirection="column" gap="sm">
           <Text as="h3">Save preset</Text>
 

--- a/docs/pages/examples/playground/header/save-modal.tsx
+++ b/docs/pages/examples/playground/header/save-modal.tsx
@@ -14,7 +14,7 @@ import {
 } from "@yamada-ui/react"
 import { memo } from "react"
 
-export interface SaveModalProps extends Omit<ModalProps, "isOpen" | "onClose"> {
+export interface SaveModalProps extends Omit<ModalProps, "onClose" | "open"> {
   onOpenRef: MutableRefObject<() => void>
 }
 
@@ -24,7 +24,7 @@ export const SaveModal: FC<SaveModalProps> = memo(({ onOpenRef, ...rest }) => {
   assignRef(onOpenRef, onOpen)
 
   return (
-    <Modal size="xl" isOpen={isOpen} onClose={onClose} {...rest}>
+    <Modal size="xl" open={isOpen} onClose={onClose} {...rest}>
       <ModalHeader alignItems="flex-start" flexDirection="column" gap="sm">
         <Text as="h3">Save preset</Text>
 

--- a/docs/pages/examples/playground/header/view-code-modal.tsx
+++ b/docs/pages/examples/playground/header/view-code-modal.tsx
@@ -32,7 +32,7 @@ response = openai.Completion.create(
 )`
 
 export interface ViewCodeModalProps
-  extends Omit<ModalProps, "isOpen" | "onClose"> {
+  extends Omit<ModalProps, "onClose" | "open"> {
   onOpenRef: MutableRefObject<() => void>
 }
 
@@ -43,7 +43,7 @@ export const ViewCodeModal: FC<ViewCodeModalProps> = memo(
     assignRef(onOpenRef, onOpen)
 
     return (
-      <Modal size="xl" isOpen={isOpen} onClose={onClose} {...rest}>
+      <Modal size="xl" open={isOpen} onClose={onClose} {...rest}>
         <ModalHeader alignItems="flex-start" flexDirection="column" gap="sm">
           <Text as="h3">Save preset</Text>
 

--- a/docs/pages/icons/icon-drawer.tsx
+++ b/docs/pages/icons/icon-drawer.tsx
@@ -32,7 +32,7 @@ export const IconDrawer: FC<IconDrawerProps> = memo(({ openRef }) => {
   })
 
   return (
-    <Slide boxShadow={["lg", "dark-lg"]} isOpen={isOpen} placement="bottom">
+    <Slide boxShadow={["lg", "dark-lg"]} open={isOpen} placement="bottom">
       <Grid
         alignItems="stretch"
         bg={["white", "black"]}

--- a/docs/pages/insights/insights-header.tsx
+++ b/docs/pages/insights/insights-header.tsx
@@ -165,8 +165,8 @@ const UserSelect: FC<UserSelectProps> = memo(() => {
           </VStack>
         </Box>
       }
-      isOpen={isOpen}
       items={items}
+      open={isOpen}
       value={users}
       w={{ base: "64", md: "full" }}
       clearIconProps={{

--- a/examples/create-react-app/src/components/layouts/header.tsx
+++ b/examples/create-react-app/src/components/layouts/header.tsx
@@ -181,7 +181,6 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
       <Popover
         {...popoverProps}
         closeOnButton={false}
-        isOpen={isOpen}
         modifiers={[
           {
             name: "preventOverflow",
@@ -195,6 +194,7 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
             },
           },
         ]}
+        open={isOpen}
         restoreFocus={false}
         onClose={onClose}
         onOpen={onOpen}

--- a/examples/hono/src/components/layouts/header.tsx
+++ b/examples/hono/src/components/layouts/header.tsx
@@ -181,7 +181,6 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
       <Popover
         {...popoverProps}
         closeOnButton={false}
-        isOpen={isOpen}
         modifiers={[
           {
             name: "preventOverflow",
@@ -195,6 +194,7 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
             },
           },
         ]}
+        open={isOpen}
         restoreFocus={false}
         onClose={onClose}
         onOpen={onOpen}

--- a/examples/next/app/components/layouts/header.tsx
+++ b/examples/next/app/components/layouts/header.tsx
@@ -175,7 +175,6 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(({ popoverProps, ...r
     <Popover
       {...popoverProps}
       closeOnButton={false}
-      isOpen={isOpen}
       modifiers={[
         {
           name: 'preventOverflow',
@@ -189,6 +188,7 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(({ popoverProps, ...r
           },
         },
       ]}
+      open={isOpen}
       restoreFocus={false}
       onClose={onClose}
       onOpen={onOpen}

--- a/examples/next/pages/components/layouts/header.tsx
+++ b/examples/next/pages/components/layouts/header.tsx
@@ -173,7 +173,6 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(({ popoverProps, ...r
     <Popover
       {...popoverProps}
       closeOnButton={false}
-      isOpen={isOpen}
       modifiers={[
         {
           name: 'preventOverflow',
@@ -187,6 +186,7 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(({ popoverProps, ...r
           },
         },
       ]}
+      open={isOpen}
       restoreFocus={false}
       onClose={onClose}
       onOpen={onOpen}

--- a/examples/remix/app/components/layouts/header.tsx
+++ b/examples/remix/app/components/layouts/header.tsx
@@ -181,7 +181,6 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
       <Popover
         {...popoverProps}
         closeOnButton={false}
-        isOpen={isOpen}
         modifiers={[
           {
             name: "preventOverflow",
@@ -195,6 +194,7 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
             },
           },
         ]}
+        open={isOpen}
         restoreFocus={false}
         onClose={onClose}
         onOpen={onOpen}

--- a/examples/vite/src/components/layouts/header.tsx
+++ b/examples/vite/src/components/layouts/header.tsx
@@ -181,7 +181,6 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
       <Popover
         {...popoverProps}
         closeOnButton={false}
-        isOpen={isOpen}
         modifiers={[
           {
             name: "preventOverflow",
@@ -195,6 +194,7 @@ const ThemeSchemeButton: FC<ThemeSchemeButtonProps> = memo(
             },
           },
         ]}
+        open={isOpen}
         restoreFocus={false}
         onClose={onClose}
         onOpen={onOpen}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Related #3302

## Description

This is a documentation change: remove the `is` prefix for `isOpen` in the props

## Current behavior (updates)

Docs: props in components were using `isOpen`

## New behavior

Docs: props in components are now using `open`

## Is this a breaking change (Yes/No):

No

## Additional Information
Since #3302 is quite large, and this PR is only to rename `isOpen`
