### PR TITLE
Remove unnecessary code in next pages example

### DIFF
--- a/examples/next/pages/pages/index.tsx
+++ b/examples/next/pages/pages/index.tsx
@@ -1,16 +1,10 @@
 import type { GetServerSidePropsContext, NextPage } from 'next'
-import { RangeSlider, Slider } from '@yamada-ui/react'
 import { Layout } from 'components/layouts'
 
 interface Props {}
 
 const Page: NextPage<Props> = () => {
-  return (
-    <Layout>
-      <RangeSlider />
-      <Slider />
-    </Layout>
-  )
+  return <Layout />
 }
 
 export default Page


### PR DESCRIPTION
Related #3072 

## Description

<!-- Add a brief description. -->
Remove the `Slider' and `RangeSlider' test code that remains in the next-pages example.


## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No
## Additional Information
