### PR TITLE
refactor(breadcrumb): ｍove `Breadcrumb` logic to use-breadcrumb.tsx

### DIFF
--- a/packages/components/breadcrumb/src/breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/breadcrumb.tsx
@@ -23,12 +23,11 @@ import {
   runIfFunc,
 } from "@yamada-ui/utils"
 import { cloneElement, Fragment, useCallback, useMemo } from "react"
-
-const [BreadcrumbProvider, useBreadcrumb] = createContext<{
+const [BreadcrumbProvider, useBreadcrumbStyles] = createContext<{
   [key: string]: CSSUIObject | undefined
 }>({
   name: "BreadcrumbContext",
-  errorMessage: `useBreadcrumb returned is 'undefined'. Seems you forgot to wrap the components in "<Breadcrumb />" `,
+  errorMessage: `useBreadcrumbStyles returned is 'undefined'. Seems you forgot to wrap the components in "<Breadcrumb />" `,
 })
 
 export interface BreadcrumbGenerateItem extends BreadcrumbLinkProps {
@@ -274,7 +273,7 @@ export const BreadcrumbItem = forwardRef<BreadcrumbItemProps, "li">(
     },
     ref,
   ) => {
-    const styles = useBreadcrumb()
+    const styles = useBreadcrumbStyles()
 
     const validChildren = getValidChildren(children)
 
@@ -336,7 +335,7 @@ export interface BreadcrumbLinkProps
 
 export const BreadcrumbLink = forwardRef<BreadcrumbLinkProps, "a">(
   ({ href, className, children, isCurrentPage, ...rest }, ref) => {
-    const styles = useBreadcrumb()
+    const styles = useBreadcrumbStyles()
 
     return (
       <ui.a
@@ -369,7 +368,7 @@ export interface BreadcrumbSeparatorProps
 
 export const BreadcrumbSeparator = forwardRef<BreadcrumbSeparatorProps, "span">(
   ({ children, gap: mx, ...rest }, ref) => {
-    const styles = useBreadcrumb()
+    const styles = useBreadcrumbStyles()
     const css: CSSUIObject = {
       mx,
       ...styles.separator,
@@ -399,7 +398,7 @@ export interface BreadcrumbEllipsisProps
 
 export const BreadcrumbEllipsis = forwardRef<BreadcrumbEllipsisProps, "span">(
   ({ className, children, ...rest }, ref) => {
-    const styles = useBreadcrumb()
+    const styles = useBreadcrumbStyles()
 
     const css: CSSUIObject = {
       ...styles.ellipsis,

--- a/packages/components/breadcrumb/src/breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/breadcrumb.tsx
@@ -15,14 +15,10 @@ import {
 } from "@yamada-ui/core"
 import { Icon } from "@yamada-ui/icon"
 import { useValue } from "@yamada-ui/use-value"
-import {
-  createContext,
-  cx,
-  getValidChildren,
-  isNumber,
-  runIfFunc,
-} from "@yamada-ui/utils"
-import { cloneElement, Fragment, useCallback, useMemo } from "react"
+import { createContext, cx, getValidChildren } from "@yamada-ui/utils"
+import { cloneElement } from "react"
+import { useBreadcrumb } from "./use-breadcrumb"
+
 const [BreadcrumbProvider, useBreadcrumbStyles] = createContext<{
   [key: string]: CSSUIObject | undefined
 }>({
@@ -107,118 +103,21 @@ export const Breadcrumb = forwardRef<BreadcrumbProps, "nav">((props, ref) => {
   if (startBoundaries) endBoundaries ??= 1
   if (endBoundaries) startBoundaries ??= 1
 
-  const hasBoundaries = isNumber(startBoundaries) && isNumber(endBoundaries)
-  const isExceed =
-    hasBoundaries && startBoundaries! + endBoundaries! < items.length
+  const cloneChildren = useBreadcrumb({
+    children,
+    ellipsis,
+    endBoundaries,
+    gap,
+    items,
+    separator,
+    startBoundaries,
+  })
 
   const css: CSSUIObject = {
     alignItems: "center",
     display: "flex",
     ...styles.container,
   }
-
-  const validChildren = getValidChildren(children)
-  const hasChildren = validChildren.length
-
-  const customEllipsis = useCallback(
-    (providedItems?: BreadcrumbGenerateItem[]) => {
-      if (!ellipsis) return null
-
-      const resolvedItems =
-        providedItems ??
-        items.slice(startBoundaries!, items.length - endBoundaries!)
-
-      return runIfFunc(ellipsis, { items: resolvedItems })
-    },
-    [ellipsis, endBoundaries, items, startBoundaries],
-  )
-
-  const cloneChildren = useMemo(() => {
-    if (hasChildren) {
-      return validChildren.map((child, index) =>
-        cloneElement(child, {
-          gap,
-          isLastChild: validChildren.length === index + 1,
-          separator,
-        }),
-      )
-    } else {
-      let hiddenEllipsis: BreadcrumbGenerateItem[] = []
-
-      return items.map((item, index) => {
-        const { name, isCurrentPage, isEllipsisPage, containerProps, ...rest } =
-          item
-        const isLastChild = items.length === index + 1
-        const props: BreadcrumbItemProps = {
-          gap,
-          isCurrentPage,
-          separator,
-          ...containerProps,
-        }
-
-        if (!hasBoundaries && isEllipsisPage) {
-          hiddenEllipsis.push(item)
-
-          return isLastChild ? (
-            <BreadcrumbItem key={index} {...props} isLastChild>
-              {customEllipsis([item]) ?? <BreadcrumbEllipsis />}
-            </BreadcrumbItem>
-          ) : null
-        }
-
-        if (hasBoundaries && isExceed) {
-          const lastIndex = items.length - index - 1
-
-          if (startBoundaries! <= index && endBoundaries! <= lastIndex) {
-            if (startBoundaries === index) {
-              return (
-                <BreadcrumbItem key={index} {...props}>
-                  {customEllipsis() ?? <BreadcrumbEllipsis />}
-                </BreadcrumbItem>
-              )
-            } else {
-              return null
-            }
-          }
-        }
-
-        if (hiddenEllipsis.length) {
-          const resolvedEllipsis = customEllipsis(hiddenEllipsis) ?? (
-            <BreadcrumbEllipsis />
-          )
-
-          hiddenEllipsis = []
-
-          return (
-            <Fragment key={index}>
-              <BreadcrumbItem {...props}>{resolvedEllipsis}</BreadcrumbItem>
-
-              <BreadcrumbItem {...props} isLastChild={isLastChild}>
-                <BreadcrumbLink {...rest}>{name}</BreadcrumbLink>
-              </BreadcrumbItem>
-            </Fragment>
-          )
-        } else {
-          return (
-            <BreadcrumbItem key={index} {...props} isLastChild={isLastChild}>
-              <BreadcrumbLink {...rest}>{name}</BreadcrumbLink>
-            </BreadcrumbItem>
-          )
-        }
-      })
-    }
-  }, [
-    hasChildren,
-    validChildren,
-    separator,
-    gap,
-    items,
-    hasBoundaries,
-    isExceed,
-    startBoundaries,
-    endBoundaries,
-    customEllipsis,
-  ])
 
   return (
     <BreadcrumbProvider value={styles}>

--- a/packages/components/breadcrumb/src/use-breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/use-breadcrumb.tsx
@@ -1,0 +1,138 @@
+import type {
+  BreadcrumbGenerateItem,
+  BreadcrumbItemProps,
+  BreadcrumbProps,
+} from "./breadcrumb"
+import { getValidChildren, isNumber, runIfFunc } from "@yamada-ui/utils"
+import { cloneElement, Fragment, useCallback, useMemo } from "react"
+import {
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+} from "./breadcrumb"
+
+interface UseBreadcrumbProps
+  extends Pick<BreadcrumbProps, "children" | "ellipsis" | "gap" | "separator"> {
+  endBoundaries: number | undefined
+  items: BreadcrumbGenerateItem[]
+  startBoundaries: number | undefined
+}
+
+export const useBreadcrumb = ({
+  children,
+  ellipsis,
+  endBoundaries,
+  gap,
+  items,
+  separator,
+  startBoundaries,
+}: UseBreadcrumbProps) => {
+  const hasBoundaries = isNumber(startBoundaries) && isNumber(endBoundaries)
+  const isExceed =
+    hasBoundaries && startBoundaries! + endBoundaries! < items.length
+
+  const validChildren = getValidChildren(children)
+  const hasChildren = validChildren.length
+
+  const customEllipsis = useCallback(
+    (providedItems?: BreadcrumbGenerateItem[]) => {
+      if (!ellipsis) return null
+
+      const resolvedItems =
+        providedItems ??
+        items.slice(startBoundaries!, items.length - endBoundaries!)
+
+      return runIfFunc(ellipsis, { items: resolvedItems })
+    },
+    [ellipsis, endBoundaries, items, startBoundaries],
+  )
+
+  const cloneChildren = useMemo(() => {
+    if (hasChildren) {
+      return validChildren.map((child, index) =>
+        cloneElement(child, {
+          gap,
+          isLastChild: validChildren.length === index + 1,
+          separator,
+        }),
+      )
+    } else {
+      let hiddenEllipsis: BreadcrumbGenerateItem[] = []
+
+      return items.map((item, index) => {
+        const { name, isCurrentPage, isEllipsisPage, containerProps, ...rest } =
+          item
+        const isLastChild = items.length === index + 1
+        const props: BreadcrumbItemProps = {
+          gap,
+          isCurrentPage,
+          separator,
+          ...containerProps,
+        }
+
+        if (!hasBoundaries && isEllipsisPage) {
+          hiddenEllipsis.push(item)
+
+          return isLastChild ? (
+            <BreadcrumbItem key={index} {...props} isLastChild>
+              {customEllipsis([item]) ?? <BreadcrumbEllipsis />}
+            </BreadcrumbItem>
+          ) : null
+        }
+
+        if (hasBoundaries && isExceed) {
+          const lastIndex = items.length - index - 1
+
+          if (startBoundaries! <= index && endBoundaries! <= lastIndex) {
+            if (startBoundaries === index) {
+              return (
+                <BreadcrumbItem key={index} {...props}>
+                  {customEllipsis() ?? <BreadcrumbEllipsis />}
+                </BreadcrumbItem>
+              )
+            } else {
+              return null
+            }
+          }
+        }
+
+        if (hiddenEllipsis.length) {
+          const resolvedEllipsis = customEllipsis(hiddenEllipsis) ?? (
+            <BreadcrumbEllipsis />
+          )
+
+          hiddenEllipsis = []
+
+          return (
+            <Fragment key={index}>
+              <BreadcrumbItem {...props}>{resolvedEllipsis}</BreadcrumbItem>
+
+              <BreadcrumbItem {...props} isLastChild={isLastChild}>
+                <BreadcrumbLink {...rest}>{name}</BreadcrumbLink>
+              </BreadcrumbItem>
+            </Fragment>
+          )
+        } else {
+          return (
+            <BreadcrumbItem key={index} {...props} isLastChild={isLastChild}>
+              <BreadcrumbLink {...rest}>{name}</BreadcrumbLink>
+            </BreadcrumbItem>
+          )
+        }
+      })
+    }
+  }, [
+    hasChildren,
+    validChildren,
+    separator,
+    gap,
+    items,
+    hasBoundaries,
+    isExceed,
+    startBoundaries,
+    endBoundaries,
+    customEllipsis,
+  ])
+
+  return cloneChildren
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3348

## Description

Separate the logic in Breadcrumb component into a use-breadcrumb.tsx file.

## Is this a breaking change (Yes/No):

No
