### PR TITLE
`Tabs`: remove `is` prefix in props

### DIFF
--- a/.changeset/tricky-gifts-hear.md
+++ b/.changeset/tricky-gifts-hear.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/tabs": patch
+---
+
+remove `is` prefix in props

--- a/packages/components/tabs/src/tab-panel.tsx
+++ b/packages/components/tabs/src/tab-panel.tsx
@@ -16,17 +16,17 @@ export const TabPanel = forwardRef<TabPanelProps, "div">(
   ({ id, className, children, ...rest }, ref) => {
     const { isLazy: enabled, lazyBehavior: mode, styles } = useTabsContext()
     const uuid = useId()
-    const { index, isSelected } = useTabPanelContext()
+    const { index, selected } = useTabPanelContext()
     const { register } = useTabPanelDescendant()
     const { descendants } = useTabDescendant()
     const hasBeenSelected = useRef<boolean>(false)
     const tabId = descendants.value(index)?.node.id
 
-    if (isSelected) hasBeenSelected.current = true
+    if (selected) hasBeenSelected.current = true
 
     const shouldRenderChildren = useLazyDisclosure({
       enabled,
-      isSelected,
+      isSelected: selected,
       mode,
       wasSelected: hasBeenSelected.current,
     })
@@ -44,7 +44,7 @@ export const TabPanel = forwardRef<TabPanelProps, "div">(
         role="tabpanel"
         __css={css}
         {...rest}
-        hidden={!isSelected}
+        hidden={!selected}
       >
         {shouldRenderChildren ? children : null}
       </ui.div>

--- a/packages/components/tabs/src/tab-panel.tsx
+++ b/packages/components/tabs/src/tab-panel.tsx
@@ -14,7 +14,7 @@ export interface TabPanelProps extends HTMLUIProps {}
 
 export const TabPanel = forwardRef<TabPanelProps, "div">(
   ({ id, className, children, ...rest }, ref) => {
-    const { isLazy: enabled, lazyBehavior: mode, styles } = useTabsContext()
+    const { lazy: enabled, lazyBehavior: mode, styles } = useTabsContext()
     const uuid = useId()
     const { index, selected } = useTabPanelContext()
     const { register } = useTabPanelDescendant()

--- a/packages/components/tabs/src/tab-panels.tsx
+++ b/packages/components/tabs/src/tab-panels.tsx
@@ -11,11 +11,11 @@ export const TabPanels = forwardRef<TabPanelsProps, "div">(
     const { selectedIndex, styles, tabPanelsProps } = useTabsContext()
     const validChildren = getValidChildren(children)
     const cloneChildren = validChildren.map((child, index) => {
-      const isSelected = index === selectedIndex
+      const selected = index === selectedIndex
 
       return createElement(
         TabPanelProvider,
-        { key: index, value: { index, isSelected, selectedIndex } },
+        { key: index, value: { index, selected, selectedIndex } },
         child,
       )
     })

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -23,15 +23,15 @@ export const Tab = forwardRef<TabProps, "button">(
       children,
       clickOnEnter,
       clickOnSpace,
-      isDisabled,
-      isFocusable,
+      disabled,
+      focusable,
       ...rest
     },
     ref,
   ) => {
     const {
       disableRipple,
-      isManual,
+      manual,
       orientation,
       selectedIndex,
       setFocusedIndex,
@@ -40,7 +40,7 @@ export const Tab = forwardRef<TabProps, "button">(
     } = useTabsContext()
     const uuid = useId()
     const { index, register } = useTabDescendant({
-      disabled: isDisabled && !isFocusable,
+      disabled: disabled && !focusable,
     })
     const { descendants } = useTabPanelDescendant()
     const tabpanelId = descendants.value(index)?.node.id
@@ -51,7 +51,7 @@ export const Tab = forwardRef<TabProps, "button">(
     const onFocus = () => {
       setFocusedIndex(index)
 
-      if (!isManual && !(isDisabled && isFocusable)) setSelectedIndex(index)
+      if (!manual && !(disabled && focusable)) setSelectedIndex(index)
     }
 
     const clickableProps = useClickable<HTMLButtonElement>({
@@ -64,14 +64,14 @@ export const Tab = forwardRef<TabProps, "button">(
       ref: mergeRefs(register, ref),
       clickOnEnter,
       clickOnSpace,
-      isDisabled,
-      isFocusable,
+      disabled,
+      focusable,
       onClick: handlerAll(rest.onClick, () => setSelectedIndex(index)),
-      onFocus: isDisabled ? undefined : handlerAll(rest.onFocus, onFocus),
+      onFocus: disabled ? undefined : handlerAll(rest.onFocus, onFocus),
     })
     const { onPointerDown, ...rippleProps } = useRipple({
       ...clickableProps,
-      isDisabled: disableRipple || isDisabled,
+      disabled: disableRipple || disabled,
     })
 
     const css: CSSUIObject = {

--- a/packages/components/tabs/src/tabs-context.tsx
+++ b/packages/components/tabs/src/tabs-context.tsx
@@ -35,6 +35,6 @@ export const [TabsProvider, useTabsContext] = createContext<TabsContext>({
 
 export const [TabPanelProvider, useTabPanelContext] = createContext<{
   index: number
-  isSelected: boolean
+  selected: boolean
   selectedIndex: number
 }>({})

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -39,6 +39,12 @@ export interface TabsOptions {
    */
   disableRipple?: boolean
   /**
+   * If `true`, tabs will stretch to width of the tablist.
+   *
+   * @default false
+   */
+  fitted?: boolean
+  /**
    * The index of the selected tab.
    */
   index?: number
@@ -46,12 +52,16 @@ export interface TabsOptions {
    * If `true`, tabs will stretch to width of the tablist.
    *
    * @default false
+   *
+   * @deprecated Use `fitted` instead.
    */
   isFitted?: boolean
   /**
    * If `true`, rendering of the tab panel's will be deferred until it is selected.
    *
    * @default true
+   *
+   * @deprecated Use `lazy` instead.
    */
   isLazy?: boolean
   /**
@@ -60,8 +70,16 @@ export interface TabsOptions {
    * If `false`, the tabs will be automatically activated and their panel is displayed when they receive focus.
    *
    * @default false
+   *
+   * @deprecated Use `manual` instead.
    */
   isManual?: boolean
+  /**
+   * If `true`, rendering of the tab panel's will be deferred until it is selected.
+   *
+   * @default true
+   */
+  lazy?: boolean
   /**
    * The lazy behavior of tab panels' content when not active. Only works when `isLazy={true}`.
    *
@@ -71,6 +89,14 @@ export interface TabsOptions {
    * @default 'unmount'
    */
   lazyBehavior?: LazyMode
+  /**
+   * If `true`, the tabs will be manually activated and display its panel by pressing Space or Enter.
+   *
+   * If `false`, the tabs will be automatically activated and their panel is displayed when they receive focus.
+   *
+   * @default false
+   */
+  manual?: boolean
   /**
    * The orientation of the tab list.
    *
@@ -107,22 +133,30 @@ export const Tabs = forwardRef<TabsProps, "div">(
       align,
       ...props,
     })
-    const {
+    let {
       className,
       children,
       defaultIndex = 0,
       disableRipple = false,
+      fitted,
       index,
       isFitted,
       isLazy = true,
       isManual,
+      lazy,
       lazyBehavior = "keepMounted",
+      manual,
       orientation = "horizontal",
       tabListProps,
       tabPanelsProps,
       onChange,
       ...rest
     } = omitThemeProps(mergedProps)
+
+    fitted ??= isFitted
+    lazy ??= isLazy
+    manual ??= isManual
+
     const [focusedIndex, setFocusedIndex] = useState<number>(defaultIndex)
     const [selectedIndex, setSelectedIndex] = useControllableState({
       defaultValue: defaultIndex,
@@ -150,11 +184,11 @@ export const Tabs = forwardRef<TabsProps, "div">(
             value={{
               align,
               disableRipple,
+              fitted,
               focusedIndex,
-              isFitted,
-              isLazy,
-              isManual,
+              lazy,
               lazyBehavior,
+              manual,
               orientation,
               selectedIndex,
               setFocusedIndex,

--- a/packages/components/tabs/tests/tabs.test.tsx
+++ b/packages/components/tabs/tests/tabs.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, render, screen, waitFor } from "@yamada-ui/test"
+import { a11y, render, screen } from "@yamada-ui/test"
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from "../src"
 
 describe("<Tabs />", () => {

--- a/packages/components/tabs/tests/tabs.test.tsx
+++ b/packages/components/tabs/tests/tabs.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, render, screen } from "@yamada-ui/test"
+import { a11y, render, screen, waitFor } from "@yamada-ui/test"
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from "../src"
 
 describe("<Tabs />", () => {
@@ -81,7 +81,7 @@ describe("<Tabs />", () => {
     render(
       <Tabs>
         <Tab>Home</Tab>
-        <Tab isDisabled>About</Tab>
+        <Tab disabled>About</Tab>
         <Tab>Contact</Tab>
 
         <TabPanel>

--- a/stories/components/disclosure/tabs.stories.tsx
+++ b/stories/components/disclosure/tabs.stories.tsx
@@ -392,7 +392,7 @@ export const withOrientation: Story = () => {
 export const withFitted: Story = () => {
   return (
     <>
-      <Tabs variant="line" isFitted>
+      <Tabs variant="line" fitted>
         <Tab>孫悟空</Tab>
         <Tab>ベジータ</Tab>
         <Tab>フリーザ</Tab>
@@ -410,7 +410,7 @@ export const withFitted: Story = () => {
         </TabPanel>
       </Tabs>
 
-      <Tabs variant="sticky" isFitted>
+      <Tabs variant="sticky" fitted>
         <Tab>孫悟空</Tab>
         <Tab>ベジータ</Tab>
         <Tab>フリーザ</Tab>
@@ -431,11 +431,11 @@ export const withFitted: Story = () => {
   )
 }
 
-export const isDisabled: Story = () => {
+export const disabled: Story = () => {
   return (
     <Tabs>
       <Tab>孫悟空</Tab>
-      <Tab isDisabled>ベジータ</Tab>
+      <Tab disabled>ベジータ</Tab>
       <Tab>フリーザ</Tab>
 
       <TabPanel>
@@ -453,11 +453,11 @@ export const isDisabled: Story = () => {
   )
 }
 
-export const isFocusable: Story = () => {
+export const focusable: Story = () => {
   return (
     <Tabs>
       <Tab>孫悟空</Tab>
-      <Tab isFocusable>ベジータ</Tab>
+      <Tab focusable>ベジータ</Tab>
       <Tab>フリーザ</Tab>
 
       <TabPanel>
@@ -475,9 +475,9 @@ export const isFocusable: Story = () => {
   )
 }
 
-export const isManual: Story = () => {
+export const manual: Story = () => {
   return (
-    <Tabs isManual>
+    <Tabs manual>
       <Tab>孫悟空</Tab>
       <Tab>ベジータ</Tab>
       <Tab>フリーザ</Tab>
@@ -497,9 +497,9 @@ export const isManual: Story = () => {
   )
 }
 
-export const isLazy: Story = () => {
+export const lazy: Story = () => {
   return (
-    <Tabs isLazy lazyBehavior="unmount">
+    <Tabs lazy lazyBehavior="unmount">
       <Tab>孫悟空</Tab>
       <Tab>ベジータ</Tab>
       <Tab>フリーザ</Tab>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3498 

## Description

Removing all `is` prefix from `is*`

## Current behavior (updates)

Before: isFitted, isLazy, isManual

## New behavior

After: fitted, lazy, manual

## Is this a breaking change (Yes/No):

No

## Additional Information
