### PR TITLE
`Link`: remove is prefix in props

### DIFF
--- a/.changeset/stale-singers-joke.md
+++ b/.changeset/stale-singers-joke.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/link": patch
+---
+
+remove `is` prefix in props

--- a/packages/components/link/src/link-box.tsx
+++ b/packages/components/link/src/link-box.tsx
@@ -26,6 +26,14 @@ interface LinkOverlayOptions {
    *
    * @default false
    */
+  external?: boolean
+  /**
+   * If `true`, the link will open in new tab.
+   *
+   * @default false
+   *
+   * @deprecated Use `external` instead
+   */
   isExternal?: boolean
 }
 
@@ -34,8 +42,13 @@ export interface LinkOverlayProps
     LinkOverlayOptions {}
 
 export const LinkOverlay = forwardRef<LinkOverlayProps, "a">(
-  ({ href, target, className, children, isExternal, rel, ...rest }, ref) => {
+  (
+    { href, target, className, children, external, isExternal, rel, ...rest },
+    ref,
+  ) => {
     const { styles, variableProps } = useLinkBox()
+
+    external ??= isExternal
 
     const css: CSSUIObject = {
       position: "static",
@@ -58,9 +71,9 @@ export const LinkOverlay = forwardRef<LinkOverlayProps, "a">(
       <ui.a
         ref={ref}
         href={href}
-        target={isExternal ? "_blank" : target}
+        target={external ? "_blank" : target}
         className={cx("ui-link-box__overlay", className)}
-        rel={isExternal ? "noopener" : rel}
+        rel={external ? "noopener" : rel}
         __css={css}
         {...rest}
       >

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -13,6 +13,14 @@ interface LinkOptions {
    *
    * @default false
    */
+  external?: boolean
+  /**
+   * If `true`, the link will open in new tab.
+   *
+   * @default false
+   *
+   * @deprecated Use `external` instead
+   */
   isExternal?: boolean
 }
 
@@ -28,14 +36,16 @@ export interface LinkProps
  */
 export const Link = forwardRef<LinkProps, "a">((props, ref) => {
   const [css, mergedProps] = useComponentStyle("Link", props)
-  const { className, isExternal, ...rest } = omitThemeProps(mergedProps)
+  let { className, external, isExternal, ...rest } = omitThemeProps(mergedProps)
+
+  external ??= isExternal
 
   return (
     <ui.a
       ref={ref}
-      target={isExternal ? "_blank" : undefined}
+      target={external ? "_blank" : undefined}
       className={cx("ui-link", className)}
-      rel={isExternal ? "noopener" : undefined}
+      rel={external ? "noopener" : undefined}
       __css={css}
       {...rest}
     />

--- a/packages/components/link/tests/link.test.tsx
+++ b/packages/components/link/tests/link.test.tsx
@@ -13,7 +13,7 @@ describe("<Link />", () => {
     const url =
       "https://yamada-ui.github.io/yamada-ui/?path=/docs/documents-welcome--docs"
     render(
-      <Link href={url} data-testid="Link" isExternal>
+      <Link href={url} data-testid="Link" external>
         Welcome page
       </Link>,
     )
@@ -41,12 +41,12 @@ describe("<LinkOverlay />", () => {
     expect(link).toHaveTextContent("Welcome page")
   })
 
-  test("opens link in a new tab when isExternal is true", () => {
+  test("opens link in a new tab when external is true", () => {
     const url =
       "https://yamada-ui.github.io/yamada-ui/?path=/docs/documents-welcome--docs"
     render(
       <LinkBox>
-        <LinkOverlay href={url} isExternal>
+        <LinkOverlay href={url} external>
           Welcome page
         </LinkOverlay>
       </LinkBox>,

--- a/stories/components/data-display/table.stories.tsx
+++ b/stories/components/data-display/table.stories.tsx
@@ -1788,7 +1788,7 @@ export const customCell: Story = () => {
             <Link
               ref={referenceRef}
               href="https://dragon-ball-official.com/"
-              isExternal
+              external
               tabIndex={tabIndex}
             >
               {getValue()}

--- a/stories/components/navigation/link-box.stories.tsx
+++ b/stories/components/navigation/link-box.stories.tsx
@@ -26,7 +26,7 @@ export const basic: Story = () => {
       <Heading size="md" my="sm">
         <LinkOverlay
           href="https://ja.wikipedia.org/wiki/%E3%83%89%E3%83%A9%E3%82%B4%E3%83%B3%E3%83%9C%E3%83%BC%E3%83%AB"
-          isExternal
+          external
         >
           ドラゴンボール
         </LinkOverlay>
@@ -56,7 +56,7 @@ export const withNestedLink: Story = () => {
       <Heading size="md" my="sm">
         <LinkOverlay
           href="https://ja.wikipedia.org/wiki/%E3%83%89%E3%83%A9%E3%82%B4%E3%83%B3%E3%83%9C%E3%83%BC%E3%83%AB"
-          isExternal
+          external
         >
           ドラゴンボール
         </LinkOverlay>
@@ -67,11 +67,7 @@ export const withNestedLink: Story = () => {
         BALL）は、鳥山明による日本の漫画作品。『週刊少年ジャンプ』（集英社）にて1984年51号から1995年25号まで連載された。略称は『DB』。
       </Text>
 
-      <Link
-        href="https://dragon-ball-official.com/"
-        fontWeight="bold"
-        isExternal
-      >
+      <Link href="https://dragon-ball-official.com/" external fontWeight="bold">
         オフィシャルサイト
       </Link>
     </LinkBox>

--- a/stories/components/navigation/link.stories.tsx
+++ b/stories/components/navigation/link.stories.tsx
@@ -22,7 +22,7 @@ export const useBlank: Story = () => {
   return (
     <Link
       href="https://ja.wikipedia.org/wiki/%E3%83%89%E3%83%A9%E3%82%B4%E3%83%B3%E3%83%9C%E3%83%BC%E3%83%AB"
-      isExternal
+      external
     >
       ドラゴンボール - wikipedia
     </Link>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3522 

## Description

Removing all is prefix from is*.


## Current behavior (updates)

Before: `isExternal`

## New behavior

After: `external`

## Is this a breaking change (Yes/No):

No

## Additional Information
