### PR TITLE
feat(highlight): remove is prefix in props

### DIFF
--- a/.changeset/neat-suns-pay.md
+++ b/.changeset/neat-suns-pay.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/highlight": patch
+---
+
+remove `is` prefix in props

--- a/packages/components/highlight/src/highlight.tsx
+++ b/packages/components/highlight/src/highlight.tsx
@@ -58,6 +58,14 @@ export interface HighlightProps extends Omit<TextProps, "children"> {
    *
    * @default false
    */
+  fragment?: boolean
+  /**
+   * If `true`, `Fragment` is used for rendering.
+   *
+   * @default false
+   *
+   * @deprecated Use `fragment` instead.
+   */
   isFragment?: boolean
   /**
    * Properties passed to the Mark component which is used to highlight the matched terms.
@@ -72,6 +80,7 @@ export interface HighlightProps extends Omit<TextProps, "children"> {
  */
 export const Highlight: FC<HighlightProps> = ({
   children: text,
+  fragment,
   isFragment = false,
   lineHeight = "tall",
   query,
@@ -81,12 +90,14 @@ export const Highlight: FC<HighlightProps> = ({
   if (typeof text !== "string")
     throw new Error("The children prop of Highlight must be a string")
 
+  fragment ??= isFragment
+
   const chunks = useHighlight({ query, text })
 
-  const Component: FC = isFragment ? Fragment : Text
+  const Component: FC = fragment ? Fragment : Text
 
   return (
-    <Component {...(!isFragment ? { lineHeight } : {})} {...rest}>
+    <Component {...(!fragment ? { lineHeight } : {})} {...rest}>
       {chunks.map(({ match, text }, i) =>
         match ? (
           <Mark key={i} {...markProps}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3544

## Description

Removing all is prefix from is*.

## Current behavior (updates)

Before: `isFragment`

## New behavior

Aefore: `fragment`

## Is this a breaking change (Yes/No):

No
