### PR TITLE
feat: remove `is` prefix in props from FormControl and Fieldset components

### DIFF
--- a/.changeset/thirty-hairs-give.md
+++ b/.changeset/thirty-hairs-give.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/form-control": minor
+---
+
+feat: remove `is` prefix in props from FormControl and Fieldset components

--- a/packages/components/form-control/src/fieldset.tsx
+++ b/packages/components/form-control/src/fieldset.tsx
@@ -22,6 +22,12 @@ import {
 
 interface FieldsetOptions {
   /**
+   * If `true`, the fieldset will be disabled.
+   *
+   * @default false
+   */
+  disabled?: boolean
+  /**
    * The fieldset error message to use.
    */
   errorMessage?: ReactNode
@@ -30,39 +36,73 @@ interface FieldsetOptions {
    */
   helperMessage?: ReactNode
   /**
+   * If `true`, the fieldset will be invalid.
+   *
+   * @default false
+   */
+  invalid?: boolean
+  /**
    * If `true`, the fieldset will be disabled.
    *
    * @default false
+   *
+   * @deprecated Use `disabled` instead.
    */
   isDisabled?: boolean
   /**
    * If `true`, the fieldset will be invalid.
    *
    * @default false
+   *
+   * @deprecated Use `invalid` instead.
    */
   isInvalid?: boolean
   /**
    * If `true`, the fieldset will be readonly.
    *
    * @default false
+   *
+   * @deprecated Use `readOnly` instead.
    */
   isReadOnly?: boolean
   /**
    * If `true`, switch between helper message and error message using isInvalid.
    *
    * @default true
+   *
+   * @deprecated Use `replace` instead.
    */
   isReplace?: boolean
   /**
    * If `true`, the fieldset will be required.
    *
    * @default false
+   *
+   * @deprecated Use `required` instead.
    */
   isRequired?: boolean
   /**
    * The fieldset legend to use.
    */
   legend?: ReactNode
+  /**
+   * If `true`, the fieldset will be readonly.
+   *
+   * @default false
+   */
+  readOnly?: boolean
+  /**
+   * If `true`, switch between helper message and error message using isInvalid.
+   *
+   * @default true
+   */
+  replace?: boolean
+  /**
+   * If `true`, the fieldset will be required.
+   *
+   * @default false
+   */
+  required?: boolean
   /**
    * Props the error message component.
    */
@@ -91,18 +131,23 @@ export interface FieldsetProps
 export const Fieldset = forwardRef<FieldsetProps, "fieldset">(
   ({ id, ...props }, ref) => {
     const [styles, mergedProps] = useComponentMultiStyle("Fieldset", props)
-    const {
+    let {
       className,
       children,
+      disabled,
       errorMessage,
       helperMessage,
-      isDisabled = false,
-      isInvalid = false,
-      isReadOnly = false,
-      isReplace = true,
-      isRequired = false,
+      invalid,
+      isDisabled,
+      isInvalid,
+      isReadOnly,
+      isReplace,
+      isRequired,
       legend,
       optionalIndicator,
+      readOnly,
+      replace,
+      required,
       requiredIndicator,
       errorMessageProps,
       helperMessageProps,
@@ -114,7 +159,13 @@ export const Fieldset = forwardRef<FieldsetProps, "fieldset">(
 
     id ??= uuid
 
-    const [isFocused, setFocused] = useState<boolean>(false)
+    disabled ??= isDisabled ?? false
+    invalid ??= isInvalid ?? false
+    readOnly ??= isReadOnly ?? false
+    replace ??= isReplace ?? true
+    required ??= isRequired ?? false
+
+    const [focused, setFocused] = useState<boolean>(false)
 
     const validChildren = getValidChildren(children)
 
@@ -131,12 +182,12 @@ export const Fieldset = forwardRef<FieldsetProps, "fieldset">(
     return (
       <FormControlContextProvider
         value={{
-          isDisabled,
-          isFocused,
-          isInvalid,
-          isReadOnly,
-          isReplace,
-          isRequired,
+          disabled,
+          focused,
+          invalid,
+          readOnly,
+          replace,
+          required,
           onBlur: () => setFocused(false),
           onFocus: () => setFocused(true),
         }}
@@ -145,11 +196,11 @@ export const Fieldset = forwardRef<FieldsetProps, "fieldset">(
           <ui.fieldset
             ref={ref}
             className={cx("ui-fieldset", className)}
-            data-disabled={dataAttr(isDisabled)}
-            data-focus={dataAttr(isFocused)}
-            data-invalid={dataAttr(isInvalid)}
-            data-readonly={dataAttr(isReadOnly)}
-            disabled={isDisabled}
+            data-disabled={dataAttr(disabled)}
+            data-focus={dataAttr(focused)}
+            data-invalid={dataAttr(invalid)}
+            data-readonly={dataAttr(readOnly)}
+            disabled={disabled}
             __css={css}
             {...rest}
           >
@@ -160,10 +211,10 @@ export const Fieldset = forwardRef<FieldsetProps, "fieldset">(
                 {...legendProps}
               >
                 {legend}
-                {(!isReplace || !isInvalid) && helperMessage ? (
+                {(!replace || !invalid) && helperMessage ? (
                   <VisuallyHidden>{helperMessage}</VisuallyHidden>
                 ) : null}
-                {isInvalid && errorMessage ? (
+                {invalid && errorMessage ? (
                   <VisuallyHidden>{errorMessage}</VisuallyHidden>
                 ) : null}
               </Legend>
@@ -188,8 +239,12 @@ Fieldset.displayName = "Fieldset"
 Fieldset.__ui__ = "Fieldset"
 
 interface LegendOptions {
+  /**
+   * @deprecated Use `required` instead.
+   */
   isRequired?: boolean
   optionalIndicator?: ReactNode
+  required?: boolean
   requiredIndicator?: ReactNode
 }
 
@@ -202,16 +257,17 @@ export const Legend = forwardRef<LegendProps, "legend">(
       children,
       isRequired: isRequiredProp,
       optionalIndicator = null,
+      required: requiredProp,
       requiredIndicator = null,
       ...rest
     },
     ref,
   ) => {
-    const { isDisabled, isFocused, isInvalid, isReadOnly, isRequired } =
+    const { disabled, focused, invalid, readOnly, required } =
       useFormControlContext() ?? {}
     const styles = useFormControlStyles() ?? {}
 
-    isRequiredProp ??= isRequired
+    requiredProp ??= required ?? isRequiredProp
 
     const css: CSSUIObject = { ...styles.legend }
 
@@ -219,15 +275,15 @@ export const Legend = forwardRef<LegendProps, "legend">(
       <ui.legend
         ref={ref}
         className={cx("ui-fieldset__legend", className)}
-        data-disabled={dataAttr(isDisabled)}
-        data-focus={dataAttr(isFocused)}
-        data-invalid={dataAttr(isInvalid)}
-        data-readonly={dataAttr(isReadOnly)}
+        data-disabled={dataAttr(disabled)}
+        data-focus={dataAttr(focused)}
+        data-invalid={dataAttr(invalid)}
+        data-readonly={dataAttr(readOnly)}
         __css={css}
         {...rest}
       >
         {children}
-        {isRequiredProp ? (
+        {requiredProp ? (
           requiredIndicator ? (
             <RequiredIndicator>{requiredIndicator}</RequiredIndicator>
           ) : (

--- a/packages/components/form-control/src/form-control.tsx
+++ b/packages/components/form-control/src/form-control.tsx
@@ -24,25 +24,57 @@ export interface FormControlOptions {
    *
    * @default false
    */
+  disabled?: boolean
+  /**
+   * If `true`, the form control will be invalid.
+   *
+   * @default false
+   */
+  invalid?: boolean
+  /**
+   * If `true`, the form control will be disabled.
+   *
+   * @default false
+   *
+   * @deprecated Use `disabled` instead.
+   */
   isDisabled?: boolean
   /**
    * If `true`, the form control will be invalid.
    *
    * @default false
+   *
+   * @deprecated Use `invalid` instead.
    */
   isInvalid?: boolean
   /**
    * If `true`, the form control will be readonly.
    *
    * @default false
+   *
+   * @deprecated Use `readOnly` instead.
    */
   isReadOnly?: boolean
   /**
    * If `true`, the form control will be required.
    *
    * @default false
+   *
+   * @deprecated Use `required` instead.
    */
   isRequired?: boolean
+  /**
+   * If `true`, the form control will be readonly.
+   *
+   * @default false
+   */
+  readOnly?: boolean
+  /**
+   * If `true`, the form control will be required.
+   *
+   * @default false
+   */
+  required?: boolean
 }
 
 interface FormControlAdditionalOptions extends LabelOptions {
@@ -58,12 +90,20 @@ interface FormControlAdditionalOptions extends LabelOptions {
    * If `true`, switch between helper message and error message using isInvalid.
    *
    * @default true
+   *
+   * @deprecated Use `replace` instead.
    */
   isReplace?: boolean
   /**
    * The form control label to use.
    */
   label?: ReactNode
+  /**
+   * If `true`, switch between helper message and error message using isInvalid.
+   *
+   * @default true
+   */
+  replace?: boolean
   /**
    * Props the error message component.
    */
@@ -85,12 +125,12 @@ export interface FormControlProps
     FormControlAdditionalOptions {}
 
 interface FormControlContext {
-  isDisabled: boolean
-  isFocused: boolean
-  isInvalid: boolean
-  isReadOnly: boolean
-  isReplace: boolean
-  isRequired: boolean
+  disabled: boolean
+  focused: boolean
+  invalid: boolean
+  readOnly: boolean
+  replace: boolean
+  required: boolean
   onBlur: () => void
   onFocus: () => void
   id?: string
@@ -122,18 +162,23 @@ export const [FormControlStylesProvider, useFormControlStyles] = createContext<
 export const FormControl = forwardRef<FormControlProps, "div">(
   ({ id, ...props }, ref) => {
     const [styles, mergedProps] = useComponentMultiStyle("FormControl", props)
-    const {
+    let {
       className,
       children,
+      disabled,
       errorMessage,
       helperMessage,
-      isDisabled = false,
-      isInvalid = false,
-      isReadOnly = false,
-      isReplace = true,
-      isRequired = false,
+      invalid,
+      isDisabled,
+      isInvalid,
+      isReadOnly,
+      isReplace,
+      isRequired,
       label,
       optionalIndicator,
+      readOnly,
+      replace,
+      required,
       requiredIndicator,
       errorMessageProps,
       helperMessageProps,
@@ -145,8 +190,13 @@ export const FormControl = forwardRef<FormControlProps, "div">(
     const labelId = useId()
 
     id ??= uuid
+    disabled ??= isDisabled ?? false
+    invalid ??= isInvalid ?? false
+    readOnly ??= isReadOnly ?? false
+    replace ??= isReplace ?? false
+    required ??= isRequired ?? false
 
-    const [isFocused, setFocused] = useState<boolean>(false)
+    const [focused, setFocused] = useState<boolean>(false)
 
     const validChildren = getValidChildren(children)
 
@@ -164,13 +214,13 @@ export const FormControl = forwardRef<FormControlProps, "div">(
       <FormControlContextProvider
         value={{
           id,
-          isDisabled,
-          isFocused,
-          isInvalid,
-          isReadOnly,
-          isReplace,
-          isRequired,
+          disabled,
+          focused,
+          invalid,
           labelId,
+          readOnly,
+          replace,
+          required,
           onBlur: () => setFocused(false),
           onFocus: () => setFocused(true),
         }}
@@ -179,10 +229,10 @@ export const FormControl = forwardRef<FormControlProps, "div">(
           <ui.div
             ref={ref}
             className={cx("ui-form__control", className)}
-            data-disabled={dataAttr(isDisabled)}
-            data-focus={dataAttr(isFocused)}
-            data-invalid={dataAttr(isInvalid)}
-            data-readonly={dataAttr(isReadOnly)}
+            data-disabled={dataAttr(disabled)}
+            data-focus={dataAttr(focused)}
+            data-invalid={dataAttr(invalid)}
+            data-readonly={dataAttr(readOnly)}
             __css={css}
             {...rest}
           >
@@ -223,31 +273,32 @@ interface UseFormControlOptions extends FormControlOptions {
 
 export const useFormControl = <Y extends Dict = Dict>({
   id: idProp,
-  disabled,
+  disabled: disabledProp,
+  invalid: invalidProp,
   isDisabled: isDisabledProp,
   isInvalid: isInvalidProp,
   isReadOnly: isReadOnlyProp,
   isRequired: isRequiredProp,
-  readOnly,
-  required,
+  readOnly: readOnlyProp,
+  required: requiredProp,
   ...rest
 }: UseFormControlOptions & Y) => {
   const control = useFormControlContext()
 
   const id = idProp ?? control?.id
   const labelId = control?.labelId
-  const isDisabled = disabled ?? isDisabledProp ?? control?.isDisabled
-  const isReadOnly = readOnly ?? isReadOnlyProp ?? control?.isReadOnly
-  const isRequired = required ?? isRequiredProp ?? control?.isRequired
-  const isInvalid = isInvalidProp ?? control?.isInvalid
+  const disabled = disabledProp ?? control?.disabled ?? isDisabledProp
+  const readOnly = readOnlyProp ?? control?.readOnly ?? isReadOnlyProp
+  const required = requiredProp ?? control?.required ?? isRequiredProp
+  const invalid = invalidProp ?? control?.invalid ?? isInvalidProp
 
   return {
     id,
-    isDisabled,
-    isInvalid,
-    isReadOnly,
-    isRequired,
+    disabled,
+    invalid,
     labelId,
+    readOnly,
+    required,
     ...rest,
   }
 }
@@ -265,8 +316,8 @@ export interface UseFormControlProps<Y extends HTMLElement>
 export const useFormControlProps = <Y extends HTMLElement, M extends Dict>({
   id,
   disabled,
+  invalid,
   isDisabled,
-  isInvalid,
   isReadOnly,
   isRequired,
   readOnly,
@@ -277,15 +328,15 @@ export const useFormControlProps = <Y extends HTMLElement, M extends Dict>({
 }: M & UseFormControlProps<Y>) => {
   const control = useFormControlContext()
 
-  disabled ??= isDisabled ?? control?.isDisabled
-  required ??= isRequired ?? control?.isRequired
-  readOnly ??= isReadOnly ?? control?.isReadOnly
-  isInvalid ??= control?.isInvalid
+  disabled ??= control?.disabled ?? isDisabled
+  required ??= control?.required ?? isReadOnly
+  readOnly ??= control?.readOnly ?? isRequired
+  invalid ??= control?.invalid
 
   return {
     id: id ?? control?.id,
     "aria-disabled": ariaAttr(disabled),
-    "aria-invalid": ariaAttr(isInvalid),
+    "aria-invalid": ariaAttr(invalid),
     "aria-readonly": ariaAttr(readOnly),
     "aria-required": ariaAttr(required),
     "data-readonly": dataAttr(readOnly),
@@ -371,21 +422,21 @@ export const Label = forwardRef<LabelProps, "label">(
   ) => {
     const {
       id: formControlId,
-      isDisabled,
-      isFocused,
-      isInvalid,
-      isReadOnly,
-      isRequired,
+      disabled,
+      focused,
+      invalid,
       labelId,
+      readOnly,
+      required,
     } = useFormControlContext() ?? {}
     const styles = useFormControlStyles() ?? {}
 
     idProp ??= labelId
-    isRequiredProp ??= isRequired
+    isRequiredProp ??= required
 
     const css: CSSUIObject = {
       display: "block",
-      pointerEvents: isReadOnly ? "none" : undefined,
+      pointerEvents: readOnly ? "none" : undefined,
       ...styles.label,
     }
 
@@ -395,11 +446,11 @@ export const Label = forwardRef<LabelProps, "label">(
         ref={ref}
         htmlFor={htmlFor ?? formControlId}
         className={cx("ui-form__label", className)}
-        style={{ cursor: isDisabled ? "not-allowed" : undefined }}
-        data-disabled={dataAttr(isDisabled)}
-        data-focus={dataAttr(isFocused)}
-        data-invalid={dataAttr(isInvalid)}
-        data-readonly={dataAttr(isReadOnly)}
+        style={{ cursor: disabled ? "not-allowed" : undefined }}
+        data-disabled={dataAttr(disabled)}
+        data-focus={dataAttr(focused)}
+        data-invalid={dataAttr(invalid)}
+        data-readonly={dataAttr(readOnly)}
         __css={css}
         {...rest}
       >
@@ -453,10 +504,10 @@ export interface HelperMessageProps extends HTMLUIProps<"span"> {}
 
 export const HelperMessage = forwardRef<HelperMessageProps, "span">(
   ({ className, ...rest }, ref) => {
-    const { id, isInvalid, isReplace } = useFormControlContext() ?? {}
+    const { id, invalid, replace } = useFormControlContext() ?? {}
     const styles = useFormControlStyles() ?? {}
 
-    if (isReplace && isInvalid) return null
+    if (replace && invalid) return null
 
     const css: CSSUIObject = { ...styles.helperMessage }
 
@@ -479,10 +530,10 @@ export interface ErrorMessageProps extends HTMLUIProps<"span"> {}
 
 export const ErrorMessage = forwardRef<ErrorMessageProps, "span">(
   ({ className, ...rest }, ref) => {
-    const { isInvalid } = useFormControlContext() ?? {}
+    const { invalid } = useFormControlContext() ?? {}
     const styles = useFormControlStyles() ?? {}
 
-    if (!isInvalid) return null
+    if (!invalid) return null
 
     const css: CSSUIObject = { ...styles.errorMessage }
 

--- a/packages/components/form-control/tests/fieldset.test.tsx
+++ b/packages/components/form-control/tests/fieldset.test.tsx
@@ -49,7 +49,7 @@ describe("<Fieldset />", () => {
     render(
       <Fieldset
         errorMessage="Agreement is required."
-        isInvalid
+        invalid
         legend="Terms and Conditions"
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>
@@ -69,9 +69,9 @@ describe("<Fieldset />", () => {
       <Fieldset
         errorMessage="Agreement is required."
         helperMessage="Please review the terms carefully before agreeing."
-        isInvalid
-        isReplace
+        invalid
         legend="Terms and Conditions"
+        replace
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>
       </Fieldset>,
@@ -93,9 +93,9 @@ describe("<Fieldset />", () => {
       <Fieldset
         errorMessage="Agreement is required."
         helperMessage="Please review the terms carefully before agreeing."
-        isInvalid
-        isReplace={false}
+        invalid
         legend="Terms and Conditions"
+        replace={false}
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>
       </Fieldset>,
@@ -117,8 +117,8 @@ describe("<Fieldset />", () => {
       <Fieldset
         errorMessage="Agreement is required."
         helperMessage="Please review the terms carefully before agreeing."
-        isRequired
         legend="Terms and Conditions"
+        required
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>
       </Fieldset>,
@@ -129,9 +129,9 @@ describe("<Fieldset />", () => {
   test("should be disabled", () => {
     render(
       <Fieldset
+        disabled
         errorMessage="Agreement is required."
         helperMessage="Please review the terms carefully before agreeing."
-        isDisabled
         legend="Terms and Conditions"
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>
@@ -145,8 +145,8 @@ describe("<Fieldset />", () => {
       <Fieldset
         errorMessage="Agreement is required."
         helperMessage="Please review the terms carefully before agreeing."
-        isReadOnly
         legend="Terms and Conditions"
+        readOnly
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>
       </Fieldset>,
@@ -157,8 +157,8 @@ describe("<Fieldset />", () => {
   test("should render custom indicator", () => {
     render(
       <Fieldset
-        isRequired
         legend="Terms and Conditions"
+        required
         requiredIndicator={<div>required</div>}
       >
         <Checkbox>I agree to the Terms and Conditions.</Checkbox>

--- a/packages/components/form-control/tests/form-control.test.tsx
+++ b/packages/components/form-control/tests/form-control.test.tsx
@@ -28,7 +28,7 @@ describe("<FormControl />", () => {
 
   test("should render invalid form control", () => {
     render(
-      <FormControl errorMessage="Email is required." isInvalid label="Email">
+      <FormControl errorMessage="Email is required." invalid label="Email">
         <Input type="email" />
       </FormControl>,
     )
@@ -44,9 +44,9 @@ describe("<FormControl />", () => {
       <FormControl
         errorMessage="Email is required."
         helperMessage="Please enter your email"
-        isInvalid
-        isReplace
+        invalid
         label="Email"
+        replace
       >
         <Input type="email" />
       </FormControl>,
@@ -64,9 +64,9 @@ describe("<FormControl />", () => {
       <FormControl
         errorMessage="Email is required."
         helperMessage="Please enter your email"
-        isInvalid
-        isReplace={false}
+        invalid
         label="Email"
+        replace={false}
       >
         <Input type="email" />
       </FormControl>,
@@ -81,7 +81,7 @@ describe("<FormControl />", () => {
 
   test("should be required", () => {
     render(
-      <FormControl isRequired label="Email">
+      <FormControl label="Email" required>
         <Input type="email" />
       </FormControl>,
     )
@@ -90,7 +90,7 @@ describe("<FormControl />", () => {
 
   test("should be disabled", () => {
     render(
-      <FormControl isDisabled label="Email">
+      <FormControl disabled label="Email">
         <Input type="email" />
       </FormControl>,
     )
@@ -99,7 +99,7 @@ describe("<FormControl />", () => {
 
   test("should be readonly", () => {
     render(
-      <FormControl isReadOnly label="Email">
+      <FormControl label="Email" readOnly>
         <Input type="email" />
       </FormControl>,
     )
@@ -108,7 +108,7 @@ describe("<FormControl />", () => {
 
   test("should render custom indicator *", () => {
     render(
-      <FormControl isRequired label="Email">
+      <FormControl label="Email" required>
         <Input type="email" />
       </FormControl>,
     )
@@ -117,7 +117,7 @@ describe("<FormControl />", () => {
 
   test("should render custom indicator text", () => {
     render(
-      <FormControl isRequired label="Email" requiredIndicator="required">
+      <FormControl label="Email" required requiredIndicator="required">
         <Input type="email" />
       </FormControl>,
     )
@@ -127,8 +127,8 @@ describe("<FormControl />", () => {
   test("should render custom indicator jsx", () => {
     render(
       <FormControl
-        isRequired
         label="Email"
+        required
         requiredIndicator={<div data-testid="required">required</div>}
       >
         <Input type="email" />

--- a/stories/components/forms/form-control.stories.tsx
+++ b/stories/components/forms/form-control.stories.tsx
@@ -19,7 +19,7 @@ export default meta
 
 export const basic: Story = () => {
   return (
-    <FormControl label="Email address">
+    <FormControl label="Email address" replace>
       <Input type="email" placeholder="your email address" />
     </FormControl>
   )
@@ -40,7 +40,7 @@ export const withErrorMessage: Story = () => {
   return (
     <FormControl
       errorMessage="Email is required."
-      isInvalid
+      invalid
       label="Email address"
     >
       <Input type="email" placeholder="your email address" />
@@ -48,15 +48,15 @@ export const withErrorMessage: Story = () => {
   )
 }
 
-export const isReplace: Story = () => {
+export const Replace: Story = () => {
   return (
     <>
       <FormControl
         errorMessage="Email is required."
         helperMessage="We'll never share your email."
-        isInvalid
-        isReplace
+        invalid
         label="Email address"
+        replace
       >
         <Input type="email" placeholder="your email address" />
       </FormControl>
@@ -64,9 +64,9 @@ export const isReplace: Story = () => {
       <FormControl
         errorMessage="Email is required."
         helperMessage="We'll never share your email."
-        isInvalid
-        isReplace={false}
+        invalid
         label="Email address"
+        replace={false}
       >
         <Input type="email" placeholder="your email address" />
       </FormControl>
@@ -74,12 +74,25 @@ export const isReplace: Story = () => {
   )
 }
 
-export const isRequired: Story = () => {
+export const Required: Story = () => {
   return (
     <FormControl
       errorMessage="Email is required."
       helperMessage="We'll never share your email."
-      isRequired
+      label="Email address"
+      required
+    >
+      <Input type="email" placeholder="your email address" />
+    </FormControl>
+  )
+}
+
+export const disabled: Story = () => {
+  return (
+    <FormControl
+      disabled
+      errorMessage="Email is required."
+      helperMessage="We'll never share your email."
       label="Email address"
     >
       <Input type="email" placeholder="your email address" />
@@ -87,26 +100,13 @@ export const isRequired: Story = () => {
   )
 }
 
-export const isDisabled: Story = () => {
+export const readonly: Story = () => {
   return (
     <FormControl
       errorMessage="Email is required."
       helperMessage="We'll never share your email."
-      isDisabled
       label="Email address"
-    >
-      <Input type="email" placeholder="your email address" />
-    </FormControl>
-  )
-}
-
-export const isReadonly: Story = () => {
-  return (
-    <FormControl
-      errorMessage="Email is required."
-      helperMessage="We'll never share your email."
-      isReadOnly
-      label="Email address"
+      readOnly
     >
       <Input type="email" placeholder="your email address" />
     </FormControl>
@@ -135,7 +135,7 @@ export const customHelperMessage: Story = () => {
 
 export const customErrorMessage: Story = () => {
   return (
-    <FormControl isInvalid label="Email address">
+    <FormControl invalid label="Email address">
       <Input type="email" placeholder="your email address" />
       <ErrorMessage color="gray.300">Email is required.</ErrorMessage>
     </FormControl>
@@ -146,8 +146,8 @@ export const customRequiredIndicator: Story = () => {
   return (
     <>
       <FormControl
-        isRequired
         label="Email address"
+        required
         requiredIndicator={
           <Tag colorScheme="red" size="sm" ms={2}>
             required
@@ -157,7 +157,7 @@ export const customRequiredIndicator: Story = () => {
         <Input type="email" placeholder="your email address" />
       </FormControl>
 
-      <FormControl isRequired>
+      <FormControl required>
         <Label
           requiredIndicator={
             <Tag colorScheme="red" size="sm" ms={2}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3545 

## Description
remove `is` prefix in props from FormControl and Fieldset components

