### PR TITLE
feat: rename `direction` to `orientation` in `yamada-ui/resizable`

### DIFF
--- a/.changeset/nervous-ways-heal.md
+++ b/.changeset/nervous-ways-heal.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/resizable": minor
+---
+
+Rename `direction` to `orientation` in `yamada-ui/resizable`

--- a/packages/components/resizable/src/resizable.tsx
+++ b/packages/components/resizable/src/resizable.tsx
@@ -30,9 +30,10 @@ export interface ResizableProps
     ResizableOptions {}
 
 export const Resizable = forwardRef<ResizableProps, "div">(
-  ({ direction = "horizontal", ...props }, ref) => {
+  ({ direction = "horizontal", orientation = direction, ...props }, ref) => {
     const [styles, mergedProps] = useComponentMultiStyle("Resizable", {
       direction,
+      orientation,
       ...props,
     })
     const { className, children, containerRef, ...computedProps } =

--- a/packages/components/resizable/src/use-resizable.ts
+++ b/packages/components/resizable/src/use-resizable.ts
@@ -34,7 +34,7 @@ import {
   getResizeHandleElement,
 } from "react-resizable-panels"
 
-type ResizableDirection = "horizontal" | "vertical"
+type ResizableOrientation = "horizontal" | "vertical"
 
 export type As = keyof HTMLElementTagNameMap
 
@@ -57,8 +57,8 @@ export interface ResizableItemControl extends ImperativePanelHandle {}
 
 interface ResizableContext {
   controlRef: RefObject<ResizableGroupControl>
-  direction: ResizableDirection
   disabled: boolean
+  orientation: ResizableOrientation
   styles: { [key: string]: CSSUIObject | undefined }
 }
 
@@ -85,8 +85,10 @@ export interface UseResizableProps {
    * The direction of the resizable.
    *
    * @default "horizontal"
+   *
+   * @deprecated Use `orientation` instead.
    */
-  direction?: ResizableDirection
+  direction?: ResizableOrientation
   /**
    * If `true`, the resizable trigger will be disabled.
    */
@@ -103,6 +105,12 @@ export interface UseResizableProps {
    * @default 10
    */
   keyboardStep?: number
+  /**
+   * The orientation of the resizable.
+   *
+   * @default "horizontal"
+   */
+  orientation?: ResizableOrientation
   /**
    * A callback that gets and sets a value in custom storage.
    */
@@ -127,9 +135,10 @@ export const useResizable = ({
   ref,
   controlRef: controlRefProp,
   direction = "horizontal",
-  disabled = false,
   isDisabled = false,
+  disabled = isDisabled,
   keyboardStep,
+  orientation = direction,
   storage,
   storageKey,
   groupProps,
@@ -155,7 +164,7 @@ export const useResizable = ({
         id,
         ref: mergeRefs(controlRefProp, controlRef),
         autoSaveId: storageKey,
-        direction,
+        direction: orientation,
         keyboardResizeBy: keyboardStep,
         storage,
         tagName: as,
@@ -165,7 +174,7 @@ export const useResizable = ({
     },
     [
       id,
-      direction,
+      orientation,
       groupProps,
       controlRefProp,
       storageKey,
@@ -185,8 +194,8 @@ export const useResizable = ({
 
   return {
     controlRef,
-    direction,
-    disabled: disabled || isDisabled,
+    disabled,
+    orientation,
     getContainerProps,
     getGroupProps,
   }
@@ -376,22 +385,22 @@ export const useResizableTrigger = ({
   id,
   ref,
   as,
-  disabled,
   isDisabled,
+  disabled = isDisabled,
   ...rest
 }: UseResizableTriggerProps) => {
   const uuid = useId()
+  const {
+    controlRef,
+    disabled: groupDisabled,
+    orientation,
+  } = useResizableContext()
 
   id ??= uuid
 
-  const {
-    controlRef,
-    direction,
-    disabled: groupDisabled,
-  } = useResizableContext()
   const [active, setActive] = useState<boolean>(false)
 
-  const trulyDisabled = disabled || isDisabled || groupDisabled
+  const trulyDisabled = disabled || groupDisabled
 
   const onDoubleClick = useCallback(
     (ev: MouseEvent<HTMLDivElement>) => {
@@ -418,7 +427,7 @@ export const useResizableTrigger = ({
       ({
         ...props,
         id,
-        "aria-orientation": direction,
+        "aria-orientation": orientation,
         disabled: trulyDisabled,
         tagName: as,
         ...rest,
@@ -434,7 +443,7 @@ export const useResizableTrigger = ({
         ),
         onDragging: handlerAll(rest.onDragging, (active) => setActive(active)),
       }) as PanelResizeHandleProps,
-    [id, as, direction, trulyDisabled, rest, onDoubleClick, active],
+    [id, as, orientation, trulyDisabled, rest, onDoubleClick, active],
   )
 
   const getIconProps: PropGetter = useCallback(

--- a/packages/theme/src/components/resizable.ts
+++ b/packages/theme/src/components/resizable.ts
@@ -2,18 +2,18 @@ import type { ComponentMultiStyle } from "@yamada-ui/core"
 import { isGray, transparentizeColor } from "@yamada-ui/utils"
 
 export const Resizable: ComponentMultiStyle<"Resizable"> = {
-  baseStyle: ({ direction: d }) => ({
+  baseStyle: ({ orientation: o }) => ({
     container: {},
     icon: {
       color: ["blackAlpha.600", "whiteAlpha.700"],
-      rotate: d === "vertical" ? "90deg" : "0deg",
+      rotate: o === "vertical" ? "90deg" : "0deg",
     },
     item: {},
     trigger: {},
   }),
 
   variants: {
-    border: ({ direction: d }) => ({
+    border: ({ orientation: o }) => ({
       icon: {
         bg: "border",
         p: "1",
@@ -21,14 +21,14 @@ export const Resizable: ComponentMultiStyle<"Resizable"> = {
       },
       trigger: {
         bg: "border",
-        ...(d === "vertical" ? { h: "px" } : { w: "px" }),
+        ...(o === "vertical" ? { h: "px" } : { w: "px" }),
         _after: {
           content: "''",
           position: "absolute",
-          ...(d === "vertical"
+          ...(o === "vertical"
             ? { left: "0", right: "0", transform: "translateY(-50%)" }
             : { bottom: "0", top: "0", transform: "translateX(-50%)" }),
-          ...(d === "vertical" ? { h: "2" } : { w: "2" }),
+          ...(o === "vertical" ? { h: "2" } : { w: "2" }),
         },
         _focus: {
           outline: "none",
@@ -42,7 +42,7 @@ export const Resizable: ComponentMultiStyle<"Resizable"> = {
     spacer: ({
       colorScheme: c = "gray",
       colorMode: m,
-      direction: d,
+      orientation: o,
       theme: t,
     }) => ({
       icon: {
@@ -53,7 +53,7 @@ export const Resizable: ComponentMultiStyle<"Resizable"> = {
         },
       },
       trigger: {
-        ...(d === "vertical" ? { p: "1" } : { p: "1" }),
+        ...(o === "vertical" ? { p: "1" } : { p: "1" }),
         _active: {
           _after: {
             bg: isGray(c) ? "border" : `${c}.50`,
@@ -73,7 +73,7 @@ export const Resizable: ComponentMultiStyle<"Resizable"> = {
           rounded: "full",
           transitionDuration: "slower",
           transitionProperty: "common",
-          ...(d === "vertical" ? { h: "2", w: "full" } : { h: "full", w: "2" }),
+          ...(o === "vertical" ? { h: "2", w: "full" } : { h: "full", w: "2" }),
         },
         _dark: {
           _after: {
@@ -98,15 +98,15 @@ export const Resizable: ComponentMultiStyle<"Resizable"> = {
         },
       },
     }),
-    unstyled: ({ direction: d }) => ({
+    unstyled: ({ orientation: o }) => ({
       trigger: {
         _after: {
           content: "''",
           position: "absolute",
-          ...(d === "vertical"
+          ...(o === "vertical"
             ? { left: "0", right: "0", transform: "translateY(-50%)" }
             : { bottom: "0", top: "0", transform: "translateX(-50%)" }),
-          ...(d === "vertical" ? { h: "2" } : { w: "2" }),
+          ...(o === "vertical" ? { h: "2" } : { w: "2" }),
         },
       },
     }),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3516 

## Description

<!-- Add a brief description. -->
- Rename direction to orientation in yamada-ui/resizable
- add deprecate to direction

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No