### PR TITLE
Remove outdated 'Updated' labels from documentation

### DIFF
--- a/docs/contents/components/data-display/badge/index.ja.mdx
+++ b/docs/contents/components/data-display/badge/index.ja.mdx
@@ -6,7 +6,6 @@ order: 2
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/data-display/badge/index.mdx
+++ b/docs/contents/components/data-display/badge/index.mdx
@@ -8,7 +8,6 @@ order: 2
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/data-display/badge/props.ja.mdx
+++ b/docs/contents/components/data-display/badge/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/badge"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/badge/props.mdx
+++ b/docs/contents/components/data-display/badge/props.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/badge"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/badge/theming.ja.mdx
+++ b/docs/contents/components/data-display/badge/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/badge"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/data-display/badge/theming.mdx
+++ b/docs/contents/components/data-display/badge/theming.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/badge"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/data-display/paging-table/index.ja.mdx
+++ b/docs/contents/components/data-display/paging-table/index.ja.mdx
@@ -6,7 +6,6 @@ order: 8
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 <PackageManagers packageNameOrCommand="@yamada-ui/table" />

--- a/docs/contents/components/data-display/paging-table/index.mdx
+++ b/docs/contents/components/data-display/paging-table/index.mdx
@@ -6,7 +6,6 @@ order: 8
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 <PackageManagers packageNameOrCommand="@yamada-ui/table" />

--- a/docs/contents/components/data-display/paging-table/props.ja.mdx
+++ b/docs/contents/components/data-display/paging-table/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/paging-table/props.mdx
+++ b/docs/contents/components/data-display/paging-table/props.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/paging-table/theming.ja.mdx
+++ b/docs/contents/components/data-display/paging-table/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/data-display/paging-table/theming.mdx
+++ b/docs/contents/components/data-display/paging-table/theming.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/data-display/table/accessibility.ja.mdx
+++ b/docs/contents/components/data-display/table/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 3
 with_description: true
 tab: アクセシビリティ
-label: Updated
 ---
 
 `Table`は、アクセシビリティに関して[WAI-ARIA - Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/)に従います。

--- a/docs/contents/components/data-display/table/accessibility.mdx
+++ b/docs/contents/components/data-display/table/accessibility.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/table"
 order: 3
 with_description: true
 tab: Accessibility
-label: Updated
 ---
 
 The `Table` follows the [WAI-ARIA - Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/) for accessibility.

--- a/docs/contents/components/data-display/table/index.ja.mdx
+++ b/docs/contents/components/data-display/table/index.ja.mdx
@@ -6,7 +6,6 @@ order: 7
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/data-display/table/index.mdx
+++ b/docs/contents/components/data-display/table/index.mdx
@@ -8,7 +8,6 @@ order: 7
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/data-display/table/props.ja.mdx
+++ b/docs/contents/components/data-display/table/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/table/props.mdx
+++ b/docs/contents/components/data-display/table/props.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/table"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/table/theming.ja.mdx
+++ b/docs/contents/components/data-display/table/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/table"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/data-display/table/theming.mdx
+++ b/docs/contents/components/data-display/table/theming.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/table"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/data-display/tag/accessibility.ja.mdx
+++ b/docs/contents/components/data-display/tag/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tag"
 order: 3
 with_description: true
 tab: アクセシビリティ
-label: Updated
 ---
 
 `Tag`は、`onClose`が設定されると閉じるボタンを表示します。この閉じるボタンの`aria-label`は、デフォルトで`"Close tag"`を設定しています。もし、`aria-label`を任意の値に変更したい場合は、`closeButtonProps`に`aria-label`を設定します。

--- a/docs/contents/components/data-display/tag/accessibility.mdx
+++ b/docs/contents/components/data-display/tag/accessibility.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/tag"
 order: 3
 with_description: true
 tab: Accessibility
-label: Updated
 ---
 
 `Tag` displays a close button when `onClose` is set. The `aria-label` of this close button is set to `"Close tag"` by default. If you want to change the `aria-label` to a custom value, set the `aria-label` in `closeButtonProps`.

--- a/docs/contents/components/data-display/tag/index.ja.mdx
+++ b/docs/contents/components/data-display/tag/index.ja.mdx
@@ -6,7 +6,6 @@ order: 1
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/data-display/tag/index.mdx
+++ b/docs/contents/components/data-display/tag/index.mdx
@@ -8,7 +8,6 @@ order: 1
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/data-display/tag/props.ja.mdx
+++ b/docs/contents/components/data-display/tag/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tag"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/tag/props.mdx
+++ b/docs/contents/components/data-display/tag/props.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/tag"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/data-display/tag/theming.ja.mdx
+++ b/docs/contents/components/data-display/tag/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tag"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/data-display/tag/theming.mdx
+++ b/docs/contents/components/data-display/tag/theming.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/tag"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/disclosure/tabs/accessibility.ja.mdx
+++ b/docs/contents/components/disclosure/tabs/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tabs"
 order: 3
 with_description: true
 tab: アクセシビリティ
-label: Updated
 ---
 
 `Tabs`は、アクセシビリティに関して[WAI-ARIA - Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs)に従います。

--- a/docs/contents/components/disclosure/tabs/accessibility.mdx
+++ b/docs/contents/components/disclosure/tabs/accessibility.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tabs"
 order: 3
 with_description: true
 tab: Accessibility
-label: Updated
 ---
 
 The `Tabs` follows the [WAI-ARIA - Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs) for accessibility.

--- a/docs/contents/components/disclosure/tabs/index.ja.mdx
+++ b/docs/contents/components/disclosure/tabs/index.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tabs"
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/disclosure/tabs/index.mdx
+++ b/docs/contents/components/disclosure/tabs/index.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/tabs"
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/disclosure/tabs/props.ja.mdx
+++ b/docs/contents/components/disclosure/tabs/props.ja.mdx
@@ -4,7 +4,6 @@ description: "`Tabs`は、異なる表示領域を切り替えるコンポーネ
 package_name: "@yamada-ui/tabs"
 with_description: true
 tab: Props
-label: Updated
 order: 1
 ---
 

--- a/docs/contents/components/disclosure/tabs/props.mdx
+++ b/docs/contents/components/disclosure/tabs/props.mdx
@@ -4,7 +4,6 @@ description: "`Tabs` is a component for switching between different display area
 package_name: "@yamada-ui/tabs"
 with_description: true
 tab: Props
-label: Updated
 order: 1
 ---
 

--- a/docs/contents/components/disclosure/tabs/theming.ja.mdx
+++ b/docs/contents/components/disclosure/tabs/theming.ja.mdx
@@ -4,7 +4,6 @@ description: "`Tabs`は、異なる表示領域を切り替えるコンポーネ
 package_name: "@yamada-ui/tabs"
 with_description: true
 tab: テーマ
-label: Updated
 order: 2
 ---
 

--- a/docs/contents/components/disclosure/tabs/theming.mdx
+++ b/docs/contents/components/disclosure/tabs/theming.mdx
@@ -4,7 +4,6 @@ description: "`Tabs` is a component for switching between different display area
 package_name: "@yamada-ui/tabs"
 with_description: true
 tab: Theming
-label: Updated
 order: 2
 ---
 

--- a/docs/contents/components/feedback/alert/accessibility.ja.mdx
+++ b/docs/contents/components/feedback/alert/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/alert"
 order: 3
 with_description: true
 tab: アクセシビリティ
-label: Updated
 ---
 
 `Alert`は、アクセシビリティに関して[WAI-ARIA - Alert Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alert/)に従います。

--- a/docs/contents/components/feedback/alert/accessibility.mdx
+++ b/docs/contents/components/feedback/alert/accessibility.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/alert"
 order: 3
 with_description: true
 tab: Accessibility
-label: Updated
 ---
 
 `Alert` follows the [WAI-ARIA - Alert Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alert/)for accessibility.

--- a/docs/contents/components/feedback/alert/index.ja.mdx
+++ b/docs/contents/components/feedback/alert/index.ja.mdx
@@ -6,7 +6,6 @@ order: 1
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/feedback/alert/index.mdx
+++ b/docs/contents/components/feedback/alert/index.mdx
@@ -6,7 +6,6 @@ order: 1
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/feedback/alert/props.ja.mdx
+++ b/docs/contents/components/feedback/alert/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/alert"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/feedback/alert/props.mdx
+++ b/docs/contents/components/feedback/alert/props.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/alert"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/feedback/alert/theming.ja.mdx
+++ b/docs/contents/components/feedback/alert/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/alert"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/feedback/alert/theming.mdx
+++ b/docs/contents/components/feedback/alert/theming.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/alert"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/forms/button/accessibility.ja.mdx
+++ b/docs/contents/components/forms/button/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/button"
 order: 4
 with_description: true
 tab: アクセシビリティ
-label: Updated
 ---
 
 `Button`は、アクセシビリティに関して[WAI-ARIA - Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)に従います。

--- a/docs/contents/components/forms/button/accessibility.mdx
+++ b/docs/contents/components/forms/button/accessibility.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/button"
 order: 4
 with_description: true
 tab: Accessibility
-label: Updated
 ---
 
 The `Button` follows the [WAI-ARIA - Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) for accessibility.

--- a/docs/contents/components/forms/button/index.ja.mdx
+++ b/docs/contents/components/forms/button/index.ja.mdx
@@ -6,7 +6,6 @@ order: 3
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/forms/button/index.mdx
+++ b/docs/contents/components/forms/button/index.mdx
@@ -8,7 +8,6 @@ order: 3
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/forms/button/props.ja.mdx
+++ b/docs/contents/components/forms/button/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/button"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/button/props.mdx
+++ b/docs/contents/components/forms/button/props.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/button"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/button/theming.ja.mdx
+++ b/docs/contents/components/forms/button/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/button"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/forms/button/theming.mdx
+++ b/docs/contents/components/forms/button/theming.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/button"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/forms/form-control/accessibility.mdx
+++ b/docs/contents/components/forms/form-control/accessibility.mdx
@@ -1,6 +1,8 @@
 ---
 title: FormControl
-description: "`FormControl` is a component used to group form elements with label, helper message, error message, etc."
+description: >-
+  `FormControl` is a component used to group form elements with label, helper
+  message, error message, etc.
 package_name: "@yamada-ui/form-control"
 order: 3
 with_description: true

--- a/docs/contents/components/forms/multi-select/index.ja.mdx
+++ b/docs/contents/components/forms/multi-select/index.ja.mdx
@@ -6,7 +6,6 @@ order: 18
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/forms/multi-select/index.mdx
+++ b/docs/contents/components/forms/multi-select/index.mdx
@@ -8,7 +8,6 @@ order: 18
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/forms/multi-select/props.ja.mdx
+++ b/docs/contents/components/forms/multi-select/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/select"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/multi-select/props.mdx
+++ b/docs/contents/components/forms/multi-select/props.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/select"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/multi-select/theming.ja.mdx
+++ b/docs/contents/components/forms/multi-select/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/select"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/forms/multi-select/theming.mdx
+++ b/docs/contents/components/forms/multi-select/theming.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/select"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/forms/range-date-picker/index.ja.mdx
+++ b/docs/contents/components/forms/range-date-picker/index.ja.mdx
@@ -6,7 +6,6 @@ order: 24
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/forms/range-date-picker/index.mdx
+++ b/docs/contents/components/forms/range-date-picker/index.mdx
@@ -6,7 +6,6 @@ order: 24
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/forms/range-date-picker/props.ja.mdx
+++ b/docs/contents/components/forms/range-date-picker/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/calendar"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/range-date-picker/props.mdx
+++ b/docs/contents/components/forms/range-date-picker/props.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/calendar"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/range-date-picker/theming.ja.mdx
+++ b/docs/contents/components/forms/range-date-picker/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/calendar"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/forms/range-date-picker/theming.mdx
+++ b/docs/contents/components/forms/range-date-picker/theming.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/calendar"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/forms/rating/accessibility.ja.mdx
+++ b/docs/contents/components/forms/rating/accessibility.ja.mdx
@@ -1,6 +1,7 @@
 ---
 title: Rating
-description: "`Rating`は、ユーザーがアイテムに対して評価を行うためのUI要素で、星やハートなどのアイコンで提供され、ユーザーが選択した評価を視覚的に表示するコンポーネントです。"
+description: >-
+  `Rating`は、ユーザーがアイテムに対して評価を行うためのUI要素で、星やハートなどのアイコンで提供され、ユーザーが選択した評価を視覚的に表示するコンポーネントです。
 package-name: "@yamada-ui/rating"
 order: 3
 with_description: true

--- a/docs/contents/components/forms/rating/accessibility.mdx
+++ b/docs/contents/components/forms/rating/accessibility.mdx
@@ -1,6 +1,9 @@
 ---
 title: Rating
-description: "Rating is a component that allows users to evaluate items, presented in the form of icons such as stars or hearts, and visually displays the rating selected by the user."
+description: >-
+  Rating is a component that allows users to evaluate items, presented in the
+  form of icons such as stars or hearts, and visually displays the rating
+  selected by the user.
 package-name: "@yamada-ui/rating"
 order: 3
 with_description: true

--- a/docs/contents/components/forms/segmented-control/index.ja.mdx
+++ b/docs/contents/components/forms/segmented-control/index.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/segmented-control"
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/forms/segmented-control/index.mdx
+++ b/docs/contents/components/forms/segmented-control/index.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/segmented-control"
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/forms/segmented-control/props.ja.mdx
+++ b/docs/contents/components/forms/segmented-control/props.ja.mdx
@@ -4,7 +4,6 @@ description: "`SegmentedControl`は、ユーザーが複数の選択肢の中か
 package_name: "@yamada-ui/segmented-control"
 with_description: true
 tab: Props
-label: Updated
 order: 1
 ---
 

--- a/docs/contents/components/forms/segmented-control/props.mdx
+++ b/docs/contents/components/forms/segmented-control/props.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/segmented-control"
 with_description: true
 tab: Props
-label: Updated
 order: 1
 ---
 

--- a/docs/contents/components/forms/segmented-control/theming.ja.mdx
+++ b/docs/contents/components/forms/segmented-control/theming.ja.mdx
@@ -4,7 +4,6 @@ description: "`SegmentedControl`は、ユーザーが複数の選択肢の中か
 package_name: "@yamada-ui/segmented-control"
 with_description: true
 tab: テーマ
-label: Updated
 order: 2
 ---
 

--- a/docs/contents/components/forms/segmented-control/theming.mdx
+++ b/docs/contents/components/forms/segmented-control/theming.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/segmented-control"
 with_description: true
 tab: Theming
-label: Updated
 order: 2
 ---
 

--- a/docs/contents/components/forms/select/index.ja.mdx
+++ b/docs/contents/components/forms/select/index.ja.mdx
@@ -6,7 +6,6 @@ order: 17
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/forms/select/index.mdx
+++ b/docs/contents/components/forms/select/index.mdx
@@ -8,7 +8,6 @@ order: 17
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/forms/select/props.ja.mdx
+++ b/docs/contents/components/forms/select/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/select"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/select/props.mdx
+++ b/docs/contents/components/forms/select/props.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/select"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/select/theming.ja.mdx
+++ b/docs/contents/components/forms/select/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/select"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/forms/select/theming.mdx
+++ b/docs/contents/components/forms/select/theming.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/select"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/forms/toggle/accessibility.ja.mdx
+++ b/docs/contents/components/forms/toggle/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/toggle"
 order: 3
 with_description: true
 tab: アクセシビリティ
-label: Updated
 ---
 
 `Toggle`にアイコンのみを使用する場合は、`Toggle`に`aria-label`を設定します。

--- a/docs/contents/components/forms/toggle/accessibility.mdx
+++ b/docs/contents/components/forms/toggle/accessibility.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/toggle"
 order: 3
 with_description: true
 tab: Accessibility
-label: Updated
 ---
 
 When using only icons in `Toggle`, set `aria-label` for the `Toggle`.

--- a/docs/contents/components/forms/toggle/index.ja.mdx
+++ b/docs/contents/components/forms/toggle/index.ja.mdx
@@ -6,7 +6,6 @@ order: 16
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/forms/toggle/index.mdx
+++ b/docs/contents/components/forms/toggle/index.mdx
@@ -6,7 +6,6 @@ order: 16
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/forms/toggle/props.ja.mdx
+++ b/docs/contents/components/forms/toggle/props.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/toggle"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/toggle/props.mdx
+++ b/docs/contents/components/forms/toggle/props.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/toggle"
 order: 1
 with_description: true
 tab: Props
-label: Updated
 ---
 
 ## Props

--- a/docs/contents/components/forms/toggle/theming.ja.mdx
+++ b/docs/contents/components/forms/toggle/theming.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/toggle"
 order: 2
 with_description: true
 tab: テーマ
-label: Updated
 ---
 
 ## テーマ

--- a/docs/contents/components/forms/toggle/theming.mdx
+++ b/docs/contents/components/forms/toggle/theming.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/toggle"
 order: 2
 with_description: true
 tab: Theming
-label: Updated
 ---
 
 ## Theming

--- a/docs/contents/components/layouts/bleed/index.ja.mdx
+++ b/docs/contents/components/layouts/bleed/index.ja.mdx
@@ -3,7 +3,6 @@ title: Bleed
 description: "`Bleed`は、要素をコンテナの境界から外すために使用されるコンポーネントです。"
 package_name: "@yamada-ui/layouts"
 order: 10
-label: New
 is_tabs: true
 with_description: true
 tab: 使い方

--- a/docs/contents/components/layouts/bleed/index.mdx
+++ b/docs/contents/components/layouts/bleed/index.mdx
@@ -1,9 +1,10 @@
 ---
 title: Bleed
-description: "`Bleed` is a component used to extend elements beyond the boundaries of a container."
+description: >-
+  `Bleed` is a component used to extend elements beyond the boundaries of a
+  container.
 package_name: "@yamada-ui/layouts"
 order: 10
-label: New
 is_tabs: true
 with_description: true
 tab: Usage

--- a/docs/contents/components/layouts/bleed/props.ja.mdx
+++ b/docs/contents/components/layouts/bleed/props.ja.mdx
@@ -3,7 +3,6 @@ title: Bleed
 description: "`Bleed`は、要素をコンテナの境界から外すために使用されるコンポーネントです。"
 package_name: "@yamada-ui/layouts"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/layouts/bleed/props.mdx
+++ b/docs/contents/components/layouts/bleed/props.mdx
@@ -5,7 +5,6 @@ description: >-
   container.
 package_name: "@yamada-ui/layouts"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/layouts/float/index.ja.mdx
+++ b/docs/contents/components/layouts/float/index.ja.mdx
@@ -3,7 +3,6 @@ title: Float
 description: "`Float`は、要素をコンテナの端に固定するために使用されるコンポーネントです。"
 package_name: "@yamada-ui/layouts"
 order: 11
-label: New
 is_tabs: true
 with_description: true
 tab: 使い方

--- a/docs/contents/components/layouts/float/index.mdx
+++ b/docs/contents/components/layouts/float/index.mdx
@@ -3,7 +3,6 @@ title: Float
 description: "`Float` is a component used to fix elements to the edges of a container."
 package_name: "@yamada-ui/layouts"
 order: 11
-label: New
 is_tabs: true
 with_description: true
 tab: Usage

--- a/docs/contents/components/layouts/float/props.ja.mdx
+++ b/docs/contents/components/layouts/float/props.ja.mdx
@@ -3,7 +3,6 @@ title: Float
 description: "`Float`は、要素をコンテナの端に固定するために使用されるコンポーネントです。"
 package_name: "@yamada-ui/layouts"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/layouts/float/props.mdx
+++ b/docs/contents/components/layouts/float/props.mdx
@@ -3,7 +3,6 @@ title: Float
 description: "`Float` is a component used to fix elements to the edges of a container."
 package_name: "@yamada-ui/layouts"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/media-and-icons/picture/index.ja.mdx
+++ b/docs/contents/components/media-and-icons/picture/index.ja.mdx
@@ -3,7 +3,6 @@ title: Picture
 description: "`Picture`は、`picture`要素を使用し、異なる表示やデバイスのシナリオに応じて代替の画像を提供するコンポーネントです。"
 package_name: "@yamada-ui/image"
 order: 3
-label: New
 is_tabs: true
 with_description: true
 tab: 使い方

--- a/docs/contents/components/media-and-icons/picture/index.mdx
+++ b/docs/contents/components/media-and-icons/picture/index.mdx
@@ -1,9 +1,10 @@
 ---
 title: Picture
-description: "`Picture` is a component that uses the `picture` element to provide alternative images for different display and device scenarios."
+description: >-
+  `Picture` is a component that uses the `picture` element to provide
+  alternative images for different display and device scenarios.
 package_name: "@yamada-ui/image"
 order: 3
-label: New
 is_tabs: true
 with_description: true
 tab: Usage

--- a/docs/contents/components/media-and-icons/picture/props.ja.mdx
+++ b/docs/contents/components/media-and-icons/picture/props.ja.mdx
@@ -3,7 +3,6 @@ title: Picture
 description: "`Picture`は、`picture`要素を使用し、異なる表示やデバイスのシナリオに応じて代替の画像を提供するコンポーネントです。"
 package_name: "@yamada-ui/image"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/media-and-icons/picture/props.mdx
+++ b/docs/contents/components/media-and-icons/picture/props.mdx
@@ -5,7 +5,6 @@ description: >-
   alternative images for different display or device scenarios.
 package_name: "@yamada-ui/image"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/navigation/pagination/accessibility.ja.mdx
+++ b/docs/contents/components/navigation/pagination/accessibility.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/pagination"
 with_description: true
 tab: アクセシビリティ
 order: 3
-label: Updated
 ---
 
 ## ARIAロールと属性

--- a/docs/contents/components/navigation/pagination/accessibility.mdx
+++ b/docs/contents/components/navigation/pagination/accessibility.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/pagination"
 with_description: true
 tab: Accessibility
 order: 3
-label: Updated
 ---
 
 ## ARIA Roles and Attributes

--- a/docs/contents/components/navigation/pagination/index.ja.mdx
+++ b/docs/contents/components/navigation/pagination/index.ja.mdx
@@ -5,7 +5,6 @@ package_name: "@yamada-ui/pagination"
 is_tabs: true
 with_description: true
 tab: 使い方
-label: Updated
 ---
 
 ## インポート

--- a/docs/contents/components/navigation/pagination/index.mdx
+++ b/docs/contents/components/navigation/pagination/index.mdx
@@ -7,7 +7,6 @@ package_name: "@yamada-ui/pagination"
 is_tabs: true
 with_description: true
 tab: Usage
-label: Updated
 ---
 
 ## Import

--- a/docs/contents/components/navigation/pagination/props.ja.mdx
+++ b/docs/contents/components/navigation/pagination/props.ja.mdx
@@ -4,7 +4,6 @@ description: "`Pagination`は、コンテンツのページ分割とナビゲー
 package_name: "@yamada-ui/pagination"
 with_description: true
 tab: Props
-label: Updated
 order: 1
 ---
 

--- a/docs/contents/components/navigation/pagination/props.mdx
+++ b/docs/contents/components/navigation/pagination/props.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/pagination"
 with_description: true
 tab: Props
-label: Updated
 order: 1
 ---
 

--- a/docs/contents/components/navigation/pagination/theming.ja.mdx
+++ b/docs/contents/components/navigation/pagination/theming.ja.mdx
@@ -4,7 +4,6 @@ description: "`Pagination`は、コンテンツのページ分割とナビゲー
 package_name: "@yamada-ui/pagination"
 with_description: true
 tab: テーマ
-label: Updated
 order: 2
 ---
 

--- a/docs/contents/components/navigation/pagination/theming.mdx
+++ b/docs/contents/components/navigation/pagination/theming.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/pagination"
 with_description: true
 tab: Theming
-label: Updated
 order: 2
 ---
 

--- a/docs/contents/components/overlay/popover/accessibility.ja.mdx
+++ b/docs/contents/components/overlay/popover/accessibility.ja.mdx
@@ -1,6 +1,7 @@
 ---
 title: Popover
-description: "`Popover`は、特定の要素に関連する情報やアクションを表示する小さな浮かぶウィンドウで、ボタンやリンクに対してトリガーされ、ユーザーがクリックまたはホバーしたときに表示されるコンポーネントです。"
+description: >-
+  `Popover`は、特定の要素に関連する情報やアクションを表示する小さな浮かぶウィンドウで、ボタンやリンクに対してトリガーされ、ユーザーがクリックまたはホバーしたときに表示されるコンポーネントです。
 package-name: "@yamada-ui/popover"
 order: 3
 with_description: true

--- a/docs/contents/components/overlay/popover/accessibility.mdx
+++ b/docs/contents/components/overlay/popover/accessibility.mdx
@@ -1,6 +1,9 @@
 ---
 title: Popover
-description: "`Popover` is a small floating window that displays information or actions related to a specific element. It is triggered by buttons or links and appears when the user clicks or hovers over them."
+description: >-
+  `Popover` is a small floating window that displays information or actions
+  related to a specific element. It is triggered by buttons or links and appears
+  when the user clicks or hovers over them.
 package-name: "@yamada-ui/popover"
 order: 3
 with_description: true

--- a/docs/contents/components/transitions/airy/index.ja.mdx
+++ b/docs/contents/components/transitions/airy/index.ja.mdx
@@ -1,12 +1,10 @@
 ---
 title: Airy
-description: >-
-  `Airy`は、２つの要素をふわっと切り替えるアニメーションを提供するコンポーネントです。
+description: "`Airy`は、２つの要素をふわっと切り替えるアニメーションを提供するコンポーネントです。"
 package_name: "@yamada-ui/transitions"
 is_tabs: true
 with_description: true
 tab: 使い方
-label: New
 ---
 
 ## インポート

--- a/docs/contents/components/transitions/airy/index.mdx
+++ b/docs/contents/components/transitions/airy/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Airy
 description: >-
-  `Airy` is a component that provides a smooth animation to switch between two elements.
+  `Airy` is a component that provides a smooth animation to switch between two
+  elements.
 package_name: "@yamada-ui/transitions"
 is_tabs: true
 with_description: true
 tab: Usage
-label: New
 ---
 
 ## Import

--- a/docs/contents/components/transitions/airy/props.ja.mdx
+++ b/docs/contents/components/transitions/airy/props.ja.mdx
@@ -4,7 +4,6 @@ description: "`Airy`は、２つの要素をふわっと切り替えるアニメ
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Props
-label: New
 order: 1
 ---
 

--- a/docs/contents/components/transitions/airy/props.mdx
+++ b/docs/contents/components/transitions/airy/props.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Props
-label: New
 order: 1
 ---
 

--- a/docs/contents/components/transitions/airy/theming.ja.mdx
+++ b/docs/contents/components/transitions/airy/theming.ja.mdx
@@ -4,7 +4,6 @@ description: "`Airy`は、２つの要素をふわっと切り替えるアニメ
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: テーマ
-label: New
 order: 2
 ---
 

--- a/docs/contents/components/transitions/airy/theming.mdx
+++ b/docs/contents/components/transitions/airy/theming.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Theming
-label: New
 order: 2
 ---
 

--- a/docs/contents/components/transitions/flip/index.ja.mdx
+++ b/docs/contents/components/transitions/flip/index.ja.mdx
@@ -1,12 +1,10 @@
 ---
 title: Flip
-description: >-
-  `Flip`は、２つの要素をフリップさせながら切り替えるアニメーションを提供するコンポーネントです。
+description: "`Flip`は、２つの要素をフリップさせながら切り替えるアニメーションを提供するコンポーネントです。"
 package_name: "@yamada-ui/transitions"
 is_tabs: true
 with_description: true
 tab: 使い方
-label: New
 ---
 
 ## インポート

--- a/docs/contents/components/transitions/flip/index.mdx
+++ b/docs/contents/components/transitions/flip/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Flip
 description: >-
-  `Flip` is a component that provides an animation to switch between two elements while flipping.
+  `Flip` is a component that provides an animation to switch between two
+  elements while flipping.
 package_name: "@yamada-ui/transitions"
 is_tabs: true
 with_description: true
 tab: Usage
-label: New
 ---
 
 ## Import

--- a/docs/contents/components/transitions/flip/props.ja.mdx
+++ b/docs/contents/components/transitions/flip/props.ja.mdx
@@ -4,7 +4,6 @@ description: "`Flip`は、２つの要素をフリップさせながら切り替
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Props
-label: New
 order: 1
 ---
 

--- a/docs/contents/components/transitions/flip/props.mdx
+++ b/docs/contents/components/transitions/flip/props.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Props
-label: New
 order: 1
 ---
 

--- a/docs/contents/components/transitions/flip/theming.ja.mdx
+++ b/docs/contents/components/transitions/flip/theming.ja.mdx
@@ -4,7 +4,6 @@ description: "`Flip`は、２つの要素をフリップさせながら切り替
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: テーマ
-label: New
 order: 2
 ---
 

--- a/docs/contents/components/transitions/flip/theming.mdx
+++ b/docs/contents/components/transitions/flip/theming.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Theming
-label: New
 order: 2
 ---
 

--- a/docs/contents/components/transitions/rotate/index.ja.mdx
+++ b/docs/contents/components/transitions/rotate/index.ja.mdx
@@ -1,12 +1,10 @@
 ---
 title: Rotate
-description: >-
-  `Rotate`は、２つの要素を回転させながら切り替えるアニメーションを提供するコンポーネントです。
+description: "`Rotate`は、２つの要素を回転させながら切り替えるアニメーションを提供するコンポーネントです。"
 package_name: "@yamada-ui/transitions"
 is_tabs: true
 with_description: true
 tab: 使い方
-label: New
 ---
 
 ## インポート

--- a/docs/contents/components/transitions/rotate/index.mdx
+++ b/docs/contents/components/transitions/rotate/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Rotate
 description: >-
-  `Rotate` is a component that provides an animation to switch between two elements while rotating.
+  `Rotate` is a component that provides an animation to switch between two
+  elements while rotating.
 package_name: "@yamada-ui/transitions"
 is_tabs: true
 with_description: true
 tab: Usage
-label: New
 ---
 
 ## Import

--- a/docs/contents/components/transitions/rotate/props.ja.mdx
+++ b/docs/contents/components/transitions/rotate/props.ja.mdx
@@ -4,7 +4,6 @@ description: "`Rotate`は、２つの要素を回転させながら切り替え�
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Props
-label: New
 order: 1
 ---
 

--- a/docs/contents/components/transitions/rotate/props.mdx
+++ b/docs/contents/components/transitions/rotate/props.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Props
-label: New
 order: 1
 ---
 

--- a/docs/contents/components/transitions/rotate/theming.ja.mdx
+++ b/docs/contents/components/transitions/rotate/theming.ja.mdx
@@ -4,7 +4,6 @@ description: "`Rotate`は、２つの要素を回転させながら切り替え�
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: テーマ
-label: New
 order: 2
 ---
 

--- a/docs/contents/components/transitions/rotate/theming.mdx
+++ b/docs/contents/components/transitions/rotate/theming.mdx
@@ -6,7 +6,6 @@ description: >-
 package_name: "@yamada-ui/transitions"
 with_description: true
 tab: Theming
-label: New
 order: 2
 ---
 

--- a/docs/contents/components/typography/blockquote/index.ja.mdx
+++ b/docs/contents/components/typography/blockquote/index.ja.mdx
@@ -3,7 +3,6 @@ title: Blockquote
 description: "`Blockquote` は引用を表すコンポーネントです。デフォルトでは `blockquote` 要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 3
-label: New
 is_tabs: true
 with_description: true
 tab: 使い方

--- a/docs/contents/components/typography/blockquote/index.mdx
+++ b/docs/contents/components/typography/blockquote/index.mdx
@@ -1,9 +1,10 @@
 ---
 title: Blockquote
-description: "`Blockquote` is a component that represents a quotation. By default, it renders a `blockquote` element."
+description: >-
+  `Blockquote` is a component that represents a quotation. By default, it
+  renders a `blockquote` element.
 package_name: "@yamada-ui/typography"
 order: 3
-label: New
 is_tabs: true
 with_description: true
 tab: Usage

--- a/docs/contents/components/typography/blockquote/props.ja.mdx
+++ b/docs/contents/components/typography/blockquote/props.ja.mdx
@@ -3,7 +3,6 @@ title: Blockquote
 description: "`Blockquote` は引用を表すコンポーネントです。デフォルトでは `blockquote` 要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/typography/blockquote/props.mdx
+++ b/docs/contents/components/typography/blockquote/props.mdx
@@ -5,7 +5,6 @@ description: >-
   renders a `blockquote` element.
 package_name: "@yamada-ui/typography"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/typography/blockquote/theming.ja.mdx
+++ b/docs/contents/components/typography/blockquote/theming.ja.mdx
@@ -3,7 +3,6 @@ title: Blockquote
 description: "`Blockquote` は引用を表すコンポーネントです。デフォルトでは `blockquote` 要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 2
-label: New
 with_description: true
 tab: テーマ
 ---

--- a/docs/contents/components/typography/blockquote/theming.mdx
+++ b/docs/contents/components/typography/blockquote/theming.mdx
@@ -5,7 +5,6 @@ description: >-
   renders a `blockquote` element.
 package_name: "@yamada-ui/typography"
 order: 2
-label: New
 with_description: true
 tab: Theming
 ---

--- a/docs/contents/components/typography/code/index.ja.mdx
+++ b/docs/contents/components/typography/code/index.ja.mdx
@@ -3,7 +3,6 @@ title: Code
 description: "`Code` はコードブロックを表すコンポーネントです。デフォルトでは `code` 要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 5
-label: New
 is_tabs: true
 with_description: true
 tab: 使い方

--- a/docs/contents/components/typography/code/index.mdx
+++ b/docs/contents/components/typography/code/index.mdx
@@ -1,9 +1,10 @@
 ---
 title: Code
-description: "`Code` is a component that represents a code block. By default, it renders a `code` element."
+description: >-
+  `Code` is a component that represents a code block. By default, it renders a
+  `code` element.
 package_name: "@yamada-ui/typography"
 order: 5
-label: New
 is_tabs: true
 with_description: true
 tab: Usage

--- a/docs/contents/components/typography/code/props.ja.mdx
+++ b/docs/contents/components/typography/code/props.ja.mdx
@@ -3,7 +3,6 @@ title: Code
 description: "`Code` はコードブロックを表すコンポーネントです。デフォルトでは `code` 要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/typography/code/props.mdx
+++ b/docs/contents/components/typography/code/props.mdx
@@ -5,7 +5,6 @@ description: >-
   `code` element.
 package_name: "@yamada-ui/typography"
 order: 1
-label: New
 with_description: true
 tab: Props
 ---

--- a/docs/contents/components/typography/code/theming.ja.mdx
+++ b/docs/contents/components/typography/code/theming.ja.mdx
@@ -3,7 +3,6 @@ title: Code
 description: "`Code` はコードブロックを表すコンポーネントです。デフォルトでは `code` 要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 2
-label: New
 with_description: true
 tab: テーマ
 ---

--- a/docs/contents/components/typography/code/theming.mdx
+++ b/docs/contents/components/typography/code/theming.mdx
@@ -5,7 +5,6 @@ description: >-
   `code` element.
 package_name: "@yamada-ui/typography"
 order: 2
-label: New
 with_description: true
 tab: Theming
 ---

--- a/docs/contents/components/typography/em/index.ja.mdx
+++ b/docs/contents/components/typography/em/index.ja.mdx
@@ -3,7 +3,6 @@ title: Em
 description: "`Em`は強調されたテキストを表すコンポーネントです。デフォルトでは、`em`要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 4
-label: New
 is_tabs: true
 with_description: true
 tab: 使い方

--- a/docs/contents/components/typography/em/index.mdx
+++ b/docs/contents/components/typography/em/index.mdx
@@ -1,9 +1,10 @@
 ---
 title: Em
-description: "`Em` is a component that represents emphasized text. By default, it renders a `em` element."
+description: >-
+  `Em` is a component that represents emphasized text. By default, it renders a
+  `em` element.
 package_name: "@yamada-ui/typography"
 order: 4
-label: New
 is_tabs: true
 with_description: true
 tab: Usage

--- a/docs/contents/components/typography/em/theming.ja.mdx
+++ b/docs/contents/components/typography/em/theming.ja.mdx
@@ -3,7 +3,6 @@ title: Em
 description: "`Em`は強調されたテキストを表すコンポーネントです。デフォルトでは、`em`要素をレンダリングします。"
 package_name: "@yamada-ui/typography"
 order: 2
-label: New
 with_description: true
 tab: テーマ
 ---

--- a/docs/contents/components/typography/em/theming.mdx
+++ b/docs/contents/components/typography/em/theming.mdx
@@ -5,7 +5,6 @@ description: >-
   `em` element.
 package_name: "@yamada-ui/typography"
 order: 2
-label: New
 with_description: true
 tab: Theming
 ---

--- a/docs/contents/hooks/use-async-callback.ja.mdx
+++ b/docs/contents/hooks/use-async-callback.ja.mdx
@@ -2,7 +2,6 @@
 title: useAsyncCallback
 description: "`useAsyncCallback`は、非同期コールバックを管理するためのカスタムフックです。"
 package_name: "@yamada-ui/use-async-callback"
-label: New
 with_description: true
 ---
 

--- a/docs/contents/hooks/use-async-callback.mdx
+++ b/docs/contents/hooks/use-async-callback.mdx
@@ -2,7 +2,6 @@
 title: useAsyncCallback
 description: "`useAsyncCallback` is a custom hook for managing asynchronous callbacks."
 package_name: "@yamada-ui/use-async-callback"
-label: New
 with_description: true
 ---
 

--- a/docs/contents/hooks/use-processing.ja.mdx
+++ b/docs/contents/hooks/use-processing.ja.mdx
@@ -2,7 +2,6 @@
 title: useProcessing
 description: "`useProcessing` は処理状態を管理するためのカスタムフックです。"
 package_name: "@yamada-ui/use-processing"
-label: New
 with_description: true
 ---
 

--- a/docs/contents/hooks/use-processing.mdx
+++ b/docs/contents/hooks/use-processing.mdx
@@ -2,7 +2,6 @@
 title: useProcessing
 description: "`useProcessing` is a custom hook for handling processing states."
 package_name: "@yamada-ui/use-processing"
-label: New
 with_description: true
 ---
 

--- a/docs/contents/hooks/use-promise-disclosure.ja.mdx
+++ b/docs/contents/hooks/use-promise-disclosure.ja.mdx
@@ -1,6 +1,7 @@
 ---
 title: usePromiseDisclosure
-description: "`usePromiseDisclosure`は、一般的な開閉や切り替えのシナリオを非同期処理するのに役立つカスタムフックです。`Modal`、`Dialog`、`Drawer`などのコンポーネントを制御するために使用できます。"
+description: >-
+  `usePromiseDisclosure`は、一般的な開閉や切り替えのシナリオを非同期処理するのに役立つカスタムフックです。`Modal`、`Dialog`、`Drawer`などのコンポーネントを制御するために使用できます。
 package_name: "@yamada-ui/use-disclosure"
 with_description: true
 ---

--- a/docs/contents/hooks/use-promise-disclosure.mdx
+++ b/docs/contents/hooks/use-promise-disclosure.mdx
@@ -1,6 +1,9 @@
 ---
 title: usePromiseDisclosure
-description: "`usePromiseDisclosure` is a custom hook that helps handle common open/close or toggle scenarios with promises. It can be used to control components such as `Modal`, `Dialog`, `Drawer`, etc."
+description: >-
+  `usePromiseDisclosure` is a custom hook that helps handle common open/close or
+  toggle scenarios with promises. It can be used to control components such as
+  `Modal`, `Dialog`, `Drawer`, etc.
 package_name: "@yamada-ui/use-disclosure"
 with_description: true
 ---


### PR DESCRIPTION
## Description

Remove outdated 'Updated' labels from documentation.

## Is this a breaking change (Yes/No):

No