### PR TITLE
Fix props doc generation script for windows

### DIFF
--- a/docs/scripts/component/props.ts
+++ b/docs/scripts/component/props.ts
@@ -24,8 +24,10 @@ interface Props {
   see?: string
 }
 
-const SOURCE_PATH = path.join(CONSTANT.PATH.ROOT, "packages", "components")
-const DIST_PATH = path.join("contents", "components")
+const SOURCE_PATH = path
+  .join(CONSTANT.PATH.ROOT, "packages", "components")
+  .replaceAll(/\\/g, "/")
+const DIST_PATH = path.join("contents", "components").replaceAll(/\\/g, "/")
 const LOCALE_TAB_MAP = {
   en: "Props",
   ja: "Props",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3667

## Description

I have fixed the props docs generation script that was not working properly for Windows.

## Current behavior (updates)

It did not replace `\` with `/`.

## New behavior

The script replaces `\` with `/` when it runs `path.join`.

## Is this a breaking change (Yes/No):

No

## Additional Information

N/A