### PR TITLE
feat(use-animation): remove is prefix from props

### DIFF
--- a/.changeset/tame-hornets-argue.md
+++ b/.changeset/tame-hornets-argue.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/use-animation": patch
+---
+
+remove `is` prefix from props

--- a/packages/hooks/use-animation/src/index.ts
+++ b/packages/hooks/use-animation/src/index.ts
@@ -122,30 +122,37 @@ export const useDynamicAnimation = <
 
 export interface UseAnimationObserverProps {
   ref: React.RefObject<HTMLElement>
+  /**
+   * @deprecated Use `open` instead
+   */
   isOpen: boolean
+  open?: boolean
 }
 
 export const useAnimationObserver = ({
   ref,
   isOpen,
+  open,
 }: UseAnimationObserverProps) => {
-  const [mounted, setMounted] = useState(isOpen)
+  open ??= isOpen
+
+  const [mounted, setMounted] = useState(open)
   const [flg, { on }] = useBoolean()
 
   useEffect(() => {
     if (flg) return
 
-    setMounted(isOpen)
+    setMounted(open)
     on()
-  }, [isOpen, flg, on])
+  }, [open, flg, on])
 
   useEventListener(
     () => ref.current,
     "animationend",
-    () => setMounted(isOpen),
+    () => setMounted(open),
   )
 
-  const hidden = isOpen ? false : !mounted
+  const hidden = open ? false : !mounted
 
   return {
     present: !hidden,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3805

## Description

Removing all is prefix from is*.

## Is this a breaking change (Yes/No):

No
