### PR TITLE
Refactor `convertColor` to replace lookbehind in regular expression.

### DIFF
--- a/.changeset/itchy-dryers-burn.md
+++ b/.changeset/itchy-dryers-burn.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/utils": patch
+---
+
+Refactor `convertColor` to replace lookbehind in regular expression.

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -278,7 +278,7 @@ export function convertColor(color: string, fallback?: string) {
         if (isAlpha) {
           if (hexa.length === 7) hexa += "ff"
         } else {
-          hexa = hexa.replace(/(#(?:[0-9a-fA-F]{6}))[0-9a-fA-F]{2}$/, "$1")
+          hexa = hexa.replace(/^#(?:[0-9a-fA-F]{6})[0-9a-fA-F]{2}$/, "$1")
         }
 
         return hexa

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -278,7 +278,7 @@ export function convertColor(color: string, fallback?: string) {
         if (isAlpha) {
           if (hexa.length === 7) hexa += "ff"
         } else {
-          hexa = hexa.replace(/(?<=^#([0-9a-fA-F]{6}))[0-9a-fA-F]{2}$/, "")
+          hexa = hexa.replace(/(#(?:[0-9a-fA-F]{6}))[0-9a-fA-F]{2}$/, "$1")
         }
 
         return hexa


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3831  <!-- Github issue # here -->

## Description

Refactor `convertColor` to replace lookbehind in regular expression

Replaced the lookbehind assertion in the `convertColor` function's `hexa.replace` logic with a more compatible regular expression pattern. The original lookbehind `/(?<=^#([0-9a-fA-F]{6}))[0-9a-fA-F]{2}$/` was not supported in some environments, causing compatibility issues. The updated pattern `/^#(?:[0-9a-fA-F]{6})[0-9a-fA-F]{2}$/` uses a non-capturing group and matches the entire string without relying on lookbehind. This change ensures broader compatibility across different JavaScript engines.


## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
