### PR TITLE
fix: adjust hover background colors for disabled/focus item

### DIFF
--- a/.changeset/rare-sloths-exist.md
+++ b/.changeset/rare-sloths-exist.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Change `background color` for `disabled` items in `Menu`, `Select` and `Autocomplete` when hovered and focused.

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -47,6 +47,9 @@ export const Menu: ComponentMultiStyle<"Menu"> = {
         _disabled: {
           bg: ["white", "black"],
         },
+        _focus: {
+          bg: ["blackAlpha.50", "whiteAlpha.50"],
+        },
       },
       _disabled: {
         cursor: "not-allowed",

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -23,6 +23,9 @@ export const Select: ComponentMultiStyle<"Select"> = mergeMultiStyle(
           _disabled: {
             bg: ["white", "black"],
           },
+          _focus: {
+            bg: ["blackAlpha.50", "whiteAlpha.50"],
+          },
         },
       },
       itemIcon: {},


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3571 <!-- Github issue # here -->

## Description
Change `background color` for `disabled` items in `Select` when hovered and focused.
`Autocomplete` inherits `Select` `theme`, so `Select` `theme` is modified

<!-- Add a brief description. -->

## Current behavior 
When hovering over `focusable` with `disabled`, the `background color` on focus is lost.

https://github.com/user-attachments/assets/d276687f-806d-4e5b-8ebd-c48cb462b55b

<!-- Please describe the current behavior that you are modifying. -->

## New behavior
When hovering over `focusable` with `disabled`, the same background color is applied as for normal focus.

https://github.com/user-attachments/assets/bd5227a5-04bb-4d94-ad1b-8e3244fab58a

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
