### PR TITLE
Replace `StatIcon` with `TriangleIcon` from `@yamada-ui/lucide`

### DIFF
--- a/packages/components/stat/src/stat-icon.tsx
+++ b/packages/components/stat/src/stat-icon.tsx
@@ -1,7 +1,7 @@
 import type { CSSUIObject } from "@yamada-ui/core"
 import type { IconProps } from "@yamada-ui/icon"
-import { forwardRef, ui } from "@yamada-ui/core"
-import { Icon } from "@yamada-ui/icon"
+import { forwardRef } from "@yamada-ui/core"
+import { TriangleIcon } from "@yamada-ui/lucide"
 import { cx } from "@yamada-ui/utils"
 import { useStat } from "./stat-context"
 
@@ -19,30 +19,23 @@ export interface StatIconProps
 export const StatIcon = forwardRef<StatIconProps, "svg">(
   ({ type = "increase", className, ...rest }, ref) => {
     const styles = useStat()
+    const color = type === "increase" ? "$increase" : "$decrease"
 
-    const css: CSSUIObject = { ...styles.icon }
+    const css: CSSUIObject = {
+      color,
+      fill: color,
+      transform: type === "decrease" ? "rotate(180deg)" : undefined,
+      ...styles.icon,
+    }
 
     return (
-      <Icon
+      <TriangleIcon
         ref={ref}
         className={cx("ui-stat__icon", className)}
         aria-label={type === "increase" ? "Increased by" : "Decreased by"}
-        viewBox="0 0 24 24"
         __css={css}
         {...rest}
-      >
-        {type === "increase" ? (
-          <ui.path
-            d="M12.8,5.4c-0.377-0.504-1.223-0.504-1.6,0l-9,12c-0.228,0.303-0.264,0.708-0.095,1.047 C2.275,18.786,2.621,19,3,19h18c0.379,0,0.725-0.214,0.895-0.553c0.169-0.339,0.133-0.744-0.095-1.047L12.8,5.4z"
-            fill="$increase"
-          />
-        ) : (
-          <ui.path
-            d="M21,5H3C2.621,5,2.275,5.214,2.105,5.553C1.937,5.892,1.973,6.297,2.2,6.6l9,12 c0.188,0.252,0.485,0.4,0.8,0.4s0.611-0.148,0.8-0.4l9-12c0.228-0.303,0.264-0.708,0.095-1.047C21.725,5.214,21.379,5,21,5z"
-            fill="$decrease"
-          />
-        )}
-      </Icon>
+      />
     )
   },
 )

--- a/packages/theme/src/components/stat.ts
+++ b/packages/theme/src/components/stat.ts
@@ -8,7 +8,7 @@ export const Stat: ComponentMultiStyle<"Stat"> = {
       fontSize: "sm",
     },
     icon: {
-      h: "3.5",
+      h: "3",
       marginEnd: "1",
       vars: [
         {
@@ -23,7 +23,7 @@ export const Stat: ComponentMultiStyle<"Stat"> = {
         },
       ],
       verticalAlign: "middle",
-      w: "3.5",
+      w: "3",
     },
     label: {
       color: "muted",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3532 <!-- Github issue # here -->

## Description
Replace `StatIcon` with `TriangleIcon` from `@yamada-ui/lucide`.
The theme was also modified to match the current icon look and feel.

<!-- Add a brief description. -->

## Current behavior (updates)

<img width="226" alt="Stat_-_Yamada_UI" src="https://github.com/user-attachments/assets/e3f38e2f-5361-4280-b067-c6b1c4c8473d">

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<img width="227" alt="Stat_-_Yamada_UI" src="https://github.com/user-attachments/assets/4d8fd21d-989a-4b0f-92ea-646b1c08b86d">

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

