### PR TITLE
Use `For` in `dialog` documentation

### DIFF
--- a/docs/contents/components/overlay/dialog/index.ja.mdx
+++ b/docs/contents/components/overlay/dialog/index.ja.mdx
@@ -115,17 +115,19 @@ const { isOpen, onOpen, onClose } = useDisclosure()
 return (
   <>
     <Wrap gap="md">
-      {sizeMap.map((size) => (
-        <Button
-          key={size}
-          onClick={() => {
-            setSize(size)
-            onOpen()
-          }}
-        >
-          Open {size} Dialog
-        </Button>
-      ))}
+      <For each={sizeMap}>
+        {(size) => (
+          <Button
+            key={size}
+            onClick={() => {
+              setSize(size)
+              onOpen()
+            }}
+          >
+            Open {size} Dialog
+          </Button>
+        )}
+      </For>
     </Wrap>
 
     <Dialog
@@ -167,17 +169,19 @@ const { isOpen, onOpen, onClose } = useDisclosure()
 return (
   <>
     <Wrap gap="md">
-      {placementMap.map((placement) => (
-        <Button
-          key={placement}
-          onClick={() => {
-            setPlacement(placement)
-            onOpen()
-          }}
-        >
-          Open {placement} Dialog
-        </Button>
-      ))}
+      <For each={placementMap}>
+        {(placement) => (
+          <Button
+            key={placement}
+            onClick={() => {
+              setPlacement(placement)
+              onOpen()
+            }}
+          >
+            Open {placement} Dialog
+          </Button>
+        )}
+      </For>
     </Wrap>
 
     <Dialog

--- a/docs/contents/components/overlay/dialog/index.mdx
+++ b/docs/contents/components/overlay/dialog/index.mdx
@@ -115,17 +115,19 @@ const { isOpen, onOpen, onClose } = useDisclosure()
 return (
   <>
     <Wrap gap="md">
-      {sizeMap.map((size) => (
-        <Button
-          key={size}
-          onClick={() => {
-            setSize(size)
-            onOpen()
-          }}
-        >
-          Open {size} Dialog
-        </Button>
-      ))}
+      <For each={sizeMap}>
+        {(size) => (
+          <Button
+            key={size}
+            onClick={() => {
+              setSize(size)
+              onOpen()
+            }}
+          >
+            Open {size} Dialog
+          </Button>
+        )}
+      </For>
     </Wrap>
 
     <Dialog
@@ -167,17 +169,19 @@ const { isOpen, onOpen, onClose } = useDisclosure()
 return (
   <>
     <Wrap gap="md">
-      {placementMap.map((placement) => (
-        <Button
-          key={placement}
-          onClick={() => {
-            setPlacement(placement)
-            onOpen()
-          }}
-        >
-          Open {placement} Dialog
-        </Button>
-      ))}
+      <For each={placementMap}>
+        {(placement) => (
+          <Button
+            key={placement}
+            onClick={() => {
+              setPlacement(placement)
+              onOpen()
+            }}
+          >
+            Open {placement} Dialog
+          </Button>
+        )}
+      </For>
     </Wrap>
 
     <Dialog


### PR DESCRIPTION
Closes #3769 

## New behavior

The part using `map` was rewritten as `For`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Since I was told last time that there is no need to use `For` forcibly in `useTheme`, I use `For` only in the parts where `map` was used. I didn't think it was necessary to use a loop for the other parts.

