### PR TITLE
fix: replaced icon in `Autocomplete`

### DIFF
--- a/packages/react/src/components/autocomplete/autocomplete-create.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete-create.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react"
 import type { CSSUIObject, FC, HTMLUIProps } from "../../core"
 import { ui } from "../../core"
 import { cx, runIfFunc } from "../../utils"
+import { PlusIcon } from "../icon"
 import { useAutocompleteContext } from "./autocomplete-context"
 import { AutocompleteItemIcon } from "./autocomplete-icon"
 import { useAutocompleteCreate } from "./use-autocomplete-option"
@@ -55,7 +56,7 @@ export const AutocompleteCreate: FC<AutocompleteCreateProps> = ({
     >
       {icon !== null ? (
         <AutocompleteItemIcon>
-          {icon || <AutocompletePlusIcon />}
+          {icon || <PlusIcon boxSize="5.5" />}
         </AutocompleteItemIcon>
       ) : null}
       {icon ? (
@@ -70,14 +71,3 @@ export const AutocompleteCreate: FC<AutocompleteCreateProps> = ({
 }
 
 AutocompleteCreate.__ui__ = "AutocompleteCreate"
-
-const AutocompletePlusIcon: FC = () => (
-  <svg height="1em" viewBox="0 0 45.402 45.402" width="1em">
-    <path
-      d="M41.267,18.557H26.832V4.134C26.832,1.851,24.99,0,22.707,0c-2.283,0-4.124,1.851-4.124,4.135v14.432H4.141   c-2.283,0-4.139,1.851-4.138,4.135c-0.001,1.141,0.46,2.187,1.207,2.934c0.748,0.749,1.78,1.222,2.92,1.222h14.453V41.27   c0,1.142,0.453,2.176,1.201,2.922c0.748,0.748,1.777,1.211,2.919,1.211c2.282,0,4.129-1.851,4.129-4.133V26.857h14.435   c2.283,0,4.134-1.867,4.133-4.15C45.399,20.425,43.548,18.557,41.267,18.557z"
-      fill="currentColor"
-    />
-  </svg>
-)
-
-AutocompletePlusIcon.__ui__ = "AutocompletePlusIcon"

--- a/packages/react/src/components/autocomplete/autocomplete-empty.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete-empty.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react"
 import type { CSSUIObject, FC, HTMLUIProps } from "../../core"
 import { ui } from "../../core"
 import { cx } from "../../utils"
+import { MinusIcon } from "../icon"
 import { useAutocompleteContext } from "./autocomplete-context"
 import { AutocompleteItemIcon } from "./autocomplete-icon"
 import { useAutocompleteEmpty } from "./use-autocomplete-option"
@@ -56,7 +57,7 @@ export const AutocompleteEmpty: FC<AutocompleteEmptyProps> = ({
     >
       {icon !== null ? (
         <AutocompleteItemIcon>
-          {icon || <AutocompleteMinusIcon />}
+          {icon || <MinusIcon boxSize="5.5" />}
         </AutocompleteItemIcon>
       ) : null}
 
@@ -72,14 +73,3 @@ export const AutocompleteEmpty: FC<AutocompleteEmptyProps> = ({
 }
 
 AutocompleteEmpty.__ui__ = "AutocompleteEmpty"
-
-const AutocompleteMinusIcon: FC = () => (
-  <svg height="1em" viewBox="0 0 448 512" width="1em">
-    <path
-      d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z"
-      fill="currentColor"
-    />
-  </svg>
-)
-
-AutocompleteMinusIcon.__ui__ = "AutocompleteMinusIcon"

--- a/packages/react/src/components/autocomplete/autocomplete-icon.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete-icon.tsx
@@ -4,7 +4,7 @@ import { cloneElement, useRef } from "react"
 import { ui } from "../../core"
 import { useClickable } from "../../hooks/use-clickable"
 import { cx, getValidChildren, isValidElement } from "../../utils"
-import { ChevronIcon, CloseIcon } from "../icon"
+import { ChevronDownIcon, XIcon } from "../icon/icons"
 import { useAutocompleteContext } from "./autocomplete-context"
 
 export interface AutocompleteIconProps extends HTMLUIProps {}
@@ -50,7 +50,7 @@ export const AutocompleteIcon: FC<AutocompleteIconProps> = ({
       __css={css}
       {...rest}
     >
-      {isValidElement(children) ? cloneChildren : <ChevronIcon />}
+      {isValidElement(children) ? cloneChildren : <ChevronDownIcon />}
     </ui.div>
   )
 }
@@ -81,7 +81,7 @@ export const AutocompleteClearIcon: FC<AutocompleteClearIconProps> = ({
       __css={styles.clearIcon}
       {...rest}
     >
-      {children ?? <CloseIcon h="0.5em" w="0.5em" />}
+      {children ?? <XIcon boxSize="5.5" />}
     </AutocompleteIcon>
   )
 }

--- a/packages/react/src/components/autocomplete/autocomplete-option.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete-option.tsx
@@ -3,6 +3,7 @@ import type { CSSUIObject, FC } from "../../core"
 import type { UseAutocompleteOptionProps } from "./use-autocomplete-option"
 import { ui } from "../../core"
 import { cx } from "../../utils"
+import { CheckIcon } from "../icon/icons"
 import { useAutocompleteContext } from "./autocomplete-context"
 import { AutocompleteItemIcon } from "./autocomplete-icon"
 import { useAutocompleteOption } from "./use-autocomplete-option"
@@ -52,7 +53,7 @@ export const AutocompleteOption: FC<AutocompleteOptionProps> = ({
     >
       {icon !== null ? (
         <AutocompleteItemIcon opacity={selected ? 1 : 0}>
-          {icon || <AutocompleteCheckIcon />}
+          {icon || <CheckIcon boxSize="5" />}
         </AutocompleteItemIcon>
       ) : null}
 
@@ -64,14 +65,3 @@ export const AutocompleteOption: FC<AutocompleteOptionProps> = ({
 }
 
 AutocompleteOption.__ui__ = "AutocompleteOption"
-
-const AutocompleteCheckIcon: FC = () => (
-  <svg height="1em" viewBox="0 0 14 14" width="1em">
-    <polygon
-      fill="currentColor"
-      points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"
-    />
-  </svg>
-)
-
-AutocompleteCheckIcon.__ui__ = "AutocompleteCheckIcon"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3534  <!-- Github issue # here -->

## Description

Replaced by `LucideIcon`

<!-- Add a brief description. -->
<img width="686" alt="image" src="https://github.com/user-attachments/assets/a03b1f22-915d-4738-9667-a073a24b3d67" /> <img width="684" alt="image" src="https://github.com/user-attachments/assets/2402d96b-349e-4697-bdf3-bf4111cb2744" /> <img width="691" alt="image" src="https://github.com/user-attachments/assets/06ece77b-aea4-41aa-a4f3-ddc283686575" />



## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
