### PR TITLE
`avatar`: remove deprecated props

### DIFF
--- a/packages/react/src/components/avatar/avatar.stories.tsx
+++ b/packages/react/src/components/avatar/avatar.stories.tsx
@@ -58,7 +58,7 @@ export const WithFallback: Story = () => {
   )
 }
 
-export const WithBarge: Story = () => {
+export const WithBadge: Story = () => {
   return (
     <Avatar
       name="Hirotomo Yamada"

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -93,7 +93,7 @@ export const Avatar: FC<AvatarProps> = (props) => {
     ...rest
   } = omitThemeProps(mergedProps)
 
-  const [isLoaded, setIsLoaded] = useState<boolean>(false)
+  const [loaded, setLoaded] = useState<boolean>(false)
 
   const css: CSSUIObject = {
     alignItems: "center",
@@ -111,7 +111,7 @@ export const Avatar: FC<AvatarProps> = (props) => {
     <AvatarContext value={styles}>
       <ui.span
         className={cx("ui-avatar", className)}
-        data-loaded={dataAttr(isLoaded)}
+        data-loaded={dataAttr(loaded)}
         borderRadius={borderRadius}
         rounded={rounded}
         __css={css}
@@ -131,7 +131,7 @@ export const Avatar: FC<AvatarProps> = (props) => {
           referrerPolicy={referrerPolicy}
           rounded={rounded}
           onError={onError}
-          onLoad={handlerAll(onLoad, () => setIsLoaded(true))}
+          onLoad={handlerAll(onLoad, () => setLoaded(true))}
         />
         {children}
       </ui.span>
@@ -164,11 +164,11 @@ const AvatarImage: FC<AvatarImageProps> = ({
 }) => {
   const status = useImage({ src, crossOrigin, ignoreFallback, onError, onLoad })
 
-  const isLoaded = status === "loaded"
+  const loaded = status === "loaded"
 
-  const isFallback = !src || !isLoaded
+  const fallback = !src || !loaded
 
-  if (isFallback)
+  if (fallback)
     return name ? (
       <AvatarName name={name} format={format} />
     ) : (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3852 

## Description

This PR is to rename internal variables (remove `is` prefix) and fix storybook typo only, since there are no deprecated props.


## Is this a breaking change (Yes/No):
No

