### PR TITLE
Supported React 19.

### DIFF
--- a/.changeset/great-turkeys-sparkle.md
+++ b/.changeset/great-turkeys-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@yamada-ui/layouts": minor
+"@yamada-ui/popover": minor
+"@yamada-ui/tooltip": minor
+---
+
+Supported React 19.

--- a/.changeset/silly-moose-fetch.md
+++ b/.changeset/silly-moose-fetch.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/utils": minor
+---
+
+Added getRef function to react utils.

--- a/.changeset/young-tigers-warn.md
+++ b/.changeset/young-tigers-warn.md
@@ -1,0 +1,7 @@
+---
+"@yamada-ui/markdown": minor
+"@yamada-ui/motion": minor
+"@yamada-ui/core": minor
+---
+
+Supported React 19.

--- a/packages/components/layouts/src/stack.tsx
+++ b/packages/components/layouts/src/stack.tsx
@@ -3,6 +3,7 @@ import type { ReactElement, RefObject } from "react"
 import { forwardRef, ui } from "@yamada-ui/core"
 import {
   cx,
+  getRef,
   getValidChildren,
   mergeRefs,
   replaceObject,
@@ -284,9 +285,7 @@ export const ZStack = forwardRef<ZStackProps, "div">(
     )
 
     const cloneChildren = useMemo(() => {
-      const validChildren = getValidChildren(children) as ({
-        ref: RefObject<any>
-      } & ReactElement)[]
+      const validChildren = getValidChildren(children) as ReactElement[]
 
       const clonedChildren = validChildren.map((child, index) => {
         const ref = createRef<HTMLDivElement>()
@@ -311,7 +310,7 @@ export const ZStack = forwardRef<ZStackProps, "div">(
 
         const props = {
           ...child.props,
-          ref: mergeRefs(child.ref, ref),
+          ref: mergeRefs(getRef(child), ref),
           __css: css,
         }
 

--- a/packages/components/markdown/src/markdown.tsx
+++ b/packages/components/markdown/src/markdown.tsx
@@ -29,8 +29,9 @@ interface UIComponents {
 }
 
 export interface MarkdownComponents extends Components, UIComponents {}
-export type MarkdownComponentProps<Y extends keyof JSX.IntrinsicElements> =
-  JSX.IntrinsicElements[Y]
+export type MarkdownComponentProps<
+  Y extends keyof React.JSX.IntrinsicElements,
+> = React.JSX.IntrinsicElements[Y]
 
 const uiComponents = ({
   codeProps,

--- a/packages/components/motion/src/motion.types.ts
+++ b/packages/components/motion/src/motion.types.ts
@@ -175,7 +175,7 @@ export interface MotionComponent<Y extends MotionAs, D extends object = {}>
   <M extends MotionAs = Y>(props: ComponentProps<Y, M, D>): React.ReactElement
 }
 
-export type MotionAs = keyof React.ReactDOM
+export type MotionAs = keyof React.JSX.IntrinsicElements
 
 export type MotionComponents = {
   [Y in MotionAs]: UIMotionComponent<Y>
@@ -188,28 +188,8 @@ interface UIMotionProps extends Merge<UIProps, OriginMotionProps> {
   as?: MotionAs
 }
 
-type FactoryAttributes<Y> =
-  Y extends React.DetailedHTMLFactory<infer M, any>
-    ? M
-    : Y extends React.SVGFactory
-      ? React.SVGAttributes<SVGElement>
-      : never
-type FactoryElement<Y> =
-  Y extends React.DetailedHTMLFactory<any, infer M>
-    ? M
-    : Y extends React.SVGFactory
-      ? SVGElement
-      : never
-type DOMAttributes<
-  Y extends React.HTMLAttributes<M> | React.SVGAttributes<SVGElement>,
-  M extends HTMLElement | SVGElement,
-> = Y
-
 export type MotionProps<Y extends MotionAs = "div"> = Merge<
-  DOMAttributes<
-    FactoryAttributes<React.ReactDOM[Y]>,
-    FactoryElement<React.ReactDOM[Y]>
-  >,
+  React.ComponentPropsWithoutRef<Y>,
   UIMotionProps
 >
 

--- a/packages/components/popover/src/popover-anchor.tsx
+++ b/packages/components/popover/src/popover-anchor.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "@yamada-ui/core"
 import type { PropsWithChildren, ReactElement, RefObject } from "react"
+import { getRef } from "@yamada-ui/utils"
 import { Children, cloneElement } from "react"
 import { usePopover } from "./popover"
 
@@ -9,7 +10,7 @@ export const PopoverAnchor: FC<PropsWithChildren<{}>> = ({ children }) => {
   } & ReactElement
   const { getAnchorProps } = usePopover()
 
-  return cloneElement(child, getAnchorProps(child.props, child.ref))
+  return cloneElement(child, getAnchorProps(child.props, getRef(child)))
 }
 
 PopoverAnchor.displayName = "PopoverAnchor"

--- a/packages/components/popover/src/popover-trigger.tsx
+++ b/packages/components/popover/src/popover-trigger.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "@yamada-ui/core"
 import type { PropsWithChildren, ReactElement, RefObject } from "react"
+import { getRef } from "@yamada-ui/utils"
 import { Children, cloneElement } from "react"
 import { usePopover } from "./popover"
 
@@ -9,7 +10,7 @@ export const PopoverTrigger: FC<PropsWithChildren<{}>> = ({ children }) => {
   } & ReactElement
   const { getTriggerProps } = usePopover()
 
-  return cloneElement(child, getTriggerProps(child.props, child.ref))
+  return cloneElement(child, getTriggerProps(child.props, getRef(child)))
 }
 
 PopoverTrigger.displayName = "PopoverTrigger"

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -7,7 +7,7 @@ import type {
 import type { MotionProps, MotionTransitionProps } from "@yamada-ui/motion"
 import type { PortalProps } from "@yamada-ui/portal"
 import type { UsePopperProps } from "@yamada-ui/use-popper"
-import type { ReactElement, ReactNode, Ref } from "react"
+import type { ReactElement, ReactNode } from "react"
 import { omitThemeProps, ui, useComponentStyle } from "@yamada-ui/core"
 import { AnimatePresence, motion, motionForwardRef } from "@yamada-ui/motion"
 import { Portal } from "@yamada-ui/portal"
@@ -20,6 +20,7 @@ import {
   cx,
   getOwnerDocument,
   getOwnerWindow,
+  getRef,
   handlerAll,
   mergeRefs,
 } from "@yamada-ui/utils"
@@ -369,13 +370,14 @@ export const Tooltip = motionForwardRef<TooltipProps, "div">(
     // eslint-disable-next-line react/jsx-no-useless-fragment
     if (!label) return <>{children}</>
 
-    const child = Children.only(children) as {
-      ref?: Ref<HTMLElement>
-    } & ReactElement
+    const child = Children.only(children) as ReactElement
 
     const trigger = cloneElement(
       child,
-      getTriggerProps({ ...child.props, "aria-describedby": id }, child.ref),
+      getTriggerProps(
+        { ...child.props, "aria-describedby": id },
+        getRef(child),
+      ),
     )
 
     const css: CSSUIObject = {

--- a/packages/core/src/components/component.types.ts
+++ b/packages/core/src/components/component.types.ts
@@ -80,14 +80,14 @@ export interface UIComponent<Y extends As = As, M extends object = {}>
   extends Component<Y, Merge<UIProps, M>> {}
 
 export type HTMLRef<Y extends DOMElement = "div"> =
-  JSX.IntrinsicElements[Y]["ref"]
+  React.JSX.IntrinsicElements[Y]["ref"]
 
 export interface HTMLRefAttributes<Y extends DOMElement = "div"> {
   ref?: HTMLRef<Y> | undefined
 }
 
 export type HTMLProps<Y extends DOMElement = "div"> = Omit<
-  JSX.IntrinsicElements[Y],
+  React.JSX.IntrinsicElements[Y],
   "ref" | "size" | keyof UIProps
 >
 

--- a/packages/utils/src/react.tsx
+++ b/packages/utils/src/react.tsx
@@ -235,6 +235,22 @@ export function isRefObject(val: any): val is { current: any } {
   return isObject(val) && "current" in val
 }
 
+export function getRef<Y = HTMLElement>(
+  element: React.ReactElement<{ ref: React.Ref<Y> }>,
+): React.Ref<Y> | undefined {
+  let getter = Object.getOwnPropertyDescriptor(element.props, "ref")?.get
+
+  if (getter && "isReactWarning" in getter && getter.isReactWarning)
+    return (element as unknown as { ref: React.Ref<Y> }).ref
+
+  getter = Object.getOwnPropertyDescriptor(element, "ref")?.get
+
+  if (getter && "isReactWarning" in getter && getter.isReactWarning)
+    return element.props.ref
+
+  return element.props.ref || (element as unknown as { ref: React.Ref<Y> }).ref
+}
+
 export function assignRef<T = any>(ref: ReactRef<T> | undefined, value: T) {
   if (ref == null) return
 


### PR DESCRIPTION
Closes #3248
Closes #3835

## Description

- I have solved the `ref` problem in React.Specifically, we implemented a process to switch ref references in React's 18 and 19.
- Updated type definitions to reflect the updated React types.

## Is this a breaking change (Yes/No):

No