### PR TITLE
refactor: move styles to theme for form control

### DIFF
--- a/packages/react/src/components/form-control/form-control.tsx
+++ b/packages/react/src/components/form-control/form-control.tsx
@@ -190,7 +190,6 @@ export const FormControl: FC<FormControlProps> = ({ id, ...props }) => {
   const isCustomLabel = !!customLabel
   const isCustomHelperMessage = !!customHelperMessage
   const isCustomErrorMessage = !!customErrorMessage
-  const css: CSSUIObject = { ...styles.container }
 
   id ??= uuid
 
@@ -216,7 +215,7 @@ export const FormControl: FC<FormControlProps> = ({ id, ...props }) => {
           data-focus={dataAttr(focused)}
           data-invalid={dataAttr(invalid)}
           data-readonly={dataAttr(readOnly)}
-          __css={css}
+          __css={styles.container}
           {...rest}
         >
           {!isCustomLabel && label ? (
@@ -429,11 +428,6 @@ export const Label: FC<LabelProps> = ({
     required,
   } = useFormControlContext() ?? {}
   const styles = useFormControlStyles() ?? {}
-  const css: CSSUIObject = {
-    display: "block",
-    pointerEvents: readOnly ? "none" : undefined,
-    ...styles.label,
-  }
 
   id ??= labelId
   requiredProp ??= required
@@ -448,7 +442,10 @@ export const Label: FC<LabelProps> = ({
       data-focus={dataAttr(focused)}
       data-invalid={dataAttr(invalid)}
       data-readonly={dataAttr(readOnly)}
-      __css={css}
+      __css={{
+        pointerEvents: readOnly ? "none" : undefined,
+        ...styles.label,
+      }}
       {...rest}
     >
       {children}
@@ -475,14 +472,13 @@ export const RequiredIndicator: FC<RequiredIndicatorProps> = ({
   ...rest
 }) => {
   const styles = useFormControlStyles() ?? {}
-  const css: CSSUIObject = { ...styles.requiredIndicator }
 
   return !isValidElement(children) ? (
     <ui.span
       className={cx("ui-form__required-indicator", className)}
       aria-hidden
       role="presentation"
-      __css={css}
+      __css={styles.requiredIndicator}
       {...rest}
     >
       {children ?? <>*</>}
@@ -502,7 +498,6 @@ export const HelperMessage: FC<HelperMessageProps> = ({
 }) => {
   const { id, invalid, replace } = useFormControlContext() ?? {}
   const styles = useFormControlStyles() ?? {}
-  const css: CSSUIObject = { ...styles.helperMessage }
 
   if (replace && invalid) return null
 
@@ -510,7 +505,7 @@ export const HelperMessage: FC<HelperMessageProps> = ({
     <ui.span
       className={cx("ui-form__helper-message", className)}
       aria-describedby={id}
-      __css={css}
+      __css={styles.helperMessage}
       {...rest}
     />
   )
@@ -523,7 +518,6 @@ export interface ErrorMessageProps extends HTMLUIProps<"span"> {}
 export const ErrorMessage: FC<ErrorMessageProps> = ({ className, ...rest }) => {
   const { invalid } = useFormControlContext() ?? {}
   const styles = useFormControlStyles() ?? {}
-  const css: CSSUIObject = { ...styles.errorMessage }
 
   if (!invalid) return null
 
@@ -531,7 +525,7 @@ export const ErrorMessage: FC<ErrorMessageProps> = ({ className, ...rest }) => {
     <ui.span
       className={cx("ui-form__error-message", className)}
       aria-live="polite"
-      __css={css}
+      __css={styles.errorMessage}
       {...rest}
     />
   )

--- a/packages/react/src/theme/components/form-control.ts
+++ b/packages/react/src/theme/components/form-control.ts
@@ -19,6 +19,7 @@ export const FormControl: ComponentMultiStyle<"FormControl"> = {
       mt: "2",
     },
     label: {
+      display: "block",
       fontSize: "md",
       fontWeight: "medium",
       mb: "2",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/3896

## Description

<!-- Add a brief description. -->

Migrate styles from components to themes.
Since component styles in themes inherit styles from other components using mergeStyle etc., duplicate styles should be removed.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
