### PR TITLE
`file-input`: remove deprecated props

### DIFF
--- a/packages/react/src/components/file-input/file-input.stories.tsx
+++ b/packages/react/src/components/file-input/file-input.stories.tsx
@@ -103,56 +103,52 @@ export const WithBorderColor: Story = () => {
       />
       <FileInput
         errorBorderColor="orange.500"
-        isInvalid
+        invalid
         placeholder="custom border color"
       />
     </>
   )
 }
 
-export const IsDisabled: Story = () => {
+export const Disabled: Story = () => {
   return (
     <>
-      <FileInput variant="outline" isDisabled placeholder="outline" />
-      <FileInput variant="filled" isDisabled placeholder="filled" />
-      <FileInput variant="flushed" isDisabled placeholder="flushed" />
-      <FileInput variant="unstyled" isDisabled placeholder="unstyled" />
+      <FileInput variant="outline" disabled placeholder="outline" />
+      <FileInput variant="filled" disabled placeholder="filled" />
+      <FileInput variant="flushed" disabled placeholder="flushed" />
+      <FileInput variant="unstyled" disabled placeholder="unstyled" />
 
-      <FormControl isDisabled label="Upload file">
+      <FormControl disabled label="Upload file">
         <FileInput type="email" placeholder="your file" />
       </FormControl>
     </>
   )
 }
 
-export const IsReadonly: Story = () => {
+export const Readonly: Story = () => {
   return (
     <>
-      <FileInput variant="outline" isReadOnly placeholder="outline" />
-      <FileInput variant="filled" isReadOnly placeholder="filled" />
-      <FileInput variant="flushed" isReadOnly placeholder="flushed" />
-      <FileInput variant="unstyled" isReadOnly placeholder="unstyled" />
+      <FileInput variant="outline" placeholder="outline" readOnly />
+      <FileInput variant="filled" placeholder="filled" readOnly />
+      <FileInput variant="flushed" placeholder="flushed" readOnly />
+      <FileInput variant="unstyled" placeholder="unstyled" readOnly />
 
-      <FormControl isReadOnly label="Upload file">
+      <FormControl label="Upload file" readOnly>
         <FileInput type="email" placeholder="your file" />
       </FormControl>
     </>
   )
 }
 
-export const IsInvalid: Story = () => {
+export const Invalid: Story = () => {
   return (
     <>
-      <FileInput variant="outline" isInvalid placeholder="outline" />
-      <FileInput variant="filled" isInvalid placeholder="filled" />
-      <FileInput variant="flushed" isInvalid placeholder="flushed" />
-      <FileInput variant="unstyled" isInvalid placeholder="unstyled" />
+      <FileInput variant="outline" invalid placeholder="outline" />
+      <FileInput variant="filled" invalid placeholder="filled" />
+      <FileInput variant="flushed" invalid placeholder="flushed" />
+      <FileInput variant="unstyled" invalid placeholder="unstyled" />
 
-      <FormControl
-        errorMessage="File is required."
-        isInvalid
-        label="Upload file"
-      >
+      <FormControl errorMessage="File is required." invalid label="Upload file">
         <FileInput type="email" placeholder="your file" />
       </FormControl>
     </>
@@ -203,7 +199,7 @@ export const UseReset: Story = () => {
         />
 
         {value?.length ? (
-          <InputRightElement isClickable onClick={onReset}>
+          <InputRightElement clickable onClick={onReset}>
             <XIcon color="gray.500" />
           </InputRightElement>
         ) : null}
@@ -250,7 +246,7 @@ export const ReactHookForm: Story = () => {
     <VStack as="form" onSubmit={handleSubmit(onSubmit)}>
       <FormControl
         errorMessage={errors.fileInput?.message}
-        isInvalid={!!errors.fileInput}
+        invalid={!!errors.fileInput}
         label="Files"
       >
         <Controller
@@ -261,7 +257,7 @@ export const ReactHookForm: Story = () => {
               <FileInput multiple {...field} resetRef={resetRef} />
 
               {field.value?.length ? (
-                <InputRightElement isClickable onClick={onReset}>
+                <InputRightElement clickable onClick={onReset}>
                   <XIcon color="gray.500" />
                 </InputRightElement>
               ) : null}

--- a/packages/react/src/components/file-input/file-input.test.tsx
+++ b/packages/react/src/components/file-input/file-input.test.tsx
@@ -77,25 +77,19 @@ describe("<FileInput />", () => {
   })
 
   test("should be disabled", () => {
-    const { container } = render(
-      <FileInput data-testid="FileInput" isDisabled />,
-    )
+    const { container } = render(<FileInput data-testid="FileInput" disabled />)
     expect(container.querySelector('input[type="file"]')).toBeDisabled()
   })
 
   test("should be read only", () => {
-    const { container } = render(
-      <FileInput data-testid="FileInput" isReadOnly />,
-    )
+    const { container } = render(<FileInput data-testid="FileInput" readOnly />)
     expect(container.querySelector('input[type="file"]')).toHaveAttribute(
       "readonly",
     )
   })
 
   test("should be invalid", () => {
-    const { container } = render(
-      <FileInput data-testid="FileInput" isInvalid />,
-    )
+    const { container } = render(<FileInput data-testid="FileInput" invalid />)
     expect(container.querySelector('input[type="file"]')).toHaveAttribute(
       "aria-invalid",
       "true",
@@ -255,7 +249,7 @@ describe("<FileInput />", () => {
 
   test("click should not be called in the inner input element after click when disabled", () => {
     const { container } = render(
-      <FileInput data-testid="file-input" isDisabled />,
+      <FileInput data-testid="file-input" disabled />,
     )
     const fileInputElement = container.querySelector('input[type="file"]')
     const listener = vi.fn()
@@ -268,7 +262,7 @@ describe("<FileInput />", () => {
 
   test("click should not be called in the inner input element after click when readonly", () => {
     const { container } = render(
-      <FileInput data-testid="file-input" isReadOnly />,
+      <FileInput data-testid="file-input" readOnly />,
     )
     const fileInputElement = container.querySelector('input[type="file"]')
     const listener = vi.fn()

--- a/packages/react/src/components/file-input/file-input.tsx
+++ b/packages/react/src/components/file-input/file-input.tsx
@@ -180,12 +180,12 @@ export const FileInput: FC<FileInputProps> = ({ ref, children, ...props }) => {
       return (
         <ui.span lineClamp={lineClamp}>
           {values.map((value, index) => {
-            const isLast = values.length === index + 1
+            const last = values.length === index + 1
 
             return (
               <ui.span key={index} display="inline-block" me="0.25rem">
                 {format(value, index)}
-                {!isLast ? separator : null}
+                {!last ? separator : null}
               </ui.span>
             )
           })}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3866 

## Description

Removed `isReadOnly`, `isInvalid`, `isDisabled` from `form-control` package

## Is this a breaking change (Yes/No):

No

## Additional Information
