### PR TITLE
`input`: remove deprecated props

### DIFF
--- a/packages/react/src/components/input/input-element.tsx
+++ b/packages/react/src/components/input/input-element.tsx
@@ -11,22 +11,6 @@ interface InputElementOptions {
    */
   clickable?: boolean
   /**
-   * If `true`, the element clickable.
-   *
-   * @default false
-   *
-   * @deprecated Use `clickable` instead.
-   */
-  isClick?: boolean
-  /**
-   * If `true`, the element clickable.
-   *
-   * @default false
-   *
-   * @deprecated Use `clickable` instead.
-   */
-  isClickable?: boolean
-  /**
    * The placement of the element.
    *
    * @default 'left'
@@ -38,9 +22,7 @@ export interface InputElementProps extends HTMLUIProps, InputElementOptions {}
 
 const InputElement: FC<InputElementProps> = ({
   className,
-  isClick = false,
-  isClickable = isClick,
-  clickable = isClickable,
+  clickable = false,
   placement = "left",
   ...rest
 }) => {

--- a/packages/react/src/components/input/input-group.tsx
+++ b/packages/react/src/components/input/input-group.tsx
@@ -47,14 +47,14 @@ export const InputGroup: FC<InputGroupProps> = (props) => {
   })
 
   const cloneChildren = validChildren.map((child) => {
-    const isAddonElement = [
+    const addonElement = [
       InputLeftAddon,
       InputRightAddon,
       InputLeftElement,
       InputRightElement,
     ].some((type) => child.type === type)
 
-    if (isAddonElement) {
+    if (addonElement) {
       return child
     } else {
       const childProps = filterUndefined({

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -61,24 +61,24 @@ export const WithBorderColor: Story = () => {
       <Input focusBorderColor="green.500" placeholder="custom border color" />
       <Input
         errorBorderColor="orange.500"
-        isInvalid
+        invalid
         placeholder="custom border color"
       />
     </>
   )
 }
 
-export const IsDisabled: Story = () => {
+export const Disabled: Story = () => {
   return (
     <>
-      <Input variant="outline" isDisabled placeholder="outline" />
-      <Input variant="filled" isDisabled placeholder="filled" />
-      <Input variant="flushed" isDisabled placeholder="flushed" />
-      <Input variant="unstyled" isDisabled placeholder="unstyled" />
+      <Input variant="outline" disabled placeholder="outline" />
+      <Input variant="filled" disabled placeholder="filled" />
+      <Input variant="flushed" disabled placeholder="flushed" />
+      <Input variant="unstyled" disabled placeholder="unstyled" />
 
       <FormControl
+        disabled
         helperMessage="We'll never share your email."
-        isDisabled
         label="Email address"
       >
         <Input type="email" placeholder="your email address" />
@@ -87,18 +87,18 @@ export const IsDisabled: Story = () => {
   )
 }
 
-export const IsReadonly: Story = () => {
+export const Readonly: Story = () => {
   return (
     <>
-      <Input variant="outline" isReadOnly placeholder="outline" />
-      <Input variant="filled" isReadOnly placeholder="filled" />
-      <Input variant="flushed" isReadOnly placeholder="flushed" />
-      <Input variant="unstyled" isReadOnly placeholder="unstyled" />
+      <Input variant="outline" placeholder="outline" readOnly />
+      <Input variant="filled" placeholder="filled" readOnly />
+      <Input variant="flushed" placeholder="flushed" readOnly />
+      <Input variant="unstyled" placeholder="unstyled" readOnly />
 
       <FormControl
         helperMessage="We'll never share your email."
-        isReadOnly
         label="Email address"
+        readOnly
       >
         <Input type="email" placeholder="your email address" />
       </FormControl>
@@ -106,17 +106,17 @@ export const IsReadonly: Story = () => {
   )
 }
 
-export const IsInvalid: Story = () => {
+export const Invalid: Story = () => {
   return (
     <>
-      <Input variant="outline" isInvalid placeholder="outline" />
-      <Input variant="filled" isInvalid placeholder="filled" />
-      <Input variant="flushed" isInvalid placeholder="flushed" />
-      <Input variant="unstyled" isInvalid placeholder="unstyled" />
+      <Input variant="outline" invalid placeholder="outline" />
+      <Input variant="filled" invalid placeholder="filled" />
+      <Input variant="flushed" invalid placeholder="flushed" />
+      <Input variant="unstyled" invalid placeholder="unstyled" />
 
       <FormControl
         errorMessage="Email is required."
-        isInvalid
+        invalid
         label="Email address"
       >
         <Input type="email" placeholder="your email address" />
@@ -170,7 +170,7 @@ export const UseElement: Story = () => {
           placeholder="your password"
           pr="4.5rem"
         />
-        <InputRightElement isClickable w="4.5rem">
+        <InputRightElement clickable w="4.5rem">
           <Button size="sm" h="1.75rem" onClick={toggle}>
             {show ? "Hide" : "Show"}
           </Button>
@@ -229,7 +229,7 @@ export const ReactHookForm: Story = () => {
     <VStack as="form" onSubmit={handleSubmit(onSubmit)}>
       <FormControl
         errorMessage={errors.name?.message}
-        isInvalid={!!errors.name}
+        invalid={!!errors.name}
         label="Name"
       >
         <Input
@@ -242,7 +242,7 @@ export const ReactHookForm: Story = () => {
 
       <FormControl
         errorMessage={errors.cellphone?.message}
-        isInvalid={!!errors.cellphone}
+        invalid={!!errors.cellphone}
         label="Cellphone"
       >
         <InputGroup>
@@ -259,7 +259,7 @@ export const ReactHookForm: Story = () => {
 
       <FormControl
         errorMessage={errors.email?.message}
-        isInvalid={!!errors.email}
+        invalid={!!errors.email}
         label="Email"
       >
         <InputGroup>
@@ -311,7 +311,7 @@ export const ReactHookFormWithDefaultValue: Story = () => {
     <VStack as="form" onSubmit={handleSubmit(onSubmit)}>
       <FormControl
         errorMessage={errors.name?.message}
-        isInvalid={!!errors.name}
+        invalid={!!errors.name}
         label="Name"
       >
         <Input
@@ -324,7 +324,7 @@ export const ReactHookFormWithDefaultValue: Story = () => {
 
       <FormControl
         errorMessage={errors.cellphone?.message}
-        isInvalid={!!errors.cellphone}
+        invalid={!!errors.cellphone}
         label="Cellphone"
       >
         <InputGroup>
@@ -341,7 +341,7 @@ export const ReactHookFormWithDefaultValue: Story = () => {
 
       <FormControl
         errorMessage={errors.email?.message}
-        isInvalid={!!errors.email}
+        invalid={!!errors.email}
         label="Email"
       >
         <InputGroup>

--- a/packages/react/src/components/input/input.test.tsx
+++ b/packages/react/src/components/input/input.test.tsx
@@ -53,7 +53,7 @@ describe("<Input />", () => {
   })
 
   test("Invalid input renders correctly", async () => {
-    render(<Input isInvalid />)
+    render(<Input invalid />)
 
     const input = await screen.findByRole("textbox")
     expect(input).toBeInvalid()
@@ -61,14 +61,14 @@ describe("<Input />", () => {
   })
 
   test("Disabled input renders correctly", async () => {
-    render(<Input isDisabled />)
+    render(<Input disabled />)
 
     const input = await screen.findByRole("textbox")
     expect(input).toBeDisabled()
   })
 
   test("Readonly input renders correctly", async () => {
-    render(<Input isReadOnly />)
+    render(<Input readOnly />)
 
     const input = await screen.findByRole("textbox")
     expect(input).toHaveAttribute("aria-readonly", "true")


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3873 

## Description
Removed `isClick`, `isClickable` props

## Is this a breaking change (Yes/No):
No

## Additional Information
