### PR TITLE
refactor: move styles to theme for form native-select

### DIFF
--- a/packages/react/src/components/native-select/native-select.tsx
+++ b/packages/react/src/components/native-select/native-select.tsx
@@ -215,17 +215,6 @@ const NativeSelectIcon: FC<NativeSelectIconProps> = ({
 }) => {
   const styles = useNativeSelect()
 
-  const css: CSSUIObject = {
-    alignItems: "center",
-    display: "inline-flex",
-    justifyContent: "center",
-    pointerEvents: "none",
-    position: "absolute",
-    top: "50%",
-    transform: "translateY(-50%)",
-    ...styles.icon,
-  }
-
   const validChildren = getValidChildren(children)
 
   const cloneChildren = validChildren.map((child) =>
@@ -241,7 +230,11 @@ const NativeSelectIcon: FC<NativeSelectIconProps> = ({
   )
 
   return (
-    <ui.div className={cx("ui-select__icon", className)} __css={css} {...rest}>
+    <ui.div
+      className={cx("ui-select__icon", className)}
+      __css={styles.icon}
+      {...rest}
+    >
       {isValidElement(children) ? cloneChildren : <ChevronIcon />}
     </ui.div>
   )

--- a/packages/react/src/theme/components/native-select.ts
+++ b/packages/react/src/theme/components/native-select.ts
@@ -21,10 +21,17 @@ export const NativeSelect: ComponentMultiStyle<"NativeSelect"> =
         },
       },
       icon: {
+        alignItems: "center",
         color: ["blackAlpha.600", "whiteAlpha.700"],
+        display: "inline-flex",
+        justifyContent: "center",
         outline: 0,
+        pointerEvents: "none",
+        position: "absolute",
         py: "2",
         rounded: "md",
+        top: "50%",
+        transform: "translateY(-50%)",
         w: "6",
         _disabled: {
           opacity: 0.4,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/3913

## Description

<!-- Add a brief description. -->
Migrate styles from components to themes.
Since component styles in themes inherit styles from other components using mergeStyle etc., duplicate styles should be removed.
## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
