### PR TITLE
refactor: move styles to theme for form tabs

### DIFF
--- a/packages/react/src/components/tabs/tab-list.tsx
+++ b/packages/react/src/components/tabs/tab-list.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent, KeyboardEventHandler } from "react"
-import type { CSSUIObject, HTMLUIProps } from "../../core"
+import type { HTMLUIProps } from "../../core"
 import { useCallback } from "react"
 import { forwardRef, ui } from "../../core"
 import { cx, handlerAll } from "../../utils"
@@ -58,15 +58,13 @@ export const TabList = forwardRef<TabListProps, "div">(
       [onFirst, onLast, isVertical, onPrev, onNext],
     )
 
-    const css: CSSUIObject = { display: "flex", ...styles.tabList }
-
     return (
       <ui.div
         ref={ref}
         className={cx("ui-tabs__list", className)}
         aria-orientation={orientation}
         role="tablist"
-        __css={css}
+        __css={styles.tabList}
         {...tabListProps}
         {...rest}
         onKeyDown={handlerAll(rest.onKeyDown, onKeyDown)}

--- a/packages/react/src/components/tabs/tab-panels.tsx
+++ b/packages/react/src/components/tabs/tab-panels.tsx
@@ -1,4 +1,4 @@
-import type { CSSUIObject, HTMLUIProps } from "../../core"
+import type { HTMLUIProps } from "../../core"
 import { createElement } from "react"
 import { forwardRef, ui } from "../../core"
 import { cx, getValidChildren } from "../../utils"
@@ -20,16 +20,11 @@ export const TabPanels = forwardRef<TabPanelsProps, "div">(
       )
     })
 
-    const css: CSSUIObject = {
-      w: "100%",
-      ...styles.tabPanels,
-    }
-
     return (
       <ui.div
         ref={ref}
         className={cx("ui-tabs__panels", className)}
-        __css={css}
+        __css={styles.tabPanels}
         {...tabPanelsProps}
         {...rest}
       >

--- a/packages/react/src/components/tabs/tab.tsx
+++ b/packages/react/src/components/tabs/tab.tsx
@@ -1,4 +1,4 @@
-import type { CSSUIObject, HTMLUIProps } from "../../core"
+import type { HTMLUIProps } from "../../core"
 import type { UseClickableProps } from "../../hooks/use-clickable"
 import type { Merge } from "../../utils"
 import { useId } from "react"
@@ -47,15 +47,6 @@ export const Tab = forwardRef<TabProps, "button">(
     const { descendants } = useTabPanelDescendant()
     const tabpanelId = descendants.value(index)?.node.id
     const isSelected = index === selectedIndex
-    const css: CSSUIObject = {
-      alignItems: "center",
-      display: "flex",
-      justifyContent: "center",
-      outline: "0",
-      overflow: "hidden",
-      position: "relative",
-      ...styles.tab,
-    }
 
     id ??= uuid
 
@@ -88,7 +79,7 @@ export const Tab = forwardRef<TabProps, "button">(
     return (
       <ui.button
         className={cx("ui-tabs__tab", className)}
-        __css={css}
+        __css={styles.tab}
         {...clickableProps}
         type="button"
         data-orientation={orientation}

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import type { CSSUIObject, HTMLUIProps, ThemeProps } from "../../core"
+import type { HTMLUIProps, ThemeProps } from "../../core"
 import type { LazyMode } from "../../hooks/use-disclosure"
 import type { TabListProps } from "./tab-list"
 import type { TabPanelsProps } from "./tab-panels"
@@ -166,8 +166,6 @@ export const Tabs = forwardRef<TabsProps, "div">(
     const cloneTabs = pickChildren(validChildren, Tab)
     const cloneTabPanels = pickChildren(validChildren, TabPanel)
 
-    const css: CSSUIObject = { w: "100%", ...styles.container }
-
     useEffect(() => {
       if (index != null) setFocusedIndex(index)
     }, [index])
@@ -196,7 +194,7 @@ export const Tabs = forwardRef<TabsProps, "div">(
             <ui.div
               ref={ref}
               className={cx("ui-tabs", className)}
-              __css={css}
+              __css={styles.container}
               {...rest}
             >
               {customTabList ?? <TabList>{cloneTabs}</TabList>}

--- a/packages/react/src/theme/components/tabs.ts
+++ b/packages/react/src/theme/components/tabs.ts
@@ -6,9 +6,16 @@ export const Tabs: ComponentMultiStyle<"Tabs"> = {
     container: ({ orientation }) => ({
       display: "flex",
       flexDirection: orientation === "vertical" ? "row" : "column",
+      w: "100%",
     }),
     tab: ({ isFitted }) => ({
+      alignItems: "center",
+      display: "flex",
       flex: isFitted ? 1 : undefined,
+      justifyContent: "center",
+      outline: "0",
+      overflow: "hidden",
+      position: "relative",
       transitionDuration: "normal",
       transitionProperty: "common",
       whiteSpace: "nowrap",
@@ -24,13 +31,16 @@ export const Tabs: ComponentMultiStyle<"Tabs"> = {
       _selected: { _hover: { opacity: 1 } },
     }),
     tabList: ({ align, orientation }) => ({
+      display: "flex",
       flexDirection: orientation === "vertical" ? "column" : "row",
       justifyContent: align === "center" ? align : `flex-${align}`,
     }),
     tabPanel: {
       p: "md",
     },
-    tabPanels: {},
+    tabPanels: {
+      w: "100%",
+    },
   },
 
   variants: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/3939

## Description
Migrate styles from components to themes.
Since component styles in themes inherit styles from other components using mergeStyle etc., duplicate styles should be removed.

<!-- Add a brief description. -->

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
