### PR TITLE
`password-input`: remove deprecated props

### DIFF
--- a/packages/react/src/components/password-input/password-input.stories.tsx
+++ b/packages/react/src/components/password-input/password-input.stories.tsx
@@ -64,7 +64,7 @@ export const WithBorderColor: Story = () => {
       />
       <PasswordInput
         errorBorderColor="orange.500"
-        isInvalid
+        invalid
         placeholder="custom border color"
       />
     </>
@@ -98,17 +98,17 @@ export const WithStrengthMeter: Story = () => {
   )
 }
 
-export const IsDisabled: Story = () => {
+export const Disabled: Story = () => {
   return (
     <>
-      <PasswordInput variant="outline" isDisabled placeholder="outline" />
-      <PasswordInput variant="filled" isDisabled placeholder="filled" />
-      <PasswordInput variant="flushed" isDisabled placeholder="flushed" />
-      <PasswordInput variant="unstyled" isDisabled placeholder="unstyled" />
+      <PasswordInput variant="outline" disabled placeholder="outline" />
+      <PasswordInput variant="filled" disabled placeholder="filled" />
+      <PasswordInput variant="flushed" disabled placeholder="flushed" />
+      <PasswordInput variant="unstyled" disabled placeholder="unstyled" />
 
       <FormControl
+        disabled
         helperMessage="We'll never share your password."
-        isDisabled
         label="Password"
       >
         <PasswordInput placeholder="your password" />
@@ -117,18 +117,18 @@ export const IsDisabled: Story = () => {
   )
 }
 
-export const IsReadonly: Story = () => {
+export const Readonly: Story = () => {
   return (
     <>
-      <PasswordInput variant="outline" isReadOnly placeholder="outline" />
-      <PasswordInput variant="filled" isReadOnly placeholder="filled" />
-      <PasswordInput variant="flushed" isReadOnly placeholder="flushed" />
-      <PasswordInput variant="unstyled" isReadOnly placeholder="unstyled" />
+      <PasswordInput variant="outline" placeholder="outline" readOnly />
+      <PasswordInput variant="filled" placeholder="filled" readOnly />
+      <PasswordInput variant="flushed" placeholder="flushed" readOnly />
+      <PasswordInput variant="unstyled" placeholder="unstyled" readOnly />
 
       <FormControl
         helperMessage="We'll never share your password."
-        isReadOnly
         label="Password"
+        readOnly
       >
         <PasswordInput placeholder="your password" />
       </FormControl>
@@ -136,15 +136,15 @@ export const IsReadonly: Story = () => {
   )
 }
 
-export const IsInvalid: Story = () => {
+export const Invalid: Story = () => {
   return (
     <>
-      <PasswordInput variant="outline" isInvalid placeholder="outline" />
-      <PasswordInput variant="filled" isInvalid placeholder="filled" />
-      <PasswordInput variant="flushed" isInvalid placeholder="flushed" />
-      <PasswordInput variant="unstyled" isInvalid placeholder="unstyled" />
+      <PasswordInput variant="outline" invalid placeholder="outline" />
+      <PasswordInput variant="filled" invalid placeholder="filled" />
+      <PasswordInput variant="flushed" invalid placeholder="flushed" />
+      <PasswordInput variant="unstyled" invalid placeholder="unstyled" />
 
-      <FormControl errorMessage="Email is required." isInvalid label="Password">
+      <FormControl errorMessage="Email is required." invalid label="Password">
         <PasswordInput placeholder="your password" />
       </FormControl>
     </>
@@ -193,7 +193,7 @@ export const ReactHookForm: Story = () => {
     <VStack as="form" onSubmit={handleSubmit(onSubmit)}>
       <FormControl
         errorMessage={errors.password?.message}
-        isInvalid={!!errors.password}
+        invalid={!!errors.password}
         label="Password"
       >
         <PasswordInput
@@ -229,7 +229,7 @@ export const ReactHookFormWithDefaultValue: Story = () => {
     <VStack as="form" onSubmit={handleSubmit(onSubmit)}>
       <FormControl
         errorMessage={errors.password?.message}
-        isInvalid={!!errors.password}
+        invalid={!!errors.password}
         label="Password"
       >
         <PasswordInput

--- a/packages/react/src/components/password-input/use-password-input.tsx
+++ b/packages/react/src/components/password-input/use-password-input.tsx
@@ -12,24 +12,8 @@ interface UsePasswordInputOptions {
    * Determines whether the password input is visible by default.
    *
    * @default false
-   *
-   * @deprecated Use `defaultVisible` instead.
-   */
-  defaultIsVisible?: boolean
-  /**
-   * Determines whether the password input is visible by default.
-   *
-   * @default false
    */
   defaultVisible?: boolean
-  /**
-   * Determines the visibility of the password input.
-   *
-   * @default false
-   *
-   * @deprecated Use `visible` instead.
-   */
-  isVisible?: boolean
   /**
    * Determines the visibility of the password input.
    *
@@ -52,10 +36,8 @@ export interface UsePasswordInputProps
 
 export const usePasswordInput = (props: UsePasswordInputProps) => {
   const {
-    defaultIsVisible,
-    defaultVisible = defaultIsVisible,
-    isVisible,
-    visible: visibleProp = isVisible,
+    defaultVisible,
+    visible: visibleProp,
     onVisibleChange,
     ...rest
   } = useFormControlProps(props)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3962 

## Description
Removed `defaultIsVisible` and `isVisible` props
Replaced `form-control` props


## Is this a breaking change (Yes/No):

No

## Additional Information
