### PR TITLE
`<Drawer />`: `fullHeight` did not work

### DIFF
--- a/.changeset/fifty-mugs-appear.md
+++ b/.changeset/fifty-mugs-appear.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/modal": patch
+"@yamada-ui/theme": patch
+---
+
+Fixed the issue that `fullHeight` prop did not work in `Drawer`

--- a/packages/components/modal/src/drawer.tsx
+++ b/packages/components/modal/src/drawer.tsx
@@ -88,10 +88,21 @@ export interface DrawerProps
  * @see Docs https://yamada-ui.com/components/overlay/drawer
  */
 export const Drawer = motionForwardRef<DrawerProps, "div">(
-  ({ size, closeOnDrag = false, placement = "right", ...props }, ref) => {
+  (
+    {
+      size,
+      closeOnDrag = false,
+      isFullHeight,
+      fullHeight = isFullHeight,
+      placement = "right",
+      ...props
+    },
+    ref,
+  ) => {
     const [styles, mergedProps] = useComponentMultiStyle("Drawer", {
       size,
       closeOnDrag,
+      fullHeight,
       placement,
       ...props,
     })
@@ -124,7 +135,7 @@ export const Drawer = motionForwardRef<DrawerProps, "div">(
       onEsc,
       onOverlayClick,
       ...rest
-    } = omitThemeProps(mergedProps, ["isFullHeight"])
+    } = omitThemeProps(mergedProps, ["fullHeight"])
     const validChildren = getValidChildren(children)
     const [customDrawerOverlay, ...cloneChildren] = findChildren(
       validChildren,

--- a/packages/theme/src/components/drawer.ts
+++ b/packages/theme/src/components/drawer.ts
@@ -8,8 +8,8 @@ export const Drawer: ComponentMultiStyle<"Drawer"> = mergeMultiStyle(Modal, {
     body: {
       overflow: "auto",
     },
-    container: ({ isFullHeight, placement }) => ({
-      ...(isFullHeight ? { height: "100dvh", rounded: 0 } : {}),
+    container: ({ fullHeight, placement }) => ({
+      ...(fullHeight ? { height: "100dvh", rounded: 0 } : {}),
       [`rounded${toPascalCase(placement)}`]: 0,
     }),
     dragBar: ({ placement }) => ({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4278 

## Description

Fixed the bug that `fullHeight` prop did not work in `Drawer`

## Current behavior (updates)

`fullHeight` won't occupy the viewport height.

## New behavior

`fullHeight` will occupy the viewport height.

## Is this a breaking change (Yes/No):

No

## Additional Information
