### PR TITLE
`progress`: remove deprecated props

### DIFF
--- a/packages/react/src/components/progress/circle-progress.stories.tsx
+++ b/packages/react/src/components/progress/circle-progress.stories.tsx
@@ -39,9 +39,5 @@ export const WithLabel: Story = () => {
 }
 
 export const WithRounded: Story = () => {
-  return <CircleProgress aria-label="Storage space" isRounded value={18} />
-}
-
-export const UseAnimation: Story = () => {
-  return <CircleProgress isAnimation value={18} />
+  return <CircleProgress aria-label="Storage space" fullRounded value={18} />
 }

--- a/packages/react/src/components/progress/circle-progress.test.tsx
+++ b/packages/react/src/components/progress/circle-progress.test.tsx
@@ -12,7 +12,7 @@ describe("<CircleProgress />", () => {
         data-testid="circle-progress-a"
         boxSize="8rem"
         color="green.500"
-        isRounded
+        fullRounded
         max={100}
         min={0}
         thickness="0.5rem"
@@ -26,16 +26,8 @@ describe("<CircleProgress />", () => {
   test("render correctly with animation", () => {
     render(
       <>
-        <CircleProgress
-          data-testid="circle-progress-b"
-          isAnimation
-          speed={["1s", "3s"]}
-        />
-        <CircleProgress
-          data-testid="circle-progress-c"
-          isAnimation
-          speed={[1, 3]}
-        />
+        <CircleProgress data-testid="circle-progress-b" speed={["1s", "3s"]} />
+        <CircleProgress data-testid="circle-progress-c" speed={[1, 3]} />
       </>,
     )
     expect(screen.getByTestId("circle-progress-b")).toBeInTheDocument()

--- a/packages/react/src/components/progress/circle-progress.tsx
+++ b/packages/react/src/components/progress/circle-progress.tsx
@@ -6,7 +6,6 @@ import type {
   ThemeProps,
 } from "../../core"
 import { forwardRef, omitThemeProps, ui, useComponentStyle } from "../../core"
-import { useAnimation } from "../../hooks/use-animation"
 import { cx, valueToPercent } from "../../utils"
 
 interface CircleProgressOptions {
@@ -29,22 +28,6 @@ interface CircleProgressOptions {
    * @default false
    */
   fullRounded?: boolean
-  /**
-   * If `true`, the progress will be indeterminate and the `value` prop will be ignored.
-   *
-   * @default false
-   *
-   * @deprecated It will be deprecated in version 2.0.
-   */
-  isAnimation?: boolean
-  /**
-   * If `true`, the cap of the progress indicator will be rounded.
-   *
-   * @default false
-   *
-   * @deprecated Use `fullRounded` instead.
-   */
-  isRounded?: boolean
   /**
    * The maximum value of the progress.
    *
@@ -104,9 +87,7 @@ export const CircleProgress = forwardRef<CircleProgressProps, "div">(
       boxSize = size,
       children,
       color = "primary",
-      isRounded,
-      fullRounded = isRounded,
-      isAnimation = false,
+      fullRounded,
       max = 100,
       min = 0,
       speed = ["1.4s", "2s"],
@@ -115,28 +96,10 @@ export const CircleProgress = forwardRef<CircleProgressProps, "div">(
       value = 0,
       ...rest
     } = omitThemeProps(mergedProps)
-    const isTransparent = value === 0 && !isAnimation
+    const transparent = value === 0
     const percent = valueToPercent(value, min, max)
-    const interval = !isAnimation ? percent * 2.64 : undefined
-    const animation = useAnimation({
-      duration: typeof speed[0] === "string" ? speed[0] : `${speed[0]}s`,
-      iterationCount: "infinite",
-      keyframes: {
-        "0%": {
-          strokeDasharray: "1, 400",
-          strokeDashoffset: "0",
-        },
-        "50%": {
-          strokeDasharray: "400, 400",
-          strokeDashoffset: "-100",
-        },
-        "100%": {
-          strokeDasharray: "400, 400",
-          strokeDashoffset: "-260",
-        },
-      },
-      timingFunction: "linear",
-    })
+    const interval = percent * 2.64
+
     const css: CSSUIObject = {
       ...styles,
       fontSize: "$boxSize",
@@ -145,26 +108,20 @@ export const CircleProgress = forwardRef<CircleProgressProps, "div">(
         { name: "thickness", token: "sizes", value: thickness },
       ],
     }
-    const circleProps: CircleProgressCircleProps = isAnimation
-      ? {
-          animation,
-        }
-      : {
-          strokeDasharray:
-            interval == null ? undefined : `${interval} ${264 - interval}`,
-          strokeDashoffset: 66,
-          transitionDuration: "0.6s",
-          transitionProperty: "stroke-dasharray, stroke",
-          transitionTimingFunction: "ease",
-        }
-    const ariaProps: HTMLUIProps = !isAnimation
-      ? {
-          "aria-valuemax": max,
-          "aria-valuemin": min,
-          "aria-valuenow": value,
-          role: "meter",
-        }
-      : {}
+    const circleProps: CircleProgressCircleProps = {
+      strokeDasharray: `${interval} ${264 - interval}`,
+      strokeDashoffset: 66,
+      transitionDuration: "0.6s",
+      transitionProperty: "stroke-dasharray, stroke",
+      transitionTimingFunction: "ease",
+    }
+
+    const ariaProps: HTMLUIProps = {
+      "aria-valuemax": max,
+      "aria-valuemin": min,
+      "aria-valuenow": value,
+      role: "meter",
+    }
 
     return (
       <ui.div
@@ -174,14 +131,10 @@ export const CircleProgress = forwardRef<CircleProgressProps, "div">(
         {...ariaProps}
         {...rest}
       >
-        <CircleProgressShape
-          boxSize={boxSize}
-          isAnimation={isAnimation}
-          speed={speed}
-        >
+        <CircleProgressShape boxSize={boxSize} speed={speed}>
           <CircleProgressCircle stroke={trackColor} strokeWidth="$thickness" />
           <CircleProgressCircle
-            opacity={isTransparent ? 0 : undefined}
+            opacity={transparent ? 0 : undefined}
             stroke={color}
             strokeLinecap={fullRounded ? "round" : undefined}
             strokeWidth="$thickness"
@@ -208,32 +161,15 @@ CircleProgressCircle.__ui__ = "CircleProgressCircle"
 
 interface CircleProgressShapeProps
   extends Omit<HTMLUIProps<"svg">, "children" | "speed">,
-    Pick<Required<CircleProgressProps>, "children" | "isAnimation" | "speed"> {}
+    Pick<Required<CircleProgressProps>, "children" | "speed"> {}
 
 const CircleProgressShape: FC<CircleProgressShapeProps> = ({
   boxSize,
-  isAnimation,
-  speed,
   ...rest
 }) => {
-  const animation = useAnimation({
-    duration: typeof speed[1] === "string" ? speed[1] : `${speed[1]}s`,
-    iterationCount: "infinite",
-    keyframes: {
-      "0%": {
-        transform: "rotate(0deg)",
-      },
-      "100%": {
-        transform: "rotate(360deg)",
-      },
-    },
-    timingFunction: "linear",
-  })
-
   const css: CSSUIObject = {
     boxSize,
     display: "block",
-    ...(isAnimation ? { animation } : {}),
   }
 
   return <ui.svg aria-hidden viewBox="0 0 100 100" __css={css} {...rest} />

--- a/packages/react/src/components/progress/circle-progress.tsx
+++ b/packages/react/src/components/progress/circle-progress.tsx
@@ -10,13 +10,6 @@ import { cx, valueToPercent } from "../../utils"
 
 interface CircleProgressOptions {
   /**
-   * The CSS `box-size` property.
-   *
-   * @default '6rem'
-   * @deprecated Use `boxSize` instead.
-   */
-  size?: CSSUIProps["boxSize"]
-  /**
    * The CSS `color` property.
    *
    * @default 'primary'
@@ -68,7 +61,7 @@ interface CircleProgressOptions {
 
 export interface CircleProgressProps
   extends Omit<HTMLUIProps, "color">,
-    Omit<ThemeProps<"CircleProgress">, "size">,
+    ThemeProps<"CircleProgress">,
     CircleProgressOptions {}
 
 /**
@@ -78,13 +71,10 @@ export interface CircleProgressProps
  */
 export const CircleProgress = forwardRef<CircleProgressProps, "div">(
   (props, ref) => {
-    const [styles, { size = "6rem", ...mergedProps }] = useComponentStyle(
-      "CircleProgress",
-      props,
-    )
+    const [styles, mergedProps] = useComponentStyle("CircleProgress", props)
     const {
       className,
-      boxSize = size,
+      boxSize = "6rem",
       children,
       color = "primary",
       fullRounded,

--- a/packages/react/src/components/progress/progress.stories.tsx
+++ b/packages/react/src/components/progress/progress.stories.tsx
@@ -81,17 +81,3 @@ export const WithBorderRadius: Story = () => {
     </>
   )
 }
-
-export const UseStripeAnimation: Story = () => {
-  return (
-    <Progress
-      aria-label="Storage space"
-      hasStripe
-      isStripeAnimation
-      value={20}
-    />
-  )
-}
-export const UseAnimation: Story = () => {
-  return <Progress colorScheme="green" isAnimation />
-}

--- a/packages/react/src/components/progress/progress.test.tsx
+++ b/packages/react/src/components/progress/progress.test.tsx
@@ -14,14 +14,12 @@ describe("<Progress />", () => {
           data-testid="progress-a"
           borderRadius="md"
           filledTrackColor="green.500"
-          isAnimation
           value={50}
         />
         <Progress
           colorScheme="purple"
           data-testid="progress-b"
           hasStripe
-          isStripeAnimation
           rounded="md"
           value={100}
         />

--- a/packages/react/src/components/progress/progress.tsx
+++ b/packages/react/src/components/progress/progress.tsx
@@ -35,22 +35,6 @@ interface ProgressOptions {
    */
   hasStripe?: boolean
   /**
-   * If `true`, the progress will be indeterminate and the `value` prop will be ignored.
-   *
-   * @default false
-   *
-   * @deprecated It will be deprecated in version 2.0.
-   */
-  isAnimation?: boolean
-  /**
-   * If `true`, and hasStripe is `true`, the stripes will be animated.
-   *
-   * @default false
-   *
-   * @deprecated It will be deprecated in version 2.0.
-   */
-  isStripeAnimation?: boolean
-  /**
    * The maximum value of the progress.
    *
    * @default 100
@@ -93,8 +77,6 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
     borderRadius: _borderRadius,
     children,
     hasStripe,
-    isAnimation,
-    isStripeAnimation,
     max = 100,
     min = 0,
     rounded,
@@ -106,14 +88,12 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
   const borderRadius =
     _borderRadius ?? rounded ?? (styles.track?.borderRadius as number | string)
 
-  const ariaProps: HTMLUIProps = !isAnimation
-    ? {
-        "aria-valuemax": max,
-        "aria-valuemin": min,
-        "aria-valuenow": value,
-        role: "meter",
-      }
-    : {}
+  const ariaProps: HTMLUIProps = {
+    "aria-valuemax": max,
+    "aria-valuemin": min,
+    "aria-valuenow": value,
+    role: "meter",
+  }
 
   return (
     <ProgressProvider value={styles}>
@@ -128,8 +108,6 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
         <ProgressFilledTrack
           borderRadius={borderRadius}
           hasStripe={hasStripe}
-          isAnimation={isAnimation}
-          isStripeAnimation={isStripeAnimation}
           max={max}
           min={min}
           speed={speed}
@@ -148,8 +126,6 @@ interface ProgressFilledTrackProps extends HTMLUIProps, ProgressProps {}
 
 const ProgressFilledTrack: FC<ProgressFilledTrackProps> = ({
   hasStripe,
-  isAnimation,
-  isStripeAnimation,
   max = 100,
   min = 0,
   speed = "1.4s",
@@ -170,30 +146,10 @@ const ProgressFilledTrack: FC<ProgressFilledTrackProps> = ({
     timingFunction: "linear",
   })
 
-  const interpolationAnimation = useAnimation({
-    duration: typeof speed === "string" ? speed : `${speed}s`,
-    iterationCount: "infinite",
-    keyframes: {
-      "0%": { left: "-40%" },
-      "100%": { left: "100%" },
-    },
-    timingFunction: "ease",
-  })
-
-  isStripeAnimation = !isAnimation && hasStripe && isStripeAnimation
-
   const css: Interpolation<{}> = {
-    ...(isStripeAnimation
+    ...(hasStripe
       ? {
           animation: stripeAnimation,
-        }
-      : {}),
-    ...(isAnimation
-      ? {
-          animation: interpolationAnimation,
-          minWidth: "50%",
-          position: "absolute",
-          willChange: "left",
         }
       : {}),
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #3966 
Closes #3501
Closes #3341

## Description

Removed `isRounded`, `isAnimation` and `isStripeAnimation` and its uncessary logic
Removed `size` from circle-progress


## Is this a breaking change (Yes/No):

No

## Additional Information
