### PR TITLE
feat(button): add aria-busy attribute for loading state

### DIFF
--- a/.changeset/funny-tomatoes-grow.md
+++ b/.changeset/funny-tomatoes-grow.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/button": patch
+---
+
+add aria-busy attribute for loading state

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -9,7 +9,7 @@ import {
 } from "@yamada-ui/core"
 import { Loading as LoadingIcon } from "@yamada-ui/loading"
 import { Ripple, useRipple } from "@yamada-ui/ripple"
-import { cx, dataAttr, merge, mergeRefs } from "@yamada-ui/utils"
+import { ariaAttr, cx, dataAttr, merge, mergeRefs } from "@yamada-ui/utils"
 import { useCallback, useMemo, useRef } from "react"
 import { useButtonGroup } from "./button-group"
 
@@ -208,6 +208,7 @@ export const Button = forwardRef<ButtonProps, "button">(
         as={as}
         type={type ?? defaultType}
         className={cx("ui-button", className)}
+        aria-busy={ariaAttr(loading)}
         data-active={dataAttr(active)}
         data-loading={dataAttr(loading)}
         disabled={trulyDisabled}

--- a/packages/components/button/tests/button.test.tsx
+++ b/packages/components/button/tests/button.test.tsx
@@ -27,6 +27,8 @@ describe("<Button />", () => {
     )
     expect(getByTestId("btn")).toHaveAttribute("data-loading", "")
 
+    expect(getByTestId("btn")).toHaveAttribute("aria-busy", "true")
+
     // children text is hidden
     expect(screen.queryByText("Submit")).toBeNull()
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4317 

## Description

<!-- Add a brief description. -->

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
