### PR TITLE
Removed unused `ComponentArgs` properties

### DIFF
--- a/.changeset/chilly-bears-leave.md
+++ b/.changeset/chilly-bears-leave.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Removed unused `ComponentArgs` properties.

--- a/packages/core/src/components/component.types.ts
+++ b/packages/core/src/components/component.types.ts
@@ -52,10 +52,7 @@ type ComponentProps<Y extends As, M extends As, D extends object = {}> = {
 } & ComponentConditionalProps<Y, M, D>
 
 export interface ComponentArgs
-  extends Pick<
-    React.FunctionComponent,
-    "contextTypes" | "defaultProps" | "displayName" | "propTypes"
-  > {
+  extends Pick<React.FunctionComponent, "displayName" | "propTypes"> {
   __ui__?: string
 }
 


### PR DESCRIPTION
Closes #3835

## Description

Removed unused `ComponentArgs` properties.

## Is this a breaking change (Yes/No):

No