### PR TITLE
Fixed `List` component documentation

### DIFF
--- a/docs/contents/components/data-display/list/index.ja.mdx
+++ b/docs/contents/components/data-display/list/index.ja.mdx
@@ -116,7 +116,7 @@ import {
     {(styleType, index) => (
       <List
         styleType={styleType}
-        ms={styleType === "lower-alpha" ? "1.2em" : "0em"}
+        ms={styleType === "lower-alpha" ? "1.2em" : undefined}
       >
         <For
           each={[
@@ -130,7 +130,7 @@ import {
           {(text, index) => (
             <ListItem
               key={index}
-              ps={styleType === "lower-alpha" ? "0.2em" : "0em"}
+              ps={styleType === "lower-alpha" ? "0.2em" : undefined}
             >
               {text}
             </ListItem>

--- a/docs/contents/components/data-display/list/index.mdx
+++ b/docs/contents/components/data-display/list/index.mdx
@@ -118,7 +118,7 @@ To use custom icons for items, use `ListIcon`.
     {(styleType, index) => (
       <List
         styleType={styleType}
-        ms={styleType === "lower-alpha" ? "1.2em" : "0em"}
+        ms={styleType === "lower-alpha" ? "1.2em" : undefined}
       >
         <For
           each={[
@@ -132,7 +132,7 @@ To use custom icons for items, use `ListIcon`.
           {(text, index) => (
             <ListItem
               key={index}
-              ps={styleType === "lower-alpha" ? "0.2em" : "0em"}
+              ps={styleType === "lower-alpha" ? "0.2em" : undefined}
             >
               {text}
             </ListItem>


### PR DESCRIPTION
## Description

Fixed `List` component documentation.

The display of  [List - Other Lists](https://yamada-ui.com/components/data-display/list#other-lists) is incorrect.

## Is this a breaking change (Yes/No):

No