### PR TITLE
chore: add chromeos to return value of use-os

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -184,7 +184,8 @@
     "yamcha",
     "Yezi",
     "Yuto",
-    "zarbon"
+    "zarbon",
+    "chromeos"
   ],
   "ignorePaths": [
     "node_modules",

--- a/packages/hooks/use-os/src/index.ts
+++ b/packages/hooks/use-os/src/index.ts
@@ -1,5 +1,6 @@
 export type OS =
   | "android"
+  | "chromeos"
   | "ios"
   | "linux"
   | "macos"
@@ -14,12 +15,14 @@ const getOS = (): OS => {
   const ios = /(iPhone)|(iPad)|(iPod)/i
   const android = /Android/i
   const linux = /Linux/i
+  const chromeos = /CrOS/i
 
   if (macos.test(userAgent)) return "macos"
   if (ios.test(userAgent)) return "ios"
   if (windows.test(userAgent)) return "windows"
   if (android.test(userAgent)) return "android"
   if (linux.test(userAgent)) return "linux"
+  if (chromeos.test(userAgent)) return "chromeos"
 
   return "undetermined"
 }

--- a/packages/hooks/use-os/tests/use-os.test.tsx
+++ b/packages/hooks/use-os/tests/use-os.test.tsx
@@ -43,6 +43,11 @@ describe("useOS", () => {
         "Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.105 Safari/537.36 WebAppManager",
     },
     {
+      expected: "chromeos",
+      userAgent:
+        "Mozilla/5.0 (X11; CrOS x86_64 13310.93.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.133 Safari/537.36",
+    },
+    {
       expected: "undetermined",
       // Nintendo Switch
       userAgent:


### PR DESCRIPTION
## Description

Added ChromeOS to return value of useOS.
Samething as PR of  mantine UI: https://github.com/mantinedev/mantine/pull/6541/files

## Current behavior (updates)

chromeos returns `undetermined`

## New behavior

will return `chromeos`

## Is this a breaking change (Yes/No):

Yes

## Additional Information
