### PR TITLE
test: fix test for autosize textarea

### DIFF
--- a/packages/react/src/components/textarea/textarea.test.tsx
+++ b/packages/react/src/components/textarea/textarea.test.tsx
@@ -40,7 +40,7 @@ describe("<Textarea />", () => {
     expect(screen.getByRole("textbox")).toHaveProperty("rows", 1)
   })
 
-  test.todo("Autosize Textarea renders correctly", () => {
+  test("Autosize Textarea renders correctly", () => {
     let fontsData =
       "fonts" in global.document ? global.document.fonts : undefined
 
@@ -52,7 +52,7 @@ describe("<Textarea />", () => {
       writable: true,
     })
     render(<Textarea autosize />)
-    expect(screen.getByRole("textbox")).toHaveProperty("rows", 1)
+    expect(screen.getByRole("textbox")).toHaveProperty("rows", 2)
     Object.defineProperty(global.document, "fonts", {
       value: fontsData,
       writable: true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes https://github.com/yamada-ui/yamada-ui/issues/4598

## Description

<!-- Add a brief description. -->

In v1 series, row was 1, but from v2.0 onwards, it seems that row has become 2.
https://github.com/yamada-ui/yamada-ui/blob/v2.0/packages/react/src/components/textarea/textarea.tsx#L30

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
