### PR TITLE
test: increased coverage for data-list

### DIFF
--- a/packages/components/data-list/tests/data-list.test.tsx
+++ b/packages/components/data-list/tests/data-list.test.tsx
@@ -1,6 +1,11 @@
 import type { DataListItemProps } from "../src"
-import { a11y } from "@yamada-ui/test"
-import { DataList } from "../src"
+import { a11y, render, screen } from "@yamada-ui/test"
+import {
+  DataList,
+  DataListDescription,
+  DataListItem,
+  DataListTerm,
+} from "../src"
 
 describe("<DataList />", () => {
   test("DataList renders correctly", async () => {
@@ -15,5 +20,106 @@ describe("<DataList />", () => {
     ]
 
     await a11y(<DataList items={items} />)
+  })
+
+  test("renders with null description", () => {
+    const itemsWithNullDescription: DataListItemProps[] = [
+      { description: null, term: "term" },
+    ]
+    render(<DataList data-testid="DataList" items={itemsWithNullDescription} />)
+    expect(screen.getByTestId("DataList")).toBeInTheDocument()
+  })
+
+  test("renders with array description", () => {
+    const itemsWithArrayDescription: DataListItemProps[] = [
+      {
+        description: ["description1", "description2", "description3"],
+        term: "term",
+      },
+    ]
+    render(
+      <DataList data-testid="DataList" items={itemsWithArrayDescription} />,
+    )
+    expect(screen.getByTestId("DataList")).toBeInTheDocument()
+  })
+
+  test("updates column count", () => {
+    const { rerender } = render(
+      <DataList col={1} w="fit-content">
+        <DataListItem>
+          <DataListTerm>term1</DataListTerm>
+        </DataListItem>
+
+        <DataListItem>
+          <DataListTerm>term2</DataListTerm>
+        </DataListItem>
+
+        <DataListItem>
+          <DataListTerm>term3</DataListTerm>
+        </DataListItem>
+      </DataList>,
+    )
+
+    rerender(
+      <DataList data-testid="DataList" col={2}>
+        <DataListItem>
+          <DataListTerm>term1</DataListTerm>
+          <DataListDescription>description1</DataListDescription>
+        </DataListItem>
+
+        <DataListItem>
+          <DataListTerm>term2</DataListTerm>
+          <DataListDescription>description2</DataListDescription>
+        </DataListItem>
+
+        <DataListItem>
+          <DataListTerm>term3</DataListTerm>
+          <DataListDescription>description3</DataListDescription>
+        </DataListItem>
+      </DataList>,
+    )
+    expect(screen.getByTestId("DataList")).toBeInTheDocument()
+  })
+
+  test("update items", () => {
+    const initialItems: DataListItemProps[] = [
+      { description: "description1", term: "term1" },
+      { description: "description2", term: "term2" },
+    ]
+
+    const { rerender } = render(
+      <DataList data-testid="DataList" items={initialItems} />,
+    )
+
+    // update items
+    const newItems: DataListItemProps[] = [
+      { description: "description3", term: "term3" },
+      { description: "description4", term: "term4" },
+    ]
+    rerender(<DataList data-testid="DataList" items={newItems} />)
+    expect(screen.getByTestId("DataList")).toBeInTheDocument()
+
+    // update items without description
+    const newItemsWithoutDescription: DataListItemProps[] = [
+      { term: "term1" },
+      { term: "term2" },
+    ]
+
+    rerender(
+      <DataList data-testid="DataList" items={newItemsWithoutDescription} />,
+    )
+    expect(screen.getByTestId("DataList")).toBeInTheDocument()
+
+    // update items with array description and term
+    const newItemsWithArrayDescription: DataListItemProps[] = [
+      {
+        description: ["description1", "description2"],
+        term: ["term1", "term2"],
+      },
+    ]
+    rerender(
+      <DataList data-testid="DataList" items={newItemsWithArrayDescription} />,
+    )
+    expect(screen.getByTestId("DataList")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #3651

## Description

This PR enhances the test coverage for the `@yamada-ui/data-list` package by adding comprehensive tests for the `DataList` component. The changes focus on improving test coverage to meet the target of 95% or higher.

## Current behavior (updates)

- The `@yamada-ui/data-list` package has test coverage below 95%
- Missing tests for various property

## New behavior

- Added test cases for the following scenarios:
  - Testing for null description cases
  - Testing for array description cases
  - Testing column property updates
  - Testing items property updates

## Is this a breaking change (Yes/No):

No