### PR TITLE
test: increased coverage for snacks

### DIFF
--- a/packages/components/snacks/tests/snacks.test.tsx
+++ b/packages/components/snacks/tests/snacks.test.tsx
@@ -1,3 +1,4 @@
+import type { SnackComponentProps } from "@yamada-ui/core"
 import { fireEvent, render, screen, waitFor } from "@yamada-ui/test"
 import { useRef } from "react"
 import { Snacks, useSnacks } from "../src"
@@ -111,5 +112,207 @@ describe("<Snacks />", () => {
       expect(screen.queryByText("test-title")).toBeNull()
     })
     expect(screen.queryByText("test-description")).toBeNull()
+  })
+
+  test("Snacks renders correctly with custom component", async () => {
+    const CustomSnack = ({ description, title }: SnackComponentProps) => (
+      <div data-testid="custom-snack">
+        <div className="custom-title">{title}</div>
+        <div className="custom-desc">{description}</div>
+      </div>
+    )
+
+    const CustomSnackExample = () => {
+      const { snack, snacks } = useSnacks({
+        component: CustomSnack,
+      })
+
+      return (
+        <>
+          <button
+            data-testid="custom-add-btn"
+            onClick={() =>
+              snack({
+                description: "Custom Description",
+                title: "Custom Title",
+              })
+            }
+          >
+            Add Custom
+          </button>
+          <Snacks gutter={[0, "md"]} snacks={snacks} />
+        </>
+      )
+    }
+
+    render(<CustomSnackExample />)
+
+    const addBtn = screen.getByTestId("custom-add-btn")
+    fireEvent.click(addBtn)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("custom-snack")).toBeInTheDocument()
+    })
+
+    expect(screen.getByText("Custom Title")).toHaveClass("custom-title")
+    expect(screen.getByText("Custom Description")).toHaveClass("custom-desc")
+  })
+
+  test("CloseButton click event works correctly", async () => {
+    const Snack = () => {
+      const { snack, snacks } = useSnacks()
+
+      const onOpen = () => {
+        snack({
+          description: "test-description",
+          title: "test-title",
+        })
+      }
+
+      return (
+        <>
+          <button data-testid="add-btn" onClick={onOpen}>
+            Add
+          </button>
+          <Snacks gutter={[0, "md"]} snacks={snacks} />
+        </>
+      )
+    }
+
+    render(<Snack />)
+
+    const addBtn = screen.getByTestId("add-btn")
+    fireEvent.click(addBtn)
+    await waitFor(() => {
+      expect(screen.getByText("test-title")).toBeInTheDocument()
+    })
+    expect(screen.getByText("test-description")).toBeInTheDocument()
+
+    const closeButton = screen.getByRole("button", { name: /close/i })
+    fireEvent.click(closeButton)
+    await waitFor(() => {
+      expect(screen.queryByText("test-title")).toBeNull()
+    })
+    expect(screen.queryByText("test-description")).toBeNull()
+  })
+
+  test("isActive method works correctly", async () => {
+    const Snack = () => {
+      const { snack, snacks } = useSnacks()
+      const ref = useRef<number | string | undefined>(undefined)
+
+      const onOpen = () => {
+        ref.current = snack({
+          description: "test-description",
+          title: "test-title",
+        })
+      }
+
+      const onClose = () => {
+        if (ref.current) snack.close(ref.current)
+      }
+
+      return (
+        <>
+          <button data-testid="add-btn" onClick={onOpen}>
+            Add
+          </button>
+          <button data-testid="close-btn" onClick={onClose}>
+            Close
+          </button>
+          <div data-testid="status">
+            {ref.current && snack.isActive(ref.current) ? "Active" : "No snack"}
+          </div>
+          <Snacks gutter={[0, "md"]} snacks={snacks} />
+        </>
+      )
+    }
+
+    render(<Snack />)
+
+    const addBtn = screen.getByTestId("add-btn")
+    const closeBtn = screen.getByTestId("close-btn")
+    const statusElement = screen.getByTestId("status")
+
+    expect(statusElement).toHaveTextContent("No snack")
+
+    fireEvent.click(addBtn)
+    await waitFor(() => {
+      expect(screen.getByText("test-title")).toBeInTheDocument()
+    })
+    expect(statusElement).toHaveTextContent("Active")
+
+    fireEvent.click(closeBtn)
+    await waitFor(() => {
+      expect(screen.queryByText("test-title")).toBeNull()
+    })
+    expect(statusElement).toHaveTextContent("No snack")
+  })
+
+  test("Snacks renders correctly when update keeps other snacks unchanged", async () => {
+    const Snack = () => {
+      const { snack, snacks } = useSnacks()
+      const ref1 = useRef<number | string | undefined>(undefined)
+      const ref2 = useRef<number | string | undefined>(undefined)
+
+      const onOpenFirst = () => {
+        ref1.current = snack({
+          description: "first-description",
+          title: "first-title",
+        })
+      }
+
+      const onOpenSecond = () => {
+        ref2.current = snack({
+          description: "second-description",
+          title: "second-title",
+        })
+      }
+
+      const onUpdateFirst = () => {
+        if (ref1.current)
+          snack.update(ref1.current, {
+            description: "first-description-update",
+            title: "first-title-update",
+          })
+      }
+
+      return (
+        <>
+          <button data-testid="add-first-btn" onClick={onOpenFirst}>
+            Add First
+          </button>
+          <button data-testid="add-second-btn" onClick={onOpenSecond}>
+            Add Second
+          </button>
+          <button data-testid="update-first-btn" onClick={onUpdateFirst}>
+            Update First
+          </button>
+          <Snacks gutter={[0, "md"]} snacks={snacks} />
+        </>
+      )
+    }
+
+    render(<Snack />)
+
+    const addFirstBtn = screen.getByTestId("add-first-btn")
+    const addSecondBtn = screen.getByTestId("add-second-btn")
+    const updateFirstBtn = screen.getByTestId("update-first-btn")
+
+    fireEvent.click(addFirstBtn)
+    fireEvent.click(addSecondBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText("first-title")).toBeInTheDocument()
+    })
+    expect(screen.getByText("second-title")).toBeInTheDocument()
+
+    fireEvent.click(updateFirstBtn)
+
+    await waitFor(() => {
+      expect(screen.queryByText("first-title")).toBeNull()
+    })
+    expect(screen.getByText("first-title-update")).toBeInTheDocument()
+    expect(screen.getByText("second-title")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #2457 

## Description

This PR enhances the test coverage for the `@yamada-ui/snacks` package by adding comprehensive tests for the `use-snacks.tsx`. The changes focus on improving test coverage to meet the target of 95% or higher.

## Current behavior (updates)

- The `@yamada-ui/snacks` package has test coverage below 95%
- Missing tests for various property

## New behavior

- Added test cases for uncovered scenarios in `use-snacks`

## Is this a breaking change (Yes/No):

No