### PR TITLE
Updated `aria-controls` based on open state

### DIFF
--- a/packages/react/src/components/modal/use-modal.ts
+++ b/packages/react/src/components/modal/use-modal.ts
@@ -73,7 +73,7 @@ export const useModal = ({
 
   const getOpenTriggerProps: PropGetter<"button"> = useCallback(
     (props = {}) => ({
-      "aria-controls": contentId,
+      "aria-controls": open ? contentId : undefined,
       "aria-expanded": open,
       "aria-haspopup": "dialog",
       "aria-label": t("Open modal"),


### PR DESCRIPTION
## Description

There was a problem with setting `aria-controls` to an unmounted element, i.e. an `id` that did not exist. This has been corrected.
