### PR TITLE
fix(multi-select): use inline display for selected values

### DIFF
--- a/packages/components/select/src/multi-select.tsx
+++ b/packages/components/select/src/multi-select.tsx
@@ -282,7 +282,7 @@ const MultiSelectField = forwardRef<MultiSelectFieldProps, "div">(
                   dangerouslySetInnerHTML={{
                     __html: `${value}${!isLast ? separator : ""}`,
                   }}
-                  display="inline-block"
+                  display="inline"
                   me="0.25rem"
                 />
               )


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
``- Keep your PR as small as possible.``
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4701 

## Description

<!-- Add a brief description. -->

This PR fixes the Safari issue with the `MultiSelect` component where items would be truncated when the maximum width was greater than the items width. 

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

The truncation is applied when the width is greater than the components. 

<img width="1128" alt="Screenshot 2025-07-07 at 6 46 32 PM" src="https://github.com/user-attachments/assets/44efaffa-785f-42e1-9cb9-fe4145580b20" />

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

There is no longer a truncation when the width is greater than the components. 

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/7785a894-e545-4c68-8818-eb9afbe39885" />

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

No

## Additional Information
