### PR TITLE
fix(use-focus-visible): make focus property configurable to fix "Cannot redefine property: focus"

### DIFF
--- a/.changeset/easy-windows-jam.md
+++ b/.changeset/easy-windows-jam.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/use-focus-visible": patch
+---
+
+Fix `Cannot redefine property: focus` issue.

--- a/packages/hooks/use-focus-visible/src/index.ts
+++ b/packages/hooks/use-focus-visible/src/index.ts
@@ -97,7 +97,7 @@ const setGlobalFocusEvents = () => {
   if (process.env.NODE_ENV !== "test") {
     Object.defineProperties(HTMLElement.prototype, {
       focus: {
-        configurable: false,
+        configurable: true,
         value: function customFocus(...args: [FocusOptions]) {
           hasEventBeforeFocus = true
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4711 

## Description

I have fixed the issue where storybook would crash with the following error.

```
Cannot redefine property: focus
```

## Current behavior (updates)

Storybook crashed with 

```
Cannot redefine property: focus
```

## New behavior

No longer crashes.

https://github.com/user-attachments/assets/60ae3b70-1f0a-4e5e-938b-e41a6c7bf795

## Is this a breaking change (Yes/No):

No

## Additional Information
