### PR TITLE
fix(sidebar): improve pathname matching logic in mobile menu and sidebar components

### DIFF
--- a/www/app/[locale]/docs/sidebar.tsx
+++ b/www/app/[locale]/docs/sidebar.tsx
@@ -96,7 +96,8 @@ function SidebarItem({ href, segment, onClick, ...rest }: SidebarItemProps) {
   const overview = segment === "overview"
   const current = overview
     ? pathname === href
-    : pathname.startsWith(href.toString())
+    : pathname.length <= href.toString().length &&
+      pathname.startsWith(href.toString())
 
   return (
     <NextLinkButton

--- a/www/app/[locale]/mobile-menu.tsx
+++ b/www/app/[locale]/mobile-menu.tsx
@@ -262,7 +262,8 @@ function DocsMenuItem({
   const overview = segment === "overview"
   const current = overview
     ? pathname === href
-    : pathname.startsWith(href.toString())
+    : pathname.length <= href.toString().length &&
+      pathname.startsWith(href.toString())
 
   return (
     <NextLinkButton


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4728 

## Description

I have fixed the current page checking logic.

## Current behavior (updates)

If you were on `Format*` page, it would also select `For` component.

## New behavior

I added to check the length to make sure `For` is not being considered as the same as `Format*`.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
