### PR TITLE
fix(color-mode-button): fix color mode button icon on initial load

### DIFF
--- a/www/app/[locale]/color-mode-button.tsx
+++ b/www/app/[locale]/color-mode-button.tsx
@@ -1,20 +1,13 @@
 "use client"
 
 import type { ButtonProps } from "@yamada-ui/react"
-import {
-  IconButton,
-  MoonIcon,
-  SunIcon,
-  useColorMode,
-  useMounted,
-} from "@yamada-ui/react"
+import { IconButton, MoonIcon, SunIcon, useColorMode } from "@yamada-ui/react"
 import { useTranslations } from "next-intl"
 
 export interface ColorModeButtonProps extends ButtonProps {}
 
 export function ColorModeButton({ ...rest }: ColorModeButtonProps) {
   const { colorMode, toggleColorMode } = useColorMode()
-  const mounted = useMounted({ state: true })
   const t = useTranslations("component.header")
 
   return (
@@ -22,11 +15,10 @@ export function ColorModeButton({ ...rest }: ColorModeButtonProps) {
       aria-label={t("colorMode", { colorMode })}
       color="fg.emphasized"
       icon={
-        !mounted || colorMode === "light" ? (
-          <SunIcon key="icon" />
-        ) : (
-          <MoonIcon key="icon" />
-        )
+        <>
+          <SunIcon display={["inline", "none"]} />
+          <MoonIcon display={["none", "inline"]} />
+        </>
       }
       suppressHydrationWarning
       onClick={toggleColorMode}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes # <!-- Github issue # here -->

## Description

<!-- Add a brief description. -->
I have fixed color mode button showing wrong mode on initial mode due to client side rendering.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
It used client side hook that would dynamically change the icon being displayed, which had delays in initial load.

## New behavior

I am now using CSS to switch the icon.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
