### PR TITLE
fix(use-clickable): button state update in ref callback

### DIFF
--- a/.changeset/loose-actors-push.md
+++ b/.changeset/loose-actors-push.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/use-clickable": patch
+---
+
+Fix `useClickable` button state update in ref callback

--- a/packages/hooks/use-clickable/src/index.ts
+++ b/packages/hooks/use-clickable/src/index.ts
@@ -116,7 +116,7 @@ export const useClickable = <
   const refCb = (node: any) => {
     if (!node) return
 
-    if (node.tagName !== "BUTTON") setButton(false)
+    if (node.tagName !== "BUTTON" && button) setButton(false)
   }
 
   const handleClick = useCallback(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4703 

## Description

<!-- Add a brief description. -->

This fixes the error where there would be a "Client Side Exception" when clicking `clickable`s too quickly. This error was resulted by a loose if condition which triggered multiple state updates between each click. 

This has been tested by building the docs and running a macro to quickly switch between the docs tabbings. 

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

<img width="2860" height="1386" alt="image" src="https://github.com/user-attachments/assets/746074f4-ec75-4775-9e37-d14b352b21d7" />

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

This PR now adds a check to see if the `button` state is available which no longer causes the client side exception. 

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

No

## Additional Information

It was recommended to possible use a `ref` instead of `state`, although this change may affect related components. 

- https://github.com/yamada-ui/yamada-ui/issues/4703#issuecomment-3061689273
