### PR TITLE
fix(type): fix typecheck failing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "@yamada-ui/workspace/typescript/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "#storybook": ["packages/react/storybook"],
+      "#test": ["packages/react/test"]
+    }
+  },
   "include": [
     "scripts/**/*.ts",
     "scripts/**/*.tsx",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes # <!-- Github issue # here -->

## Description

The `pnpm typecheck:scripts` was failing, and I think there are 2 ways to fix this.
1. Exclude `packages/**` and `www/**` from the typecheck:scripts if it is only meant to test the scripts types.
2. Define the path for `#test` and `#storybook`.

## Current behavior (updates)

```bash
pnpm typecheck:scripts
```

throws error.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
No longer see the error.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
Yes, we are adding a `baseUrl` and `paths`.

## Additional Information
