### PR TITLE
fix(cli): fix targetPath naming for the theme command

### DIFF
--- a/.changeset/large-dryers-design.md
+++ b/.changeset/large-dryers-design.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/cli": patch
+---
+
+Normalizes targetPath folder name to match tarball naming

--- a/packages/cli/src/command/theme/index.ts
+++ b/packages/cli/src/command/theme/index.ts
@@ -81,7 +81,8 @@ const getFileMap = async (cwd: string, branch: string) => {
 
   const fileMap = new Map<string, string>()
 
-  const targetPath = `${REPO_NAME}-${branch.replace("/", "-")}/packages/theme/src`
+  const normalizedBranch = branch.startsWith("v") ? branch.slice(1) : branch
+  const targetPath = `${REPO_NAME}-${normalizedBranch}/packages/theme/src`
 
   const filter = (path: string) => {
     return path.startsWith(targetPath)


### PR DESCRIPTION
Closes #4722

## Description

Fixes an empty folder being generated when using the CLI `theme` command.

## Current behavior

Branches with a `v` prefix (like v1) downloaded a tarball with a top-level folder name which didn't match what the CLI expected, which resulted in an empty generated theme folder.

## New behavior

The CLI now normalizes the target folder name so that `targetPath` matches the downloaded tarball structure.

## Is this a breaking change (Yes/No):

No

## Additional Information
