### PR TITLE
fix(snacks): fix default `Snacks` placement in JSDoc

### DIFF
--- a/packages/react/src/core/system/index.types.ts
+++ b/packages/react/src/core/system/index.types.ts
@@ -129,7 +129,7 @@ export interface SnacksConfig {
   /**
    * The direction of the snacks.
    *
-   * @default 'top'
+   * @default 'start'
    */
   direction?: SimpleDirection
   /**


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes # <!-- Github issue # here -->

## Description

This fixes the JSDoc for `Snacks` component.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Although `SimpleDirection` is `"start" | "end"` the JSDoc says 'top'.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
I have updated it to say "start" instead.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
