### PR TITLE
fix(www-i18n): allow switching from ja to en on first visit

### DIFF
--- a/www/i18n/routing.ts
+++ b/www/i18n/routing.ts
@@ -7,7 +7,9 @@ export const routing = defineRouting({
   localePrefix: {
     mode: "as-needed",
     prefixes: Object.fromEntries(
-      CONSTANTS.I18N.LOCALES.map((locale) => [locale, `/${getLang(locale)}`]),
+      CONSTANTS.I18N.LOCALES.filter(
+        (locale) => locale !== CONSTANTS.I18N.DEFAULT_LOCALE,
+      ).map((locale) => [locale, `/${getLang(locale)}`]),
     ),
   },
   locales: CONSTANTS.I18N.LOCALES,


### PR DESCRIPTION
Closes #4772 

## Description

Avoid prefixing the default locale in `next-intl` routing so `localePrefix: as-needed` works correctly. This resolves the bug where users who land on a Japanese page first cannot switch to English until after viewing an English page.

## Current behavior (updates)

- Visiting a Japanese page first prevents switching to English via the language button.
- Switching from English to Japanese works; after visiting English once, switching becomes possible.

## New behavior

- Users can switch between Japanese and English in both directions, even on the first visit.
- Default locale is no longer incorrectly prefixed, ensuring correct locale resolution.

## Is this a breaking change (Yes/No):

No

## Additional Information
