### PR TITLE
docs(use-notice): migrate `use-notice` documentation with updated examples

### DIFF
--- a/www/contents/components/(components)/alert.ja.mdx
+++ b/www/contents/components/(components)/alert.ja.mdx
@@ -42,7 +42,7 @@ import { Alert } from "@workspaces/ui"
 </Alert.Root>
 ```
 
-## ステータスを変更する
+### ステータスを変更する
 
 ```tsx preview
 <VStack>
@@ -60,7 +60,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## バリアントを変更する
+### バリアントを変更する
 
 ```tsx preview
 <VStack>
@@ -78,7 +78,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## カラースキームを変更する
+### カラースキームを変更する
 
 ```tsx preview
 <VStack>
@@ -103,7 +103,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## ローディングを適応する
+### ローディングスキームを変更する
 
 ```tsx preview
 <VStack>
@@ -128,7 +128,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## レイアウトを変更する
+### レイアウトを変更する
 
 ```tsx preview
 <VStack>

--- a/www/contents/components/(components)/alert.mdx
+++ b/www/contents/components/(components)/alert.mdx
@@ -42,7 +42,7 @@ import { Alert } from "@workspaces/ui"
 </Alert.Root>
 ```
 
-## Change Status
+### Change Status
 
 ```tsx preview
 <VStack>
@@ -60,7 +60,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## Change Variant
+### Change Variant
 
 ```tsx preview
 <VStack>
@@ -78,7 +78,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## Change Color Scheme
+### Change Color Scheme
 
 ```tsx preview
 <VStack>
@@ -103,7 +103,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## Apply Loading
+### Change Loading Scheme
 
 ```tsx preview
 <VStack>
@@ -128,7 +128,7 @@ import { Alert } from "@workspaces/ui"
 </VStack>
 ```
 
-## Customize Layout
+### Customize Layout
 
 ```tsx preview
 <VStack>

--- a/www/contents/hooks/use-notice.ja.mdx
+++ b/www/contents/hooks/use-notice.ja.mdx
@@ -5,4 +5,393 @@ storybook: hooks-usenotice--basic
 source: hooks/use-notice
 ---
 
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Button
+    onClick={() =>
+      notice({
+        title: "シェリル・ノーム",
+        description: "私の歌を聴けー！",
+      })
+    }
+  >
+    Show Notice
+  </Button>
+)
+```
+
 ## 使い方
+
+:::code-group
+
+```tsx [package]
+import { useNotice } from "@yamada-ui/react"
+```
+
+```tsx [alias]
+import { useNotice } from "@/components/ui"
+```
+
+```tsx [monorepo]
+import { useNotice } from "@workspaces/ui"
+```
+
+:::
+
+```tsx
+const notice = useNotice()
+```
+
+### バリアントを変更する
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["plain", "solid", "subtle", "surface", "island"] as const}>
+      {(variant) => (
+        <Button
+          key={variant}
+          onClick={() => {
+            notice({
+              variant,
+              description: "こんなサービス、滅多にしないんだからね！",
+              title: "シェリル・ノーム",
+              withIcon: variant !== "island" ? true : false,
+            })
+          }}
+        >
+          Add "{toTitleCase(variant)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### カラースキームを変更する
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["info", "success", "warning", "error"] as const}>
+      {(colorScheme) => (
+        <Button
+          key={colorScheme}
+          onClick={() => {
+            notice({
+              colorScheme,
+              description:
+                "人は１人じゃ飛べない。飛んじゃいけない。それが分かったから…",
+              title: "早乙女アルト",
+            })
+          }}
+        >
+          Add "{toTitleCase(colorScheme)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### ローディングスキームを変更する
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["oval", "grid", "puff", "dots"] as const}>
+      {(loadingScheme) => (
+        <Button
+          key={loadingScheme}
+          onClick={() => {
+            notice({
+              description: "人を本気で好きになるのは命がけなんだな。",
+              loadingScheme,
+              title: "ミハエル・ブラン",
+            })
+          }}
+        >
+          Add "{toTitleCase(loadingScheme)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### ステータスを変更する
+
+ステータスを変更する場合は、`status`に`"info"`や`"success"`などを設定します。
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["info", "success", "warning", "error"] as const}>
+      {(status) => (
+        <Button
+          key={status}
+          onClick={() => {
+            notice({
+              description: "皆抱きしめて！銀河の果てまで！",
+              status,
+              title: "ランカ・リー",
+            })
+          }}
+        >
+          Add "{toTitleCase(status)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### 表示件数を変更する
+
+表示件数を変更する場合は、`limit`に数値を設定します。
+
+```tsx preview functional client
+const notice = useNotice({ limit: 10 })
+
+return (
+  <Button
+    onClick={() =>
+      notice({
+        description: "お前の恋は何処にある！",
+        title: "クラン・クラン",
+      })
+    }
+  >
+    Show Notice
+  </Button>
+)
+```
+
+### 表示時間を変更する
+
+表示時間を変更する場合は、`duration`に数値を設定します。
+
+```tsx preview functional client
+const notice = useNotice({ duration: 10000 })
+
+return (
+  <Wrap gap="md">
+    <Button
+      onClick={() =>
+        notice({
+          description: "お前も、お前の夢も、俺が守る！",
+          title: "オズマ・リー",
+        })
+      }
+    >
+      Show Notice
+    </Button>
+
+    <Button
+      onClick={() =>
+        notice({
+          description: "お前も、お前の夢も、俺が守る！",
+          duration: 5000,
+          title: "オズマ・リー",
+        })
+      }
+    >
+      Show Notice with Option
+    </Button>
+  </Wrap>
+)
+```
+
+### 表示を維持する
+
+表示を維持する場合は、`duration`に`null`を設定します。
+
+```tsx preview functional client
+const notice = useNotice({ duration: null })
+
+return (
+  <Button
+    onClick={() =>
+      notice({
+        description:
+          "覚えておきなさい、こんなにいい女滅多にいないんだからねっ！",
+        title: "シェリル・ノーム",
+      })
+    }
+  >
+    Show Notice
+  </Button>
+)
+```
+
+### 表示位置を変更する
+
+表示位置を変更する場合は、`placement`に`"start"`や`"end"`などを設定します。
+
+```tsx preview functional client
+const notice = useNotice({ duration: null })
+
+return (
+  <Wrap gap="md">
+    <For
+      each={
+        [
+          "start-start",
+          "start-center",
+          "start-end",
+          "end-start",
+          "end-center",
+          "end-end",
+        ] as const
+      }
+    >
+      {(placement) => (
+        <Button
+          key={placement}
+          onClick={() =>
+            notice({
+              description: "お前が、お前たちが俺の翼だ！",
+              placement,
+              title: "早乙女アルト",
+            })
+          }
+        >
+          Open "{placement}" Notice
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### 通知を閉じる方法を変更する
+
+通知を閉じる方法を変更する場合は、`closeStrategy`に`"click"`や`"drag"`などを設定します。
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["click", "drag", "button"] as const}>
+      {(closeStrategy) => (
+        <Button
+          key={closeStrategy}
+          onClick={() =>
+            notice({
+              closeStrategy,
+              description: "お前が、お前たちが俺の翼だ！",
+              title: "早乙女アルト",
+            })
+          }
+        >
+          {toTitleCase(closeStrategy)} Only
+        </Button>
+      )}
+    </For>
+
+    <For
+      each={
+        [
+          ["click", "drag"],
+          ["button", "drag"],
+        ] as NoticeCloseStrategy[][]
+      }
+    >
+      {(closeStrategy) => (
+        <Button
+          key={closeStrategy.join("-")}
+          onClick={() =>
+            notice({
+              closeStrategy,
+              description: "お前が、お前たちが俺の翼だ！",
+              title: "早乙女アルト",
+            })
+          }
+        >
+          {toTitleCase(closeStrategy[0]!)} & {toTitleCase(closeStrategy[1]!)}
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### 通知を閉じる
+
+通知を閉じる場合は、`close`や`closeAll`を使用します。
+
+```tsx preview functional client
+const notice = useNotice()
+const id = useRef<number | string | null>(null)
+
+const onOpen = () => {
+  id.current = notice({
+    closable: true,
+    description: "お前が好きだ。",
+    duration: 30000,
+    title: "クラン・クラン",
+  })
+}
+
+const onClose = () => {
+  if (id.current) notice.close(id.current)
+}
+
+const onCloseAll = () => {
+  notice.closeAll()
+}
+
+return (
+  <Wrap gap="md">
+    <Button onClick={onOpen}>Show Notice</Button>
+    <Button onClick={onClose}>Close last Notice</Button>
+    <Button onClick={onCloseAll}>Close all Notice</Button>
+  </Wrap>
+)
+```
+
+### 通知を更新する
+
+通知を更新する場合は、`update`メソッドを使用します。
+
+```tsx preview functional client
+const notice = useNotice()
+const id = useRef<number | string | null>(null)
+
+const onOpen = () => {
+  id.current = notice({
+    colorScheme: "orange",
+    description: "チャンスは目の前にあるものよ。",
+    duration: 5000,
+    title: "シェリル・ノーム",
+  })
+}
+
+const onUpdate = () => {
+  if (id.current)
+    notice.update(id.current, {
+      colorScheme: "blue",
+      description: "人生はワン･ツー･デカルチャー！！頑張れ、私。",
+      duration: 5000,
+      title: "ランカ・リー",
+    })
+}
+
+return (
+  <Wrap gap="md">
+    <Button onClick={onOpen}>Show Notice</Button>
+    <Button onClick={onUpdate}>Update last Notice</Button>
+  </Wrap>
+)
+```

--- a/www/contents/hooks/use-notice.mdx
+++ b/www/contents/hooks/use-notice.mdx
@@ -5,4 +5,393 @@ storybook: hooks-usenotice--basic
 source: hooks/use-notice
 ---
 
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Button
+    onClick={() =>
+      notice({
+        title: "シェリル・ノーム",
+        description: "私の歌を聴けー！",
+      })
+    }
+  >
+    Show Notice
+  </Button>
+)
+```
+
 ## Usage
+
+:::code-group
+
+```tsx [package]
+import { useNotice } from "@yamada-ui/react"
+```
+
+```tsx [alias]
+import { useNotice } from "@/components/ui"
+```
+
+```tsx [monorepo]
+import { useNotice } from "@workspaces/ui"
+```
+
+:::
+
+```tsx
+const notice = useNotice()
+```
+
+### Change Variant
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["plain", "solid", "subtle", "surface", "island"] as const}>
+      {(variant) => (
+        <Button
+          key={variant}
+          onClick={() => {
+            notice({
+              variant,
+              description: "こんなサービス、滅多にしないんだからね！",
+              title: "シェリル・ノーム",
+              withIcon: variant !== "island" ? true : false,
+            })
+          }}
+        >
+          Add "{toTitleCase(variant)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### Change Color Scheme
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["info", "success", "warning", "error"] as const}>
+      {(colorScheme) => (
+        <Button
+          key={colorScheme}
+          onClick={() => {
+            notice({
+              colorScheme,
+              description:
+                "人は１人じゃ飛べない。飛んじゃいけない。それが分かったから…",
+              title: "早乙女アルト",
+            })
+          }}
+        >
+          Add "{toTitleCase(colorScheme)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### Change Loading Scheme
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["oval", "grid", "puff", "dots"] as const}>
+      {(loadingScheme) => (
+        <Button
+          key={loadingScheme}
+          onClick={() => {
+            notice({
+              description: "人を本気で好きになるのは命がけなんだな。",
+              loadingScheme,
+              title: "ミハエル・ブラン",
+            })
+          }}
+        >
+          Add "{toTitleCase(loadingScheme)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### Change Status
+
+To change the status, set the `status` to `"info"` or `"success"` etc.
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["info", "success", "warning", "error"] as const}>
+      {(status) => (
+        <Button
+          key={status}
+          onClick={() => {
+            notice({
+              description: "皆抱きしめて！銀河の果てまで！",
+              status,
+              title: "ランカ・リー",
+            })
+          }}
+        >
+          Add "{toTitleCase(status)}" Snack
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### Change Limit
+
+To change the limit, set the `limit` to a number.
+
+```tsx preview functional client
+const notice = useNotice({ limit: 10 })
+
+return (
+  <Button
+    onClick={() =>
+      notice({
+        description: "お前の恋は何処にある！",
+        title: "クラン・クラン",
+      })
+    }
+  >
+    Show Notice
+  </Button>
+)
+```
+
+### Change Duration
+
+To change the duration, set the `duration` to a number.
+
+```tsx preview functional client
+const notice = useNotice({ duration: 10000 })
+
+return (
+  <Wrap gap="md">
+    <Button
+      onClick={() =>
+        notice({
+          description: "お前も、お前の夢も、俺が守る！",
+          title: "オズマ・リー",
+        })
+      }
+    >
+      Show Notice
+    </Button>
+
+    <Button
+      onClick={() =>
+        notice({
+          description: "お前も、お前の夢も、俺が守る！",
+          duration: 5000,
+          title: "オズマ・リー",
+        })
+      }
+    >
+      Show Notice with Option
+    </Button>
+  </Wrap>
+)
+```
+
+### Keep Stay
+
+To keep the notice staying, set the `duration` to `null`.
+
+```tsx preview functional client
+const notice = useNotice({ duration: null })
+
+return (
+  <Button
+    onClick={() =>
+      notice({
+        description:
+          "覚えておきなさい、こんなにいい女滅多にいないんだからねっ！",
+        title: "シェリル・ノーム",
+      })
+    }
+  >
+    Show Notice
+  </Button>
+)
+```
+
+### Change Placement
+
+To change the placement, set the `placement` to `"start"` or `"end"` etc.
+
+```tsx preview functional client
+const notice = useNotice({ duration: null })
+
+return (
+  <Wrap gap="md">
+    <For
+      each={
+        [
+          "start-start",
+          "start-center",
+          "start-end",
+          "end-start",
+          "end-center",
+          "end-end",
+        ] as const
+      }
+    >
+      {(placement) => (
+        <Button
+          key={placement}
+          onClick={() =>
+            notice({
+              description: "お前が、お前たちが俺の翼だ！",
+              placement,
+              title: "早乙女アルト",
+            })
+          }
+        >
+          Open "{placement}" Notice
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### Change Close Strategy
+
+To change the close strategy, set the `closeStrategy` to `"click"` or `"drag"` etc.
+
+```tsx preview functional client
+const notice = useNotice()
+
+return (
+  <Wrap gap="md">
+    <For each={["click", "drag", "button"] as const}>
+      {(closeStrategy) => (
+        <Button
+          key={closeStrategy}
+          onClick={() =>
+            notice({
+              closeStrategy,
+              description: "お前が、お前たちが俺の翼だ！",
+              title: "早乙女アルト",
+            })
+          }
+        >
+          {toTitleCase(closeStrategy)} Only
+        </Button>
+      )}
+    </For>
+
+    <For
+      each={
+        [
+          ["click", "drag"],
+          ["button", "drag"],
+        ] as NoticeCloseStrategy[][]
+      }
+    >
+      {(closeStrategy) => (
+        <Button
+          key={closeStrategy.join("-")}
+          onClick={() =>
+            notice({
+              closeStrategy,
+              description: "お前が、お前たちが俺の翼だ！",
+              title: "早乙女アルト",
+            })
+          }
+        >
+          {toTitleCase(closeStrategy[0]!)} & {toTitleCase(closeStrategy[1]!)}
+        </Button>
+      )}
+    </For>
+  </Wrap>
+)
+```
+
+### Close Notice
+
+To close the notice, use `close` or `closeAll`.
+
+```tsx preview functional client
+const notice = useNotice()
+const id = useRef<number | string | null>(null)
+
+const onOpen = () => {
+  id.current = notice({
+    closable: true,
+    description: "お前が好きだ。",
+    duration: 30000,
+    title: "クラン・クラン",
+  })
+}
+
+const onClose = () => {
+  if (id.current) notice.close(id.current)
+}
+
+const onCloseAll = () => {
+  notice.closeAll()
+}
+
+return (
+  <Wrap gap="md">
+    <Button onClick={onOpen}>Show Notice</Button>
+    <Button onClick={onClose}>Close last Notice</Button>
+    <Button onClick={onCloseAll}>Close all Notice</Button>
+  </Wrap>
+)
+```
+
+### Update Notice
+
+To update the notice, use `update`.
+
+```tsx preview functional client
+const notice = useNotice()
+const id = useRef<number | string | null>(null)
+
+const onOpen = () => {
+  id.current = notice({
+    colorScheme: "orange",
+    description: "チャンスは目の前にあるものよ。",
+    duration: 5000,
+    title: "シェリル・ノーム",
+  })
+}
+
+const onUpdate = () => {
+  if (id.current)
+    notice.update(id.current, {
+      colorScheme: "blue",
+      description: "人生はワン･ツー･デカルチャー！！頑張れ、私。",
+      duration: 5000,
+      title: "ランカ・リー",
+    })
+}
+
+return (
+  <Wrap gap="md">
+    <Button onClick={onOpen}>Show Notice</Button>
+    <Button onClick={onUpdate}>Update last Notice</Button>
+  </Wrap>
+)
+```


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #4938

## Description

<!-- Add a brief description. -->
I have migrated `useNotice` documentation.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
It had empty documentation.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
I have added actual examples to both English and Japanese.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information

<img width="1789" height="1144" alt="image" src="https://github.com/user-attachments/assets/6d576ff3-7e80-4adb-a00d-23b752621eb3" />
