### PR TITLE
chore(lefthook): add file tracking for pnpm install on `post-merge` and `post-checkout`

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -99,11 +99,13 @@ commit-msg:
 post-merge:
   commands:
     pnpm:
+      files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
       glob: "{package.json,pnpm-lock.yaml}"
       run: pnpm install --frozen-lockfile
 
 post-checkout:
   commands:
     pnpm:
+      files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
       glob: "{package.json,pnpm-lock.yaml}"
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #5250 

## Description

<!-- Add a brief description. -->
I have added `files` for not running `pnpm install` if `package.json` or `pnpm-lock` was not changed.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
It ran `pnpm install` even if `package.json` was not changed.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
It will now only run when specified files in `glob` was changed.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
