### PR TITLE
feat(lefthook): add lefthook post merge and checkout with ignore scripts in gh actions

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -22,4 +22,4 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --ignore-scripts

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -99,5 +99,13 @@ commit-msg:
 post-merge:
   commands:
     pnpm:
+      files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
       glob: "{package.json,pnpm-lock.yaml}"
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
+
+post-checkout:
+  commands:
+    pnpm:
+      files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
+      glob: "{package.json,pnpm-lock.yaml}"
+      run: pnpm install --frozen-lockfile


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes # <!-- Github issue # here -->

## Description

<!-- Add a brief description. -->
I have added back reverted lefthook config from #5264 with `--ignore-scripts` option added in composite actions.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Does not properly check for file changes.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Checks file changes and keeps lockfile.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information

```
❯ pnpm i --frozen-lockfile --ignore-scripts
Scope: all 10 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
 WARN  Failed to create bin at /home/taroj1205/yamada-ui/main/www/node_modules/.bin/yamada-cli. ENOENT: no such file or directory, open '/home/taroj1205/yamada-ui/main/packages/cli/dist/index.js'
Done in 2.7s
```