### PR TITLE
fix(cli): add shebang to binary via tsdown banner

### DIFF
--- a/.changeset/fix-cli-shebang.md
+++ b/.changeset/fix-cli-shebang.md
@@ -1,0 +1,11 @@
+---
+"@yamada-ui/cli": patch
+---
+
+fix: add shebang to CLI binary via tsdown banner configuration
+
+Add `#!/usr/bin/env node` shebang to the CLI binary by configuring tsdown's banner option.
+This fixes execution issues on Linux where the CLI failed with "import: not found" errors
+because the shell tried to execute the JavaScript file as a shell script.
+
+Fixes #5286

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "tsdown"
 
 export default defineConfig({
   target: "es2022",
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
   entry: "src/index.ts",
   format: "esm",
   shims: true,


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Configure tsdown's banner option to add `#!/usr/bin/env node` shebang
to the CLI binary. This fixes execution issues on Linux where the CLI
failed with "import: not found" errors because the shell tried to
execute the JavaScript file as a shell script.

Changes:
- Add banner.js configuration to tsdown.config.ts
- Shebang is now automatically added during build process

Closes #5286

## Description

<!-- Add a brief description. -->

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
