### PR TITLE
fix(popover, storybook): fix popover anchor storybook style

### DIFF
--- a/packages/react/src/components/popover/popover.stories.tsx
+++ b/packages/react/src/components/popover/popover.stories.tsx
@@ -80,8 +80,14 @@ export const Anchor: Story = () => {
     <Popover.Root>
       <HStack>
         <Popover.Anchor>
-          <Center borderWidth="1px" h="10" px="3" rounded="l2">
-            Here display Popover
+          <Center
+            borderWidth="1px"
+            h="10"
+            px="3"
+            rounded="l2"
+            textWrap="nowrap"
+          >
+            Display Popover Here
           </Center>
         </Popover.Anchor>
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes # <!-- Github issue # here -->

## Description

<!-- Add a brief description. -->
This fixes `Popover` anchor storybook page having weird styling.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
<img width="1904" height="1142" alt="image" src="https://github.com/user-attachments/assets/e80158e7-4731-40ae-b6af-4f8e2337c507" />


## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
<img width="819" height="1142" alt="image" src="https://github.com/user-attachments/assets/f1598664-57d9-4171-b210-ebb123300053" />

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
