### PR TITLE
fix(popover): remove `withCloseButton` and add `CloseTrigger` to `Popover`

### DIFF
--- a/.changeset/tough-tires-film.md
+++ b/.changeset/tough-tires-film.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": minor
+---
+
+Removed `withCloseButton` and added `CloseTrigger` to `Popover`.

--- a/packages/react/src/components/popover/index.ts
+++ b/packages/react/src/components/popover/index.ts
@@ -3,6 +3,7 @@ export * as Popover from "./namespace"
 export type {
   PopoverAnchorProps,
   PopoverBodyProps,
+  PopoverCloseTriggerProps,
   PopoverContentProps,
   PopoverFooterProps,
   PopoverHeaderProps,
@@ -14,6 +15,7 @@ export {
   getPopupAnimationProps,
   PopoverAnchor,
   PopoverBody,
+  PopoverCloseTrigger,
   PopoverContent,
   PopoverFooter,
   PopoverHeader,

--- a/packages/react/src/components/popover/namespace.ts
+++ b/packages/react/src/components/popover/namespace.ts
@@ -1,6 +1,7 @@
 export {
   PopoverAnchor as Anchor,
   PopoverBody as Body,
+  PopoverCloseTrigger as CloseTrigger,
   PopoverContent as Content,
   PopoverFooter as Footer,
   PopoverHeader as Header,
@@ -12,6 +13,7 @@ export {
 export type {
   PopoverAnchorProps as AnchorProps,
   PopoverBodyProps as BodyProps,
+  PopoverCloseTriggerProps as CloseTriggerProps,
   PopoverContentProps as ContentProps,
   PopoverFooterProps as FooterProps,
   PopoverHeaderProps as HeaderProps,

--- a/packages/react/src/components/popover/popover.stories.tsx
+++ b/packages/react/src/components/popover/popover.stories.tsx
@@ -377,6 +377,26 @@ export const DisabledCloseOnEsc: Story = () => {
   )
 }
 
+export const CloseTrigger: Story = () => {
+  return (
+    <Popover.Root>
+      <Popover.Trigger>
+        <Button>Click me</Button>
+      </Popover.Trigger>
+
+      <Popover.Content>
+        <Popover.Header>ベジータ!</Popover.Header>
+        <Popover.Body>がんばれカカロット……お前がナンバー１だ！！</Popover.Body>
+        <Popover.Footer>
+          <Popover.CloseTrigger>
+            <Button>Close</Button>
+          </Popover.CloseTrigger>
+        </Popover.Footer>
+      </Popover.Content>
+    </Popover.Root>
+  )
+}
+
 export const DisabledAutoFocus: Story = () => {
   return (
     <Popover.Root autoFocus={false}>

--- a/packages/react/src/components/popover/popover.test.tsx
+++ b/packages/react/src/components/popover/popover.test.tsx
@@ -46,6 +46,7 @@ describe("<Popover />", () => {
   test("sets `displayName` correctly", () => {
     expect(Popover.Root.name).toBe("PopoverRoot")
     expect(Popover.Trigger.displayName).toBe("PopoverTrigger")
+    expect(Popover.CloseTrigger.displayName).toBe("PopoverCloseTrigger")
     expect(Popover.Anchor.displayName).toBe("PopoverAnchor")
     expect(Popover.Content.displayName).toBe("PopoverContent")
     expect(Popover.Header.displayName).toBe("PopoverHeader")

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -85,6 +85,7 @@ interface ComponentContext
       UsePopoverReturn,
       | "getAnchorProps"
       | "getBodyProps"
+      | "getCloseTriggerProps"
       | "getContentProps"
       | "getFooterProps"
       | "getHeaderProps"
@@ -92,8 +93,7 @@ interface ComponentContext
       | "getTriggerProps"
       | "open"
     >,
-    PopupAnimationProps,
-    Pick<PopoverRootProps, "withCloseButton"> {}
+    PopupAnimationProps {}
 
 export interface PopoverRootProps
   extends UsePopoverProps,
@@ -112,12 +112,6 @@ export interface PopoverRootProps
    * @default 0.2
    */
   duration?: PopupAnimationProps["duration"]
-  /**
-   * If `true`, display the popover close button.
-   *
-   * @default true
-   */
-  withCloseButton?: boolean
 }
 
 const {
@@ -143,18 +137,13 @@ export { PopoverPropsContext, usePopoverPropsContext }
 export const PopoverRoot: FC<PopoverRootProps> = (props) => {
   const [
     styleContext,
-    {
-      animationScheme = "scale",
-      children,
-      duration = 0.1,
-      withCloseButton = true,
-      ...rest
-    },
+    { animationScheme = "scale", children, duration = 0.1, ...rest },
   ] = useRootComponentProps(props)
   const {
     open,
     getAnchorProps,
     getBodyProps,
+    getCloseTriggerProps,
     getContentProps,
     getFooterProps,
     getHeaderProps,
@@ -167,9 +156,9 @@ export const PopoverRoot: FC<PopoverRootProps> = (props) => {
       animationScheme,
       duration,
       open,
-      withCloseButton,
       getAnchorProps,
       getBodyProps,
+      getCloseTriggerProps,
       getContentProps,
       getFooterProps,
       getHeaderProps,
@@ -177,12 +166,12 @@ export const PopoverRoot: FC<PopoverRootProps> = (props) => {
       getTriggerProps,
     }),
     [
-      withCloseButton,
       open,
       animationScheme,
       duration,
       getAnchorProps,
       getBodyProps,
+      getCloseTriggerProps,
       getContentProps,
       getFooterProps,
       getHeaderProps,
@@ -210,6 +199,20 @@ export const PopoverTrigger = withContext<"button", PopoverTriggerProps>(
 
   return getTriggerProps(props)
 })
+
+export interface PopoverCloseTriggerProps extends HTMLStyledProps<"button"> {}
+
+export const PopoverCloseTrigger = withContext<
+  "button",
+  PopoverCloseTriggerProps
+>("button", { name: "CloseTrigger", slot: ["trigger", "close"] })(
+  { asChild: true },
+  (props) => {
+    const { getCloseTriggerProps } = useComponentContext()
+
+    return getCloseTriggerProps(props)
+  },
+)
 
 export interface PopoverAnchorProps extends HTMLStyledProps {}
 

--- a/packages/react/src/components/popover/use-popover.tsx
+++ b/packages/react/src/components/popover/use-popover.tsx
@@ -326,10 +326,23 @@ export const usePopover = ({
 
   const getFooterProps: PropGetter = useCallback((props) => ({ ...props }), [])
 
+  const getCloseTriggerProps: PropGetter<"button"> = useCallback(
+    (props = {}) => ({
+      ...props,
+      onClick: handlerAll(props.onClick, () => {
+        onClose()
+
+        triggerRef.current?.focus()
+      }),
+    }),
+    [onClose],
+  )
+
   return {
     open,
     getAnchorProps,
     getBodyProps,
+    getCloseTriggerProps,
     getContentProps,
     getFooterProps,
     getHeaderProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #5515 

## Description

<!-- Add a brief description. -->
I have removed `withCloseButton` prop and added `CloseTrigger` to `Popover`.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
`Popover` had `withCloseButton` prop that did nothing.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
This has been replaced with `CloseTrigger`.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
Yes, a prop `withCloseButton` has been removed.

## Additional Information
