### PR TITLE
fix(color-picker): add aria-label to CustomControl story for a11y 

### DIFF
--- a/packages/react/src/components/color-picker/color-picker.stories.tsx
+++ b/packages/react/src/components/color-picker/color-picker.stories.tsx
@@ -390,7 +390,11 @@ export const CustomControl: Story = () => {
   const [value, setValue] = useState("#4387f4")
 
   return (
-    <ColorPicker aria-label="Choose a color" value={value} onChange={setValue} />
+    <ColorPicker
+      aria-label="Choose a color"
+      value={value}
+      onChange={setValue}
+    />
   )
 }
 


### PR DESCRIPTION
### Summary

Fixes accessibility issue in the ColorPicker `CustomControl` story where the input had no accessible label.

### Change

- Added an `aria-label` to the ColorPicker usage in the CustomControl story.

### Verification

- Confirmed the axe accessibility warning is resolved.
- No visual or behavioral changes.

Closes #5627
