### PR TITLE
fix: add an aria-label to ColorPicker CustomControl for a11y

### DIFF
--- a/packages/react/src/components/color-picker/color-picker.stories.tsx
+++ b/packages/react/src/components/color-picker/color-picker.stories.tsx
@@ -389,7 +389,13 @@ export const BorderColor: Story = () => {
 export const CustomControl: Story = () => {
   const [value, setValue] = useState("#4387f4")
 
-  return <ColorPicker value={value} onChange={setValue} />
+  return (
+    <ColorPicker
+      value={value}
+      inputProps={{ "aria-label": "Pick a color" }}
+      onChange={setValue}
+    />
+  )
 }
 
 export const ReactHookForm: Story = () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #5627  <!-- Github issue # here -->

## Description

<!-- Add a brief description. -->
Adds an `aria-label` to the `ColorPicker` CustomControl story input to satisfy the a11y label requirement. 

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
The CustomControl story’s input had no accessible label, which triggers the a11y “form elements must have labels” rule. Just as issue #5627 says.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
The CustomControl story input now has `aria-label="Pick a color"`.

## Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
I'm new to open source and frontend development. So I just made a small change. Hope no component logic was touched. If anything should be adjusted, just contact me. I'm always eager to learn. Thank you!!
