### PR TITLE
fix(carousel): fix `Carousel` next/prev buttons affecting slide animations

### DIFF
--- a/.changeset/red-baboons-trade.md
+++ b/.changeset/red-baboons-trade.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed `Carousel` next/prev control buttons affecting slide animations.

--- a/packages/react/src/components/carousel/use-carousel.ts
+++ b/packages/react/src/components/carousel/use-carousel.ts
@@ -412,11 +412,11 @@ export const useCarousel = ({
       "data-orientation": orientation,
       ...rest,
       ...props,
-      ref: mergeRefs(ref, rest.ref, carouselRef),
+      ref: mergeRefs(ref, rest.ref),
       onMouseEnter: handlerAll(props.onMouseEnter, onMouseEnter),
       onMouseLeave: handlerAll(props.onMouseLeave, onMouseLeave),
     }),
-    [id, onMouseEnter, onMouseLeave, rest, carouselRef, orientation],
+    [id, onMouseEnter, onMouseLeave, rest, orientation],
   )
 
   const getListProps: PropGetter = useCallback(
@@ -425,9 +425,9 @@ export const useCarousel = ({
       "aria-live": autoplay ? "off" : "polite",
       "data-orientation": orientation,
       ...props,
-      ref: mergeRefs(ref, listRef),
+      ref: mergeRefs(ref, listRef, carouselRef),
     }),
-    [autoplay, listId, orientation],
+    [autoplay, listId, orientation, carouselRef],
   )
 
   const getItemProps: RequiredPropGetter<"div", { index: number }> =


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

- Closes #5186

## Description

I've fixed carousel animations getting affected by next/prev buttons.
The slides were capturing pointer down as `drag`, which made slides not move while mouse was held down.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Animations were getting stuck.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Now the button clicks doesn't go to slides so it won't be registered as `drag`.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information

https://github.com/user-attachments/assets/0f413c1a-17ba-47d8-a188-6c9e41290eba

