### PR TITLE
fix(autocomplete): keep focused state when blurring to dropdown content

### DIFF
--- a/.changeset/fix-autocomplete-blur-focused.md
+++ b/.changeset/fix-autocomplete-blur-focused.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed `onBlur` incorrectly setting `focused` to `false` when clicking on the dropdown content in `Autocomplete` with `multiple` mode, which caused the separator to disappear during mousedown.

--- a/packages/react/src/components/autocomplete/autocomplete.test.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, render, screen } from "#test"
+import { a11y, fireEvent, render, screen } from "#test"
 import { Autocomplete } from "."
 
 describe("<Autocomplete />", () => {
@@ -47,6 +47,65 @@ describe("<Autocomplete />", () => {
     expect(option.firstChild).toHaveClass("ui-autocomplete__indicator")
     expect(group).toHaveClass("ui-autocomplete__group")
     expect(group.firstChild).toHaveClass("ui-autocomplete__label")
+  })
+
+  test("does not hide separator when blurring to content in multiple mode", () => {
+    render(
+      <Autocomplete.Root
+        defaultOpen
+        defaultValue={["one", "two"]}
+        items={[
+          { label: "Option 1", value: "one" },
+          { label: "Option 2", value: "two" },
+          { label: "Option 3", value: "three" },
+        ]}
+        multiple
+      />,
+    )
+
+    const field = screen.getByRole("combobox")
+    const input = field.querySelector("input")!
+    const option = screen.getByRole("option", { name: "Option 3" })
+
+    fireEvent.focus(input)
+
+    // The separator should still be visible after blurring to an option in the content
+    fireEvent.blur(input, { relatedTarget: option })
+
+    const spans = [...field.querySelectorAll("span")]
+    const lastSpan = spans.at(-1)
+
+    expect(lastSpan?.textContent).toContain(",")
+  })
+
+  test("hides separator when blurring outside the component in multiple mode", () => {
+    render(
+      <>
+        <button data-testid="outside">outside</button>
+        <Autocomplete.Root
+          defaultOpen
+          defaultValue={["one", "two"]}
+          items={[
+            { label: "Option 1", value: "one" },
+            { label: "Option 2", value: "two" },
+            { label: "Option 3", value: "three" },
+          ]}
+          multiple
+        />
+      </>,
+    )
+
+    const field = screen.getByRole("combobox")
+    const input = field.querySelector("input")!
+    const outside = screen.getByTestId("outside")
+
+    fireEvent.focus(input)
+    fireEvent.blur(input, { relatedTarget: outside })
+
+    const spans = [...field.querySelectorAll("span")]
+    const lastSpan = spans.at(-1)
+
+    expect(lastSpan?.textContent).not.toContain(",")
   })
 
   test("renders HTML tag correctly", () => {

--- a/packages/react/src/components/autocomplete/use-autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/use-autocomplete.tsx
@@ -557,14 +557,14 @@ export const useAutocomplete = <Multiple extends boolean = false>(
 
   const onBlur = useCallback(
     (ev: FocusEvent<HTMLInputElement>) => {
-      setFocused(false)
-
       if (
         contains(fieldRef.current, ev.relatedTarget) ||
         contains(contentRef.current, ev.relatedTarget)
       ) {
         ev.preventDefault()
       } else {
+        setFocused(false)
+
         if (isArray(value)) {
           setInputValue("")
         } else {


### PR DESCRIPTION
## Summary

- Fixes `onBlur` incorrectly setting `focused` to `false` when clicking on dropdown options in `Autocomplete` with `multiple` mode
- The separator was disappearing during mousedown because `setFocused(false)` was called unconditionally at the start of `onBlur`, before checking if focus moved to the field/content area
- Fix: move `setFocused(false)` inside the `else` branch so it only fires when focus truly leaves the component

## Test plan

- [x] Added test verifying separator remains visible when blurring to dropdown content
- [x] Added test verifying separator is hidden when blurring outside the component
- [x] All existing tests pass

Closes #5562

🤖 Generated with [Claude Code](https://claude.com/claude-code)