### PR TITLE
test(bleed): achieve 100% test coverage

### DIFF
--- a/packages/react/src/components/bleed/bleed.test.tsx
+++ b/packages/react/src/components/bleed/bleed.test.tsx
@@ -19,4 +19,25 @@ describe("<Bleed />", () => {
     render(<Bleed>Box</Bleed>)
     expect(screen.getByText("Box").tagName).toBe("DIV")
   })
+
+  test("applies `calc(50% - 50vw)` to both inline sides when `inline='full'`", () => {
+    render(<Bleed inline="full">Box</Bleed>)
+    const el = screen.getByText("Box")
+    expect(el).toHaveStyle({
+      marginInlineEnd: "calc(50% - 50vw)",
+      marginInlineStart: "calc(50% - 50vw)",
+    })
+  })
+
+  test("applies `calc(50% - 50vw)` to inline start when `inlineStart='full'`", () => {
+    render(<Bleed inlineStart="full">Box</Bleed>)
+    const el = screen.getByText("Box")
+    expect(el).toHaveStyle({ marginInlineStart: "calc(50% - 50vw)" })
+  })
+
+  test("applies `calc(50% - 50vw)` to inline end when `inlineEnd='full'`", () => {
+    render(<Bleed inlineEnd="full">Box</Bleed>)
+    const el = screen.getByText("Box")
+    expect(el).toHaveStyle({ marginInlineEnd: "calc(50% - 50vw)" })
+  })
 })


### PR DESCRIPTION
## Summary

- Add tests covering the `"full"` branches in `bleed.tsx` (L71, L74)
- `inline="full"` covers both `inlineStart` and `inlineEnd` full branches
- `inlineStart="full"` covers L71 specifically
- `inlineEnd="full"` covers L74 specifically

## Test plan

- [x] All existing tests pass
- [x] New tests verify `calc(50% - 50vw)` is applied when `inline`, `inlineStart`, or `inlineEnd` is set to `"full"`

Closes #5707

🤖 Generated with [Claude Code](https://claude.com/claude-code)