### PR TITLE
test(highlight): enhance test coverage for Highlight component

### DIFF
--- a/packages/react/src/components/highlight/highlight.test.tsx
+++ b/packages/react/src/components/highlight/highlight.test.tsx
@@ -46,6 +46,32 @@ describe("<Highlight />", () => {
     expect(container.firstChild?.nodeName).toBe("#text")
   })
 
+  test("fragment prop renders Mark for matched text", () => {
+    const { container } = render(
+      <Highlight fragment query="High">
+        Highlight
+      </Highlight>,
+    )
+
+    const mark = screen.getByText("High")
+    expect(mark.tagName).toBe("MARK")
+    expect(container.querySelector("p")).toBeNull()
+  })
+
+  test("renders non-matching chunks as plain text alongside matches", () => {
+    render(
+      <Highlight data-testid="highlight" query="world">
+        Hello world
+      </Highlight>,
+    )
+
+    const container = screen.getByTestId("highlight")
+    const mark = screen.getByText("world")
+    expect(mark.tagName).toBe("MARK")
+    expect(container.tagName).toBe("P")
+    expect(container).toHaveTextContent("Hello world")
+  })
+
   test("markProps prop works correctly", () => {
     const { getByText } = render(
       <Highlight query="Highlight" markProps={{ borderRadius: "12px" }}>


### PR DESCRIPTION
## Description
Enhance test coverage for the Highlight component to reach at least 95%, covering the previously uncovered lines L50 and L68 in highlight.tsx.

Closes #5376

## Added Tests
- **fragment prop renders Mark for matched text** - Covers L50: the Mark rendering inside the fragment=true branch when a query matches.
- **renders non-matching chunks as plain text alongside matches** - Covers L68: the Fragment rendering for non-matching chunks in the default branch.

## Breaking Change
No