### PR TITLE
test(blockquote): enhance test coverage for cite prop shorthand

### DIFF
--- a/packages/react/src/components/blockquote/blockquote.test.tsx
+++ b/packages/react/src/components/blockquote/blockquote.test.tsx
@@ -51,6 +51,24 @@ describe("<Blockquote />", () => {
     )
   })
 
+  test("renders cite prop as caption when no custom BlockquoteCaption is provided", () => {
+    render(
+      <Blockquote.Root
+        data-testid="blockquote"
+        cite="Wikipedia"
+        citeUrl="https://example.com"
+        captionProps={{ "data-testid": "caption" } as any}
+        citeProps={{ "data-testid": "cite" } as any}
+      >
+        Blockquote content
+      </Blockquote.Root>,
+    )
+
+    expect(screen.getByTestId("caption")).toHaveClass("ui-blockquote__caption")
+    expect(screen.getByTestId("cite")).toHaveClass("ui-blockquote__cite")
+    expect(screen.getByText("Wikipedia")).toBeInTheDocument()
+  })
+
   test("renders HTML tag correctly", () => {
     render(
       <Blockquote.Root


### PR DESCRIPTION
Closes #5362

## Description

Added a test for the `cite` prop shorthand on `BlockquoteRoot`, which renders `BlockquoteCaption` and `BlockquoteCite` automatically when no custom `BlockquoteCaption` child is provided (covers L98 of `blockquote.tsx`).

## Current behavior (updates)

Existing tests only used the composed pattern with explicit sub-components (`<Blockquote.Caption>`), so the shorthand `cite` prop path was never exercised.

## New behavior

A new test verifies that using the `cite` prop on `<Blockquote.Root>` renders caption and cite elements with correct CSS classes and content.

## Is this a breaking change (Yes/No):

No

## Additional Information

- All existing blockquote tests continue to pass.