### PR TITLE
test(use-online): enhance test coverage with SSR snapshot tests

### DIFF
--- a/packages/react/src/hooks/use-online/index.test.tsx
+++ b/packages/react/src/hooks/use-online/index.test.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react"
 import { act, render } from "#test"
+import { createElement } from "react"
+import { renderToString } from "react-dom/server"
 import { useOnline } from "./"
 
 const Component: FC<{ getServerSnapshot?: () => boolean }> = ({
@@ -83,19 +85,27 @@ describe("useOnline", () => {
     removeSpy.mockRestore()
   })
 
-  test("uses custom getServerSnapshot", () => {
-    const { getByTestId } = render(
-      <Component getServerSnapshot={() => false} />,
-    )
+  test("uses default getServerSnapshot returning true during SSR", () => {
+    const ServerComponent = () => {
+      const online = useOnline()
 
-    expect(getByTestId("status").textContent).toBeDefined()
+      return createElement("span", null, String(online))
+    }
+
+    const html = renderToString(createElement(ServerComponent))
+
+    expect(html).toContain("true")
   })
 
-  test("uses default getServerSnapshot that returns true", () => {
-    onLineSpy.mockReturnValue(true)
+  test("uses custom getServerSnapshot returning false during SSR", () => {
+    const ServerComponent = () => {
+      const online = useOnline(() => false)
 
-    const { getByTestId } = render(<Component />)
+      return createElement("span", null, String(online))
+    }
 
-    expect(getByTestId("status").textContent).toBe("true")
+    const html = renderToString(createElement(ServerComponent))
+
+    expect(html).toContain("false")
   })
 })


### PR DESCRIPTION
Closes #5888

## Description

Enhance test coverage for useOnline hook by replacing client-only getServerSnapshot tests with actual SSR rendering tests using renderToString.

## Current behavior (updates)

The existing getServerSnapshot tests rendered in a jsdom client environment so the getServerSnapshot parameter was never actually invoked during tests.

## New behavior

- Added SSR test using renderToString that verifies the default getServerSnapshot returns true during server-side rendering.
- Added SSR test using renderToString that verifies a custom getServerSnapshot returning false is respected during server-side rendering.

## Is this a breaking change (Yes/No):

No

## Additional Information

All 7 tests pass. No source code changes were made, only test improvements.