### PR TITLE
test(checkbox-card): enhance test coverage for CheckboxCard component

### DIFF
--- a/packages/react/src/components/checkbox-card/checkbox-card.test.tsx
+++ b/packages/react/src/components/checkbox-card/checkbox-card.test.tsx
@@ -67,4 +67,34 @@ describe("<CheckboxCard />", () => {
     expect(checkbox?.parentElement?.children[3]?.tagName).toBe("SPAN")
     expect(checkbox?.parentElement?.children[4]?.tagName).toBe("SPAN")
   })
+
+  test("renders label, description, and addon via props", () => {
+    render(
+      <CheckboxCard.Root
+        addon="Test Addon"
+        description="Test Description"
+        label="Test Label"
+        value="test"
+      />,
+    )
+
+    expect(screen.getByText("Test Label")).toBeInTheDocument()
+    expect(screen.getByText("Test Description")).toBeInTheDocument()
+    expect(screen.getByText("Test Addon")).toBeInTheDocument()
+  })
+
+  test("renders without indicator when withIndicator is false", () => {
+    render(
+      <CheckboxCard.Root
+        label="No Indicator"
+        value="test"
+        withIndicator={false}
+      />,
+    )
+
+    expect(screen.getByText("No Indicator")).toBeInTheDocument()
+    const checkbox = screen.getByRole("checkbox")
+    const indicator = checkbox.parentElement?.querySelector("[data-indicator]")
+    expect(indicator).toBeNull()
+  })
 })


### PR DESCRIPTION
Closes #5709

## Description

Add tests to improve coverage for CheckboxCard component covering uncovered lines:
- L140: Rendering CheckboxCardLabel via the label prop
- L145: Rendering CheckboxCardDescription via the description prop
- L148: Rendering CheckboxCardAddon via the addon prop
- L168: Rendering without indicator when withIndicator is false

## Current behavior (updates)

Test coverage below 95%, missing tests for prop-based rendering and withIndicator=false.

## New behavior

Added two test cases:
- renders label, description, and addon via props
- renders without indicator when withIndicator is false

## Is this a breaking change (Yes/No):

No