### PR TITLE
test(table): enhance test coverage for Table component

### DIFF
--- a/packages/react/src/components/table/table.test.tsx
+++ b/packages/react/src/components/table/table.test.tsx
@@ -254,7 +254,7 @@ describe("<Table />", () => {
 
       await user.click(headerCheckbox)
 
-      expect(onRowSelectionChange).toHaveBeenCalledWith()
+      expect(onRowSelectionChange).toHaveBeenCalledWith(expect.any(Object))
     })
 
     test("selects individual row when row checkbox is clicked", async () => {
@@ -275,7 +275,7 @@ describe("<Table />", () => {
 
       await user.click(firstRowCheckbox)
 
-      expect(onRowSelectionChange).toHaveBeenCalledWith()
+      expect(onRowSelectionChange).toHaveBeenCalledWith(expect.any(Object))
     })
 
     test("selects row on click when selectOnClickRow is true", async () => {
@@ -297,7 +297,7 @@ describe("<Table />", () => {
 
       await user.click(firstDataRow)
 
-      expect(onRowSelectionChange).toHaveBeenCalledWith()
+      expect(onRowSelectionChange).toHaveBeenCalledWith(expect.any(Object))
     })
 
     test("renders footer checkbox when withFooterCheckbox is true", () => {
@@ -473,7 +473,7 @@ describe("<Table />", () => {
 
       await user.click(sortButton)
 
-      expect(onSortingChange).toHaveBeenCalledWith()
+      expect(onSortingChange).toHaveBeenCalledWith(expect.any(Array))
     })
 
     test("renders custom sorting icon", () => {
@@ -515,7 +515,6 @@ describe("<Table />", () => {
           columns={sortableColumns}
           data={data}
           enableSorting
-          // @ts-expect-error testing plain object sortingIconProps
           sortingIconProps={{ className: "custom-sorting-icon" }}
           tableProps={{ "data-testid": "table" }}
         />,
@@ -594,7 +593,6 @@ describe("<Table />", () => {
           columns={resizableColumns}
           data={data}
           enableColumnResizing
-          // @ts-expect-error testing plain object resizableTriggerProps
           resizableTriggerProps={{ "data-testid": "resize-handle" }}
           tableProps={{ "data-testid": "table" }}
         />,
@@ -621,7 +619,6 @@ describe("<Table />", () => {
           columns={resizableColumns}
           data={data}
           enableColumnResizing
-          // @ts-expect-error testing plain object resizableTriggerProps
           resizableTriggerProps={{ className: "custom-resize-trigger" }}
           tableProps={{ "data-testid": "table" }}
         />,


### PR DESCRIPTION
Closes #5938

## Description

Enhance test coverage for the `Table` component in `@yamada-ui/react` to reach at least 95% coverage.

## Current behavior (updates)

The `Table` component had minimal test coverage with only 4 basic tests (a11y, displayName, className, HTML tag).

## New behavior

Added 59 new tests covering:

- **Grouped columns**: merged header groups and footer groups (`getMergeHeaderGroups`/`getMergeFooterGroups`)
- **Row selection**: checkbox column, header/row checkboxes, `selectOnClickRow`, disabled rows, `headerCheckboxProps`, `rowCheckboxProps`, `withFooterCheckbox`
- **Sorting**: sort icon rendering, toggle sorting, custom sorting icons, `sortingIconProps`, ascending/descending states
- **Column resizing**: resizable triggers, `resizableTriggerProps`, `enableAutoResizeTableWidth`, `columnResizeMode` onEnd
- **Pagination**: page navigation, `PageDown`/`PageUp` keyboard navigation, boundary conditions
- **Keyboard navigation**: arrow keys, `Home`/`End`, `initialFocusableCell`, disabled navigation, grouped header navigation, footer group navigation
- **Controlled state**: sorting, pagination, rowSelection, columnFilters
- **Props passing**: `headerGroupProps`, `headerProps`, `rowProps`, `cellProps`, `footerGroupProps`, `footerProps`, `theadProps`, `tbodyProps`, `tfootProps`
- **Callbacks**: `onRowClick`, `onRowDoubleClick`
- **ARIA attributes**: `aria-colcount`, `aria-multiselectable`, `role="grid"`
- **Other**: header/footer render functions, truncated text, manual pagination with rowCount

## Is this a breaking change (Yes/No):

No

## Additional Information

All 63 tests pass (previously 4).