### PR TITLE
test(date-picker): enhance test coverage for DatePicker component

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -738,15 +738,15 @@ describe("<DatePicker />", () => {
   test("handles closeOnSelect for single date via calendar click", async () => {
     render(<DatePicker defaultOpen placeholder="Select date" />)
 
-    // Find a day button in the calendar and click it
+    // Find a day cell in the calendar and click it
     const dialog = screen.getByRole("dialog")
-    const dayButtons = dialog.querySelectorAll("button[data-value]")
-    const validButton = Array.from(dayButtons).find(
-      (btn) =>
-        !btn.hasAttribute("data-outside") && !btn.hasAttribute("data-disabled"),
+    const dayCells = dialog.querySelectorAll("td")
+    const validDay = Array.from(dayCells).find(
+      (td) =>
+        !td.hasAttribute("data-outside") && !td.hasAttribute("data-disabled"),
     )!
 
-    fireEvent.click(validButton)
+    fireEvent.click(validDay)
 
     // closeOnSelect defaults to true for single, so dialog should close
     await waitFor(() => {
@@ -763,15 +763,15 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    // Find a day button in the calendar and click it
+    // Find a day cell in the calendar and click it
     const dialog = screen.getByRole("dialog")
-    const dayButtons = dialog.querySelectorAll("button[data-value]")
-    const validButton = Array.from(dayButtons).find(
-      (btn) =>
-        !btn.hasAttribute("data-outside") && !btn.hasAttribute("data-disabled"),
+    const dayCells = dialog.querySelectorAll("td")
+    const validDay = Array.from(dayCells).find(
+      (td) =>
+        !td.hasAttribute("data-outside") && !td.hasAttribute("data-disabled"),
     )!
 
-    fireEvent.click(validButton)
+    fireEvent.click(validDay)
 
     // closeOnSelect is false, so dialog should remain open
     expect(screen.getByRole("dialog")).toBeInTheDocument()


### PR DESCRIPTION
Closes #5348

## Description

Enhanced test coverage for `DatePicker` in `@yamada-ui/react` by adding comprehensive tests covering uncovered lines in `date-picker.tsx` and `use-date-picker.tsx`.

## Current behavior (updates)

Test coverage for `DatePicker` was below 95%, with many uncovered lines in both `date-picker.tsx` and `use-date-picker.tsx`.

## New behavior

Added 91 new tests (94 total) covering:
- Single, multiple, and range date picker modes
- Input change, Enter key, Backspace key handling
- Blur behavior (single, range, multiple)
- Clear icon click and keyboard events (Enter, Space)
- `allowInput`, `allowInputBeyond`, `closeOnChange`, `openOnChange`, `closeOnSelect`
- `defaultInputValue` (single, range, valid/invalid)
- `format` with null input
- `excludeDate`, `pattern`, `parseDate`
- `minDate`/`maxDate` clamping
- Range field focus management (click routing to start/end input)
- Custom `render` for multiple mode with `onClear`
- Controlled value updates (single, range)
- `id`/`name` assignment in range mode
- IME composition handling
- Various props: `disabled`, `readOnly`, `required`, `separator`, `placeholder`, `focusOnClear`, `animationScheme`, `duration`, `contentProps`, `calendarProps`, `elementProps`, `iconProps`, `clearable`, `icon`

## Is this a breaking change (Yes/No):

No

## Additional Information

This is a test-only change. No source code was modified.