### PR TITLE
docs(frameworks): add TanStack Start and TanStack Router integration guides

### DIFF
--- a/www/contents/get-started/frameworks/tanstack-router.ja.mdx
+++ b/www/contents/get-started/frameworks/tanstack-router.ja.mdx
@@ -1,0 +1,296 @@
+---
+title: TanStack Router
+description: TanStack RouterのプロジェクトにYamada UIをインストールして使用するためのガイド。
+---
+
+## インストール
+
+::::steps
+
+### アプリケーションを作成する
+
+TanStack Routerのアプリケーションを作成します。
+
+:::code-group
+
+```bash [pnpm]
+pnpm create @tanstack/router my-app
+```
+
+```bash [npm]
+npx @tanstack/create-router my-app
+```
+
+```bash [yarn]
+yarn create @tanstack/router my-app
+```
+
+```bash [bun]
+bunx @tanstack/create-router my-app
+```
+
+:::
+
+### セットアップする
+
+コマンドを実行すると、プロジェクトに必要なファイルやフォルダが作成されます。
+
+:::code-group
+
+```bash [pnpm]
+pnpm dlx @yamada-ui/cli init
+```
+
+```bash [npm]
+npx @yamada-ui/cli init
+```
+
+```bash [yarn]
+yarn dlx @yamada-ui/cli init
+```
+
+```bash [bun]
+bunx @yamada-ui/cli init
+```
+
+:::
+
+### パッケージをインストールする
+
+アプリケーションに`@workspaces/ui`をインストールします。
+
+:::code-group
+
+```bash [pnpm]
+pnpm add "@workspaces/ui@workspace:*"
+```
+
+```bash [npm]
+npm install "@workspaces/ui@workspace:*"
+```
+
+```bash [yarn]
+yarn add "@workspaces/ui@workspace:*"
+```
+
+```bash [bun]
+bun add "@workspaces/ui@workspace:*"
+```
+
+:::
+
+### プロバイダーを追加する
+
+インストール後、アプリケーションのルートに`UIProvider`を追加します。
+
+```tsx title="src/main.tsx" {4,8,10}
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { RouterProvider, createRouter } from "@tanstack/react-router"
+import { UIProvider } from "@workspaces/ui"
+import { routeTree } from "./routeTree.gen"
+
+const router = createRouter({ routeTree })
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <UIProvider>
+      <RouterProvider router={router} />
+    </UIProvider>
+  </StrictMode>,
+)
+```
+
+### コンポーネントを使用する
+
+`UIProvider`を追加したら、アプリケーション内でコンポーネントを使用します。
+
+```tsx title="src/routes/index.tsx" {2,7}
+import { createFileRoute } from "@tanstack/react-router"
+import { Button } from "@workspaces/ui"
+
+export const Route = createFileRoute("/")({
+  component: Index,
+})
+
+function Index() {
+  return <Button>Click me!</Button>
+}
+```
+
+これで、Yamada UIのセットアップは完了です！
+
+::::
+
+## スクリプト
+
+### ColorModeScript
+
+[カラーモード](/docs/theming/color-mode)を使用する場合は、正常に動作させるために`body`に`ColorModeScript`を追加する必要があります。
+
+理由は、カラーモードが`localStorage`や`cookies`を用いて実装されており、ページの読み込み時に同期を正しく機能させるためです。
+
+```ts title="vite.config.ts" {1,4-18,22}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { COLOR_MODE_STORAGE_KEY, getStorageScript } from "@workspaces/ui"
+
+function injectColorModeScript(): Plugin {
+  return {
+    name: "inject-color-mode-script",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "colorMode",
+        COLOR_MODE_STORAGE_KEY,
+      )({ defaultValue: "light" })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectColorModeScript()],
+})
+```
+
+もし、[コンフィグ](/docs/theming/configuration/overview)の`defaultColorMode`を変更した場合は、`ColorModeScript`に`defaultValue`を設定します。
+
+```ts title="vite.config.ts" {5,14}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { COLOR_MODE_STORAGE_KEY, getStorageScript } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+
+function injectColorModeScript(): Plugin {
+  return {
+    name: "inject-color-mode-script",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "colorMode",
+        COLOR_MODE_STORAGE_KEY,
+      )({ defaultValue: config.defaultColorMode })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectColorModeScript()],
+})
+```
+
+### ThemeSchemeScript
+
+[テーマの切り替え](/docs/theming/switching-themes)を使用する場合は、正常に動作させるために`body`に`ThemeSchemeScript`を追加する必要があります。
+
+理由は、テーマの切り替えが`localStorage`や`cookies`を用いて実装されており、ページの読み込み時に同期を正しく機能させるためです。
+
+```ts title="vite.config.ts" {1,4-18,22}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { getStorageScript, THEME_SCHEME_STORAGE_KEY } from "@workspaces/ui"
+
+function injectThemeSchemeScript(): Plugin {
+  return {
+    name: "inject-theme-scheme-scripts",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "themeScheme",
+        THEME_SCHEME_STORAGE_KEY,
+      )({ defaultValue: "base" })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectThemeSchemeScript()],
+})
+```
+
+もし、[コンフィグ](/docs/theming/configuration/overview)の`defaultThemeScheme`を変更した場合は、`ThemeSchemeScript`に`defaultValue`を設定します。
+
+```ts title="vite.config.ts" {5,14}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { getStorageScript, THEME_SCHEME_STORAGE_KEY } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+
+function injectThemeSchemeScript(): Plugin {
+  return {
+    name: "inject-theme-scheme-scripts",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "themeScheme",
+        THEME_SCHEME_STORAGE_KEY,
+      )({ defaultValue: config.defaultThemeScheme })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectThemeSchemeScript()],
+})
+```
+
+## コンポーネントの統合
+
+TanStack Routerの[Link](https://tanstack.com/router/latest/docs/framework/react/api/router/linkComponent)などのコンポーネントとYamada UIのコンポーネントを統合することができます。
+
+### Link
+
+```tsx
+import type {
+  ButtonProps,
+  HTMLRefAttributes,
+  IconButtonProps,
+  LinkProps,
+  Merge,
+} from "@yamada-ui/react"
+import type { FC } from "react"
+import type { LinkProps as OriginalLinkProps } from "@tanstack/react-router"
+import { Button, IconButton, Link } from "@yamada-ui/react"
+import { Link as OriginalLink } from "@tanstack/react-router"
+
+export interface TanStackLinkProps extends Omit<
+  Merge<OriginalLinkProps, LinkProps>,
+  "as" | "ref"
+> {}
+
+export const TanStackLink: FC<TanStackLinkProps> = (props) => {
+  return <Link as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, ButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkButton: FC<TanStackLinkButtonProps> = (props) => {
+  return <Button as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkIconButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, IconButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkIconButton: FC<TanStackLinkIconButtonProps> = (
+  props,
+) => {
+  return <IconButton as={OriginalLink} {...props} />
+}
+```

--- a/www/contents/get-started/frameworks/tanstack-router.mdx
+++ b/www/contents/get-started/frameworks/tanstack-router.mdx
@@ -1,0 +1,296 @@
+---
+title: TanStack Router
+description: A guide for installing and using Yamada UI with TanStack Router projects.
+---
+
+## Installation
+
+::::steps
+
+### Create application
+
+Create TanStack Router application.
+
+:::code-group
+
+```bash [pnpm]
+pnpm create @tanstack/router my-app
+```
+
+```bash [npm]
+npx @tanstack/create-router my-app
+```
+
+```bash [yarn]
+yarn create @tanstack/router my-app
+```
+
+```bash [bun]
+bunx @tanstack/create-router my-app
+```
+
+:::
+
+### Setup
+
+Running the command will create the necessary files and folders in your project.
+
+:::code-group
+
+```bash [pnpm]
+pnpm dlx @yamada-ui/cli init
+```
+
+```bash [npm]
+npx @yamada-ui/cli init
+```
+
+```bash [yarn]
+yarn dlx @yamada-ui/cli init
+```
+
+```bash [bun]
+bunx @yamada-ui/cli init
+```
+
+:::
+
+### Install the package
+
+Install `@workspaces/ui` to your application.
+
+:::code-group
+
+```bash [pnpm]
+pnpm add "@workspaces/ui@workspace:*"
+```
+
+```bash [npm]
+npm install "@workspaces/ui@workspace:*"
+```
+
+```bash [yarn]
+yarn add "@workspaces/ui@workspace:*"
+```
+
+```bash [bun]
+bun add "@workspaces/ui@workspace:*"
+```
+
+:::
+
+### Add provider
+
+After installing, add `UIProvider` to the root of your application.
+
+```tsx title="src/main.tsx" {4,8,10}
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { RouterProvider, createRouter } from "@tanstack/react-router"
+import { UIProvider } from "@workspaces/ui"
+import { routeTree } from "./routeTree.gen"
+
+const router = createRouter({ routeTree })
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <UIProvider>
+      <RouterProvider router={router} />
+    </UIProvider>
+  </StrictMode>,
+)
+```
+
+### Use components
+
+After adding `UIProvider`, you can use the components in your application.
+
+```tsx title="src/routes/index.tsx" {2,7}
+import { createFileRoute } from "@tanstack/react-router"
+import { Button } from "@workspaces/ui"
+
+export const Route = createFileRoute("/")({
+  component: Index,
+})
+
+function Index() {
+  return <Button>Click me!</Button>
+}
+```
+
+That's it! You've successfully set up Yamada UI.
+
+::::
+
+## Scripts
+
+### ColorModeScript
+
+To use [Color Mode](/docs/theming/color-mode), you need to add `ColorModeScript` to the `body` to ensure it works correctly.
+
+This is because color mode is implemented using `localStorage` or `cookies`, and adding the script ensures proper synchronization when the page loads.
+
+```ts title="vite.config.ts" {1,4-18,22}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { COLOR_MODE_STORAGE_KEY, getStorageScript } from "@workspaces/ui"
+
+function injectColorModeScript(): Plugin {
+  return {
+    name: "inject-color-mode-script",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "colorMode",
+        COLOR_MODE_STORAGE_KEY,
+      )({ defaultValue: "light" })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectColorModeScript()],
+})
+```
+
+If you change the `defaultColorMode` in your [config](/docs/theming/configuration/overview), set the `defaultValue` prop on `ColorModeScript`.
+
+```ts title="vite.config.ts" {5,14}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { COLOR_MODE_STORAGE_KEY, getStorageScript } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+
+function injectColorModeScript(): Plugin {
+  return {
+    name: "inject-color-mode-script",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "colorMode",
+        COLOR_MODE_STORAGE_KEY,
+      )({ defaultValue: config.defaultColorMode })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectColorModeScript()],
+})
+```
+
+### ThemeSchemeScript
+
+To use [theme switching](/docs/theming/switching-themes), you need to add `ThemeSchemeScript` to the `body` to ensure it works correctly.
+
+This is because theme switching is implemented using `localStorage` or `cookies`, and adding the script ensures proper synchronization when the page loads.
+
+```ts title="vite.config.ts" {1,4-18,22}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { getStorageScript, THEME_SCHEME_STORAGE_KEY } from "@workspaces/ui"
+
+function injectThemeSchemeScript(): Plugin {
+  return {
+    name: "inject-theme-scheme-scripts",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "themeScheme",
+        THEME_SCHEME_STORAGE_KEY,
+      )({ defaultValue: "base" })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectThemeSchemeScript()],
+})
+```
+
+If you change the `defaultThemeScheme` in your [config](/docs/theming/configuration/overview), set the `defaultValue` prop on `ThemeSchemeScript`.
+
+```ts title="vite.config.ts" {5,14}
+import type { Plugin } from "vite"
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { getStorageScript, THEME_SCHEME_STORAGE_KEY } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+
+function injectThemeSchemeScript(): Plugin {
+  return {
+    name: "inject-theme-scheme-scripts",
+    transformIndexHtml(html) {
+      const content = getStorageScript(
+        "themeScheme",
+        THEME_SCHEME_STORAGE_KEY,
+      )({ defaultValue: config.defaultThemeScheme })
+
+      return html.replace("<body>", `<body><script>${content}</script>`)
+    },
+  }
+}
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react(), injectThemeSchemeScript()],
+})
+```
+
+## Component Integration
+
+You can integrate TanStack Router components such as [Link](https://tanstack.com/router/latest/docs/framework/react/api/router/linkComponent) with Yamada UI components.
+
+### Link
+
+```tsx
+import type {
+  ButtonProps,
+  HTMLRefAttributes,
+  IconButtonProps,
+  LinkProps,
+  Merge,
+} from "@yamada-ui/react"
+import type { FC } from "react"
+import type { LinkProps as OriginalLinkProps } from "@tanstack/react-router"
+import { Button, IconButton, Link } from "@yamada-ui/react"
+import { Link as OriginalLink } from "@tanstack/react-router"
+
+export interface TanStackLinkProps extends Omit<
+  Merge<OriginalLinkProps, LinkProps>,
+  "as" | "ref"
+> {}
+
+export const TanStackLink: FC<TanStackLinkProps> = (props) => {
+  return <Link as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, ButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkButton: FC<TanStackLinkButtonProps> = (props) => {
+  return <Button as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkIconButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, IconButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkIconButton: FC<TanStackLinkIconButtonProps> = (
+  props,
+) => {
+  return <IconButton as={OriginalLink} {...props} />
+}
+```

--- a/www/contents/get-started/frameworks/tanstack-start.ja.mdx
+++ b/www/contents/get-started/frameworks/tanstack-start.ja.mdx
@@ -1,0 +1,343 @@
+---
+title: TanStack Start
+description: TanStack StartのプロジェクトにYamada UIをインストールして使用するためのガイド。
+---
+
+## インストール
+
+::::steps
+
+### アプリケーションを作成する
+
+TanStack Startのアプリケーションを作成します。
+
+:::code-group
+
+```bash [pnpm]
+pnpm create @tanstack/start my-app
+```
+
+```bash [npm]
+npx @tanstack/create-start my-app
+```
+
+```bash [yarn]
+yarn create @tanstack/start my-app
+```
+
+```bash [bun]
+bunx @tanstack/create-start my-app
+```
+
+:::
+
+### セットアップする
+
+コマンドを実行すると、プロジェクトに必要なファイルやフォルダが作成されます。
+
+:::code-group
+
+```bash [pnpm]
+pnpm dlx @yamada-ui/cli init
+```
+
+```bash [npm]
+npx @yamada-ui/cli init
+```
+
+```bash [yarn]
+yarn dlx @yamada-ui/cli init
+```
+
+```bash [bun]
+bunx @yamada-ui/cli init
+```
+
+:::
+
+### パッケージをインストールする
+
+アプリケーションに`@workspaces/ui`をインストールします。
+
+:::code-group
+
+```bash [pnpm]
+pnpm add "@workspaces/ui@workspace:*"
+```
+
+```bash [npm]
+npm install "@workspaces/ui@workspace:*"
+```
+
+```bash [yarn]
+yarn add "@workspaces/ui@workspace:*"
+```
+
+```bash [bun]
+bun add "@workspaces/ui@workspace:*"
+```
+
+:::
+
+### プロバイダーを追加する
+
+インストール後、アプリケーションのルートルートに`UIProvider`を追加します。
+ハイドレーションエラーを抑制するために、`html`と`body`に`suppressHydrationWarning`を`true`に設定します。
+
+```tsx title="src/routes/__root.tsx" {1,2,16,17,18}
+import type { ReactNode } from "react"
+import { UIProvider } from "@workspaces/ui"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <UIProvider>
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### コンポーネントを使用する
+
+`UIProvider`を追加したら、アプリケーション内でコンポーネントを使用します。
+
+```tsx title="src/routes/index.tsx" {2,7}
+import { createFileRoute } from "@tanstack/react-router"
+import { Button } from "@workspaces/ui"
+
+export const Route = createFileRoute("/")({
+  component: Index,
+})
+
+function Index() {
+  return <Button>Click me!</Button>
+}
+```
+
+これで、Yamada UIのセットアップは完了です！
+
+::::
+
+## スクリプト
+
+### ColorModeScript
+
+[カラーモード](/docs/theming/color-mode)を使用する場合は、正常に動作させるために`body`に`ColorModeScript`を追加する必要があります。
+
+理由は、カラーモードが`localStorage`や`cookies`を用いて実装されており、ページの読み込み時に同期を正しく機能させるためです。
+
+TanStack StartはSSRをサポートしているため、ストレージにはクッキーを使用することを推奨します。
+
+```tsx title="src/routes/__root.tsx" {2,22,23,24}
+import type { ReactNode } from "react"
+import { ColorModeScript, UIProvider } from "@workspaces/ui"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ColorModeScript type="cookie" />
+
+        <UIProvider storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+もし、[コンフィグ](/docs/theming/configuration/overview)の`defaultColorMode`を変更した場合は、`ColorModeScript`に`defaultValue`を設定します。
+
+```tsx title="src/routes/__root.tsx" {2,3,23}
+import type { ReactNode } from "react"
+import { ColorModeScript, UIProvider } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ColorModeScript type="cookie" defaultValue={config.defaultColorMode} />
+
+        <UIProvider config={config} storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### ThemeSchemeScript
+
+[テーマの切り替え](/docs/theming/switching-themes)を使用する場合は、正常に動作させるために`body`に`ThemeSchemeScript`を追加する必要があります。
+
+理由は、テーマの切り替えが`localStorage`や`cookies`を用いて実装されており、ページの読み込み時に同期を正しく機能させるためです。
+
+```tsx title="src/routes/__root.tsx" {2,22,23,24}
+import type { ReactNode } from "react"
+import { ThemeSchemeScript, UIProvider } from "@workspaces/ui"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ThemeSchemeScript type="cookie" />
+
+        <UIProvider storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+もし、[コンフィグ](/docs/theming/configuration/overview)の`defaultThemeScheme`を変更した場合は、`ThemeSchemeScript`に`defaultValue`を設定します。
+
+```tsx title="src/routes/__root.tsx" {2,3,23-26}
+import type { ReactNode } from "react"
+import { ThemeSchemeScript, UIProvider } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ThemeSchemeScript
+          type="cookie"
+          defaultValue={config.defaultThemeScheme}
+        />
+
+        <UIProvider config={config} storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+## コンポーネントの統合
+
+TanStack Routerの[Link](https://tanstack.com/router/latest/docs/framework/react/api/router/linkComponent)などのコンポーネントとYamada UIのコンポーネントを統合することができます。
+
+### Link
+
+```tsx
+import type {
+  ButtonProps,
+  HTMLRefAttributes,
+  IconButtonProps,
+  LinkProps,
+  Merge,
+} from "@yamada-ui/react"
+import type { FC } from "react"
+import type { LinkProps as OriginalLinkProps } from "@tanstack/react-router"
+import { Button, IconButton, Link } from "@yamada-ui/react"
+import { Link as OriginalLink } from "@tanstack/react-router"
+
+export interface TanStackLinkProps extends Omit<
+  Merge<OriginalLinkProps, LinkProps>,
+  "as" | "ref"
+> {}
+
+export const TanStackLink: FC<TanStackLinkProps> = (props) => {
+  return <Link as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, ButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkButton: FC<TanStackLinkButtonProps> = (props) => {
+  return <Button as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkIconButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, IconButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkIconButton: FC<TanStackLinkIconButtonProps> = (
+  props,
+) => {
+  return <IconButton as={OriginalLink} {...props} />
+}
+```

--- a/www/contents/get-started/frameworks/tanstack-start.mdx
+++ b/www/contents/get-started/frameworks/tanstack-start.mdx
@@ -1,0 +1,343 @@
+---
+title: TanStack Start
+description: A guide for installing and using Yamada UI with TanStack Start projects.
+---
+
+## Installation
+
+::::steps
+
+### Create application
+
+Create TanStack Start application.
+
+:::code-group
+
+```bash [pnpm]
+pnpm create @tanstack/start my-app
+```
+
+```bash [npm]
+npx @tanstack/create-start my-app
+```
+
+```bash [yarn]
+yarn create @tanstack/start my-app
+```
+
+```bash [bun]
+bunx @tanstack/create-start my-app
+```
+
+:::
+
+### Setup
+
+Running the command will create the necessary files and folders in your project.
+
+:::code-group
+
+```bash [pnpm]
+pnpm dlx @yamada-ui/cli init
+```
+
+```bash [npm]
+npx @yamada-ui/cli init
+```
+
+```bash [yarn]
+yarn dlx @yamada-ui/cli init
+```
+
+```bash [bun]
+bunx @yamada-ui/cli init
+```
+
+:::
+
+### Install the package
+
+Install `@workspaces/ui` to your application.
+
+:::code-group
+
+```bash [pnpm]
+pnpm add "@workspaces/ui@workspace:*"
+```
+
+```bash [npm]
+npm install "@workspaces/ui@workspace:*"
+```
+
+```bash [yarn]
+yarn add "@workspaces/ui@workspace:*"
+```
+
+```bash [bun]
+bun add "@workspaces/ui@workspace:*"
+```
+
+:::
+
+### Add provider
+
+After installing, add `UIProvider` to the root route of your application.
+To suppress hydration errors, add `suppressHydrationWarning` to the `html` and `body` tags.
+
+```tsx title="src/routes/__root.tsx" {1,2,16,17,18}
+import type { ReactNode } from "react"
+import { UIProvider } from "@workspaces/ui"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <UIProvider>
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### Use components
+
+After adding `UIProvider`, you can use the components in your application.
+
+```tsx title="src/routes/index.tsx" {2,7}
+import { createFileRoute } from "@tanstack/react-router"
+import { Button } from "@workspaces/ui"
+
+export const Route = createFileRoute("/")({
+  component: Index,
+})
+
+function Index() {
+  return <Button>Click me!</Button>
+}
+```
+
+That's it! You've successfully set up Yamada UI.
+
+::::
+
+## Scripts
+
+### ColorModeScript
+
+To use [Color Mode](/docs/theming/color-mode), you need to add `ColorModeScript` to the `body` to ensure it works correctly.
+
+This is because color mode is implemented using `localStorage` or `cookies`, and adding the script ensures proper synchronization when the page loads.
+
+Since TanStack Start supports SSR, it is recommended to use cookies for storage.
+
+```tsx title="src/routes/__root.tsx" {2,22,23,24}
+import type { ReactNode } from "react"
+import { ColorModeScript, UIProvider } from "@workspaces/ui"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ColorModeScript type="cookie" />
+
+        <UIProvider storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+If you change the `defaultColorMode` in your [config](/docs/theming/configuration/overview), set the `defaultValue` prop on `ColorModeScript`.
+
+```tsx title="src/routes/__root.tsx" {2,3,23}
+import type { ReactNode } from "react"
+import { ColorModeScript, UIProvider } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ColorModeScript type="cookie" defaultValue={config.defaultColorMode} />
+
+        <UIProvider config={config} storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### ThemeSchemeScript
+
+To use [theme switching](/docs/theming/switching-themes), you need to add `ThemeSchemeScript` to the `body` to ensure it works correctly.
+
+This is because theme switching is implemented using `localStorage` or `cookies`, and adding the script ensures proper synchronization when the page loads.
+
+```tsx title="src/routes/__root.tsx" {2,22,23,24}
+import type { ReactNode } from "react"
+import { ThemeSchemeScript, UIProvider } from "@workspaces/ui"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ThemeSchemeScript type="cookie" />
+
+        <UIProvider storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+If you change the `defaultThemeScheme` in your [config](/docs/theming/configuration/overview), set the `defaultValue` prop on `ThemeSchemeScript`.
+
+```tsx title="src/routes/__root.tsx" {2,3,23-26}
+import type { ReactNode } from "react"
+import { ThemeSchemeScript, UIProvider } from "@workspaces/ui"
+import { config } from "@workspace/theme"
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <HeadContent />
+      </head>
+      <body suppressHydrationWarning>
+        <ThemeSchemeScript
+          type="cookie"
+          defaultValue={config.defaultThemeScheme}
+        />
+
+        <UIProvider config={config} storage="cookie">
+          <Outlet />
+        </UIProvider>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+## Component Integration
+
+You can integrate TanStack Router components such as [Link](https://tanstack.com/router/latest/docs/framework/react/api/router/linkComponent) with Yamada UI components.
+
+### Link
+
+```tsx
+import type {
+  ButtonProps,
+  HTMLRefAttributes,
+  IconButtonProps,
+  LinkProps,
+  Merge,
+} from "@yamada-ui/react"
+import type { FC } from "react"
+import type { LinkProps as OriginalLinkProps } from "@tanstack/react-router"
+import { Button, IconButton, Link } from "@yamada-ui/react"
+import { Link as OriginalLink } from "@tanstack/react-router"
+
+export interface TanStackLinkProps extends Omit<
+  Merge<OriginalLinkProps, LinkProps>,
+  "as" | "ref"
+> {}
+
+export const TanStackLink: FC<TanStackLinkProps> = (props) => {
+  return <Link as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, ButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkButton: FC<TanStackLinkButtonProps> = (props) => {
+  return <Button as={OriginalLink} {...props} />
+}
+
+export interface TanStackLinkIconButtonProps
+  extends
+    Omit<Merge<OriginalLinkProps, IconButtonProps>, "as" | "ref">,
+    HTMLRefAttributes<"a"> {}
+
+export const TanStackLinkIconButton: FC<TanStackLinkIconButtonProps> = (
+  props,
+) => {
+  return <IconButton as={OriginalLink} {...props} />
+}
+```

--- a/www/data/doc-map.en.json
+++ b/www/data/doc-map.en.json
@@ -65,6 +65,16 @@
               "title": "React Router",
               "segment": "react-router",
               "pathname": "/docs/get-started/frameworks/react-router"
+            },
+            {
+              "title": "TanStack Start",
+              "segment": "tanstack-start",
+              "pathname": "/docs/get-started/frameworks/tanstack-start"
+            },
+            {
+              "title": "TanStack Router",
+              "segment": "tanstack-router",
+              "pathname": "/docs/get-started/frameworks/tanstack-router"
             }
           ]
         }

--- a/www/data/doc-map.ja.json
+++ b/www/data/doc-map.ja.json
@@ -65,6 +65,16 @@
               "title": "React Router",
               "segment": "react-router",
               "pathname": "/docs/get-started/frameworks/react-router"
+            },
+            {
+              "title": "TanStack Start",
+              "segment": "tanstack-start",
+              "pathname": "/docs/get-started/frameworks/tanstack-start"
+            },
+            {
+              "title": "TanStack Router",
+              "segment": "tanstack-router",
+              "pathname": "/docs/get-started/frameworks/tanstack-router"
             }
           ]
         }


### PR DESCRIPTION
Closes #5615
Closes #5616

## Description

Add documentation for integrating Yamada UI with TanStack Start and TanStack Router.

## Current behavior (updates)

No documentation exists for TanStack Start or TanStack Router integration.

## New behavior

- **TanStack Start** (`tanstack-start.mdx` / `tanstack-start.ja.mdx`): Full SSR framework guide with cookie-based storage, covering installation, UIProvider setup in `__root.tsx`, ColorModeScript, ThemeSchemeScript, and Link component integration.
- **TanStack Router** (`tanstack-router.mdx` / `tanstack-router.ja.mdx`): SPA (Vite-based) guide covering installation, UIProvider setup in `main.tsx`, Vite plugin-based script injection for ColorMode/ThemeScheme, and Link component integration.
- Updated `doc-map.en.json` and `doc-map.ja.json` to include both new pages in the navigation.

## Is this a breaking change (Yes/No):

No

## Additional Information

- TanStack Start docs follow the React Router pattern (SSR with cookie storage)
- TanStack Router docs follow the Vite pattern (SPA with Vite plugin script injection)
- Both English and Japanese versions provided