### PR TITLE
test(data-list): enhance test coverage for DataList component

### DIFF
--- a/packages/react/src/components/data-list/data-list.test.tsx
+++ b/packages/react/src/components/data-list/data-list.test.tsx
@@ -138,4 +138,258 @@ describe("<DataList />", () => {
     expect(screen.getByText("入れ替わりの魔女")).toBeInTheDocument()
     expect(screen.getByText("テレポーテーション")).toBeInTheDocument()
   })
+
+  test("DataList calculates columns from children with DataListItem", () => {
+    render(
+      <DataList.Root data-testid="root">
+        <DataList.Item>
+          <DataList.Term>白石うらら</DataList.Term>
+          <DataList.Term>清集院桃子</DataList.Term>
+          <DataList.Description>入れ替わりの魔女</DataList.Description>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Term>小田切寧々</DataList.Term>
+          <DataList.Description>虜の魔女</DataList.Description>
+        </DataList.Item>
+      </DataList.Root>,
+    )
+
+    expect(screen.getByTestId("root").style.getPropertyValue("--col")).toBe("3")
+  })
+
+  test("DataList passes termProps and descriptionProps through context", () => {
+    render(
+      <DataList.Root
+        items={[{ description: "入れ替わりの魔女", term: "白石うらら" }]}
+        descriptionProps={{ "data-testid": "context-desc" } as any}
+        termProps={{ "data-testid": "context-term" } as any}
+      />,
+    )
+
+    expect(screen.getByTestId("context-term")).toBeInTheDocument()
+    expect(screen.getByTestId("context-desc")).toBeInTheDocument()
+  })
+
+  test("DataListItem renders single term and description via props", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item description="入れ替わりの魔女" term="白石うらら" />
+      </DataList.Root>,
+    )
+
+    expect(screen.getByText("白石うらら").tagName).toBe("DT")
+    expect(screen.getByText("入れ替わりの魔女").tagName).toBe("DD")
+  })
+
+  test("DataListItem prefers children Term/Description over props", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item description="propDescription" term="propTerm">
+          <DataList.Term>childTerm</DataList.Term>
+          <DataList.Description>childDescription</DataList.Description>
+        </DataList.Item>
+      </DataList.Root>,
+    )
+
+    expect(screen.getByText("childTerm")).toBeInTheDocument()
+    expect(screen.getByText("childDescription")).toBeInTheDocument()
+    expect(screen.queryByText("propTerm")).not.toBeInTheDocument()
+    expect(screen.queryByText("propDescription")).not.toBeInTheDocument()
+  })
+
+  test("DataListItem renders extra children alongside Term and Description", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item>
+          <DataList.Term>白石うらら</DataList.Term>
+          <DataList.Description>入れ替わりの魔女</DataList.Description>
+          <span data-testid="extra">extra content</span>
+        </DataList.Item>
+      </DataList.Root>,
+    )
+
+    expect(screen.getByText("白石うらら")).toBeInTheDocument()
+    expect(screen.getByText("入れ替わりの魔女")).toBeInTheDocument()
+    expect(screen.getByTestId("extra")).toBeInTheDocument()
+  })
+
+  test("DataListItem merges item-level termProps and descriptionProps", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item
+          description="入れ替わりの魔女"
+          term="白石うらら"
+          descriptionProps={{ "data-testid": "item-desc" } as any}
+          termProps={{ "data-testid": "item-term" } as any}
+        />
+      </DataList.Root>,
+    )
+
+    expect(screen.getByTestId("item-term")).toHaveTextContent("白石うらら")
+    expect(screen.getByTestId("item-desc")).toHaveTextContent(
+      "入れ替わりの魔女",
+    )
+  })
+
+  test("DataListItem merges context and item-level termProps/descriptionProps", () => {
+    render(
+      <DataList.Root
+        descriptionProps={{ "data-custom": "root-desc" } as any}
+        termProps={{ "data-custom": "root-term" } as any}
+      >
+        <DataList.Item
+          description="入れ替わりの魔女"
+          term="白石うらら"
+          descriptionProps={{ "data-testid": "merged-desc" } as any}
+          termProps={{ "data-testid": "merged-term" } as any}
+        />
+      </DataList.Root>,
+    )
+
+    const term = screen.getByTestId("merged-term")
+    const desc = screen.getByTestId("merged-desc")
+
+    expect(term).toHaveTextContent("白石うらら")
+    expect(desc).toHaveTextContent("入れ替わりの魔女")
+  })
+
+  test("DataList renders items with array terms and descriptions for column calculation", () => {
+    const items: DataListItemProps[] = [
+      {
+        description: ["入れ替わりの魔女", "絶望的味覚音痴"],
+        term: ["白石うらら", "清集院桃子"],
+      },
+    ]
+
+    render(<DataList.Root data-testid="root" items={items} />)
+
+    expect(screen.getByTestId("root").style.getPropertyValue("--col")).toBe("4")
+  })
+
+  test("DataList renders empty items array", () => {
+    render(<DataList.Root data-testid="root" items={[]} />)
+
+    expect(screen.getByTestId("root")).toBeInTheDocument()
+    expect(screen.getByTestId("root").style.getPropertyValue("--col")).toBe("0")
+  })
+
+  test("DataListItem with array term applies termProps to each term", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item
+          description="入れ替わりの魔女"
+          term={["白石うらら", "山田竜"]}
+          termProps={{ "data-custom": "term-prop" } as any}
+        />
+      </DataList.Root>,
+    )
+
+    const terms = screen.getAllByText(/白石うらら|山田竜/)
+    expect(terms).toHaveLength(2)
+  })
+
+  test("DataListItem with array description applies descriptionProps to each description", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item
+          description={["入れ替わりの魔女", "テレポーテーション"]}
+          term="白石うらら"
+          descriptionProps={{ "data-custom": "desc-prop" } as any}
+        />
+      </DataList.Root>,
+    )
+
+    const descriptions =
+      screen.getAllByText(/入れ替わりの魔女|テレポーテーション/)
+    expect(descriptions).toHaveLength(2)
+  })
+
+  test("DataList children take precedence over items prop", () => {
+    render(
+      <DataList.Root data-testid="root">
+        <DataList.Item>
+          <DataList.Term>子要素の用語</DataList.Term>
+          <DataList.Description>子要素の説明</DataList.Description>
+        </DataList.Item>
+      </DataList.Root>,
+    )
+
+    expect(screen.getByText("子要素の用語")).toBeInTheDocument()
+    expect(screen.getByText("子要素の説明")).toBeInTheDocument()
+  })
+
+  test("DataList items with both term and description omitted", () => {
+    const items: DataListItemProps[] = [{}]
+
+    render(<DataList.Root data-testid="root" items={items} />)
+
+    expect(screen.getByTestId("root").style.getPropertyValue("--col")).toBe("0")
+  })
+
+  test("DataListItem renders with multiple custom Term children", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item>
+          <DataList.Term>用語1</DataList.Term>
+          <DataList.Term>用語2</DataList.Term>
+          <DataList.Description>説明</DataList.Description>
+        </DataList.Item>
+      </DataList.Root>,
+    )
+
+    expect(screen.getByText("用語1")).toBeInTheDocument()
+    expect(screen.getByText("用語2")).toBeInTheDocument()
+    expect(screen.getByText("説明")).toBeInTheDocument()
+  })
+
+  test("DataListItem renders with multiple custom Description children", () => {
+    render(
+      <DataList.Root>
+        <DataList.Item>
+          <DataList.Term>用語</DataList.Term>
+          <DataList.Description>説明1</DataList.Description>
+          <DataList.Description>説明2</DataList.Description>
+        </DataList.Item>
+      </DataList.Root>,
+    )
+
+    expect(screen.getByText("用語")).toBeInTheDocument()
+    expect(screen.getByText("説明1")).toBeInTheDocument()
+    expect(screen.getByText("説明2")).toBeInTheDocument()
+  })
+
+  test("DataList with context termProps applies to items generated from items prop", () => {
+    render(
+      <DataList.Root
+        items={[
+          { description: "入れ替わりの魔女", term: ["白石うらら", "山田竜"] },
+        ]}
+        termProps={{ "data-testid": "ctx-term" } as any}
+      />,
+    )
+
+    const terms = screen.getAllByTestId("ctx-term")
+    expect(terms).toHaveLength(2)
+    expect(terms[0]).toHaveTextContent("白石うらら")
+    expect(terms[1]).toHaveTextContent("山田竜")
+  })
+
+  test("DataList with context descriptionProps applies to items generated from items prop", () => {
+    render(
+      <DataList.Root
+        items={[
+          {
+            description: ["入れ替わりの魔女", "テレポーテーション"],
+            term: "白石うらら",
+          },
+        ]}
+        descriptionProps={{ "data-testid": "ctx-desc" } as any}
+      />,
+    )
+
+    const descriptions = screen.getAllByTestId("ctx-desc")
+    expect(descriptions).toHaveLength(2)
+    expect(descriptions[0]).toHaveTextContent("入れ替わりの魔女")
+    expect(descriptions[1]).toHaveTextContent("テレポーテーション")
+  })
 })


### PR DESCRIPTION
## 概要

`DataList` コンポーネントのテストカバレッジを向上させました。

## 変更内容

`data-list.test.tsx` に以下のテストケースを追加しました：

- 子要素からのカラム数計算
- `termProps` と `descriptionProps` のコンテキスト経由の受け渡し
- `DataListItem` の単一 `term`/`description` プロパティによるレンダリング
- 子要素の `Term`/`Description` がプロパティより優先されることの検証
- `Term` と `Description` 以外の追加子要素のレンダリング
- アイテムレベルの `termProps`/`descriptionProps` のマージ
- コンテキストとアイテムレベルの Props のマージ
- 配列形式の `term` と `description` のカラム計算
- 空の `items` 配列のレンダリング
- 複数の `DataListTerm`/`DataListDescription` 子要素のレンダリング
- コンテキスト Props が `items` プロパティ生成要素に適用されることの検証
- `term` と `description` の両方が省略されたケース