### PR TITLE
test(select): enhance test coverage for Select component(#5977)

### DIFF
--- a/.changeset/eleven-poets-know.md
+++ b/.changeset/eleven-poets-know.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Formatted code.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #5977

## Description

Enhanced test coverage for the Select component in @yamada-ui/react. This PR addresses the uncovered logical branches in use-select.tsx as requested in Issue #5977.

## Current behavior (updates)

The use-select.tsx hook had less than 95% coverage, with specific lines (L197, L281, L297) not being triggered by existing unit tests.

- L197: Logic to prevent adding values when max is reached in multiple mode.
- L281: Optional chaining branch when onClear in custom render is called without an event argument.
- L297: Branch when a custom render function returns a non-ReactElement value (e.g., a string).

## New behavior

Three new test cases have been added to select.test.tsx.

- Max limit test: Verifies that clicking a disabled option does not change the value when max is already reached via defaultValue.
- onClear test: Invokes onClear() without arguments inside a custom render, covering the ev?.preventDefault() optional chaining branch.
- Non-ReactElement render test: Covers the isValidElement false branch by using a custom render that returns strings for multiple selected items.

These additions bring the component's coverage closer to the 95% requirement.

## Is this a breaking change (Yes/No):

No

## Additional Information
Development was done in a Windows (WSL2) environment. L197 (return prev) is defensive code that is unreachable through the component's public API due to the disabled control in useSelectOption, so full coverage of that line was not achieved.