### PR TITLE
fix: update maintainer icon URI to use GitHub avatar

### DIFF
--- a/www/data/maintainers.json
+++ b/www/data/maintainers.json
@@ -276,7 +276,7 @@
     },
     "github": {
       "id": "sorafujitani",
-      "icon": "https://github.com/sorafujitani/imgs/blob/main/fs0414_dot_image.png",
+      "icon": "https://avatars.githubusercontent.com/u/76100848?v=4",
       "url": "https://github.com/sorafujitani"
     },
     "x": { "url": "https://x.com/sorafujitani" }


### PR DESCRIPTION
## Summary
- Fixed icon URI in maintainers.json to use GitHub's avatar URL instead of a custom repository image link

## Changes
- Updated `sorafujitani`'s icon URL from a custom GitHub repository image to the official GitHub avatar URL
- This ensures the icon is always accessible and properly displayed

## Test plan
- [ ] Verify the icon displays correctly on the website
- [ ] Confirm the avatar URL is accessible