### PR TITLE
fix: exclude generated *.gen.ts files from eslint in lefthook

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -80,6 +80,7 @@ pre-commit:
 
           - name: tanstack-start
             root: playgrounds/tanstack/start/
+            exclude: "**/*.gen.ts"
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
               pnpm eslint {staged_files} --max-warnings=0 --fix --cache


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #6009 

## Description
Exclude generated `*.gen.ts` files from the ESLint job in lefthook.

<!-- Add a brief description. -->

## Current behavior (updates)
These files are generated by Tanstack Router and Tanstack Start are already ignored by ESLint.
However, lefthook passes staged files directly to ESLint.
<!-- Please describe the current behavior that you are modifying. -->

## New behavior
Adding an `exclude` pattern in lefthook prevents generated files from being passed to ESLint.
<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
