### PR TITLE
Add `/showcase` route with a placeholder page

### DIFF
--- a/www/app/[locale]/(apps)/page.tsx
+++ b/www/app/[locale]/(apps)/page.tsx
@@ -8,7 +8,7 @@ export default async function Page({ params }: PageProps<"/[locale]">) {
   const t = await getTranslations({ locale, namespace: "home" })
 
   return (
-    <VStack gap="0">
+    <>
       <Hero
         description={t("description")}
         title={t("title")}
@@ -27,6 +27,6 @@ export default async function Page({ params }: PageProps<"/[locale]">) {
 
         <Examples />
       </VStack>
-    </VStack>
+    </>
   )
 }

--- a/www/app/[locale]/(apps)/showcase/layout.tsx
+++ b/www/app/[locale]/(apps)/showcase/layout.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithChildren } from "react"
+import { VStack } from "@yamada-ui/react"
+import { useTranslations } from "next-intl"
+import { Hero } from "@/components"
+import { generateSharedMetadata } from "@/utils/next"
+
+export const generateMetadata = generateSharedMetadata("showcase")
+
+interface LayoutProps extends PropsWithChildren {}
+
+export default function Layout({ children }: LayoutProps) {
+  const t = useTranslations("showcase")
+
+  return (
+    <>
+      <Hero
+        description={t("description")}
+        title={t("title")}
+        primaryButtonProps={{
+          href: "/docs/get-started",
+          children: t("primaryAction"),
+        }}
+        secondaryButtonProps={{
+          href: "/showcase/submit",
+          children: t("secondaryAction"),
+        }}
+      />
+
+      <VStack as="section">{children}</VStack>
+    </>
+  )
+}

--- a/www/app/[locale]/(apps)/showcase/page.tsx
+++ b/www/app/[locale]/(apps)/showcase/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/www/app/[locale]/(apps)/showcase/submit/page.tsx
+++ b/www/app/[locale]/(apps)/showcase/submit/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/www/app/[locale]/header.tsx
+++ b/www/app/[locale]/header.tsx
@@ -23,6 +23,7 @@ export function Header() {
       { href: "/docs/get-started", label: t("component.header.docs") },
       { href: "/icons", label: t("component.header.icons") },
       { href: "/themes", label: t("component.header.themes") },
+      { href: "/showcase", label: t("component.header.showcase") },
       {
         href: "https://yamada-colors.app",
         label: t("component.header.colors"),
@@ -46,9 +47,9 @@ export function Header() {
     >
       <NextLinkIconButton href="/" variant="ghost" icon={<LogoIcon />} />
 
-      <NavMenu display={{ base: "flex", md: "none" }} flex="1" items={items} />
+      <NavMenu display={{ base: "flex", lg: "none" }} flex="1" items={items} />
 
-      <Spacer display={{ base: "none", md: "block" }} />
+      <Spacer display={{ base: "none", lg: "block" }} />
 
       <ButtonGroup.Root size="sm" variant="ghost" alignItems="center" gap="sm">
         <Search />
@@ -87,7 +88,7 @@ export function Header() {
           <ColorModeButton />
 
           <Separator
-            display={{ base: "none", md: "block" }}
+            display={{ base: "none", lg: "block" }}
             h="4"
             orientation="vertical"
           />

--- a/www/app/[locale]/mobile-menu.tsx
+++ b/www/app/[locale]/mobile-menu.tsx
@@ -69,7 +69,7 @@ export function MobileMenu({ items }: MobileMenuProps) {
         <IconButton
           aria-label={t("component.header.menu")}
           color="fg.emphasized"
-          display={{ base: "none", md: "flex" }}
+          display={{ base: "none", lg: "flex" }}
           icon={<MenuIcon />}
         />
       </Drawer.OpenTrigger>

--- a/www/messages/en.json
+++ b/www/messages/en.json
@@ -77,6 +77,12 @@
       "pink": "Pink"
     }
   },
+  "showcase": {
+    "title": "Showcase",
+    "description": "Discover projects built with Yamada UI. Get inspired before starting your next project.",
+    "primaryAction": "Get Started",
+    "secondaryAction": "Submit Your Project"
+  },
   "changelog": {
     "title": "Changelog",
     "latest": "Explore the changelog for the latest version of Yamada UI. Learn about the features, bug fixes, and improvements.",
@@ -92,6 +98,7 @@
       "icons": "Icons",
       "playground": "Playground",
       "themes": "Themes",
+      "showcase": "Showcase",
       "colors": "Colors",
       "github": "GitHub repository",
       "colorMode": "Change to {colorMode}",

--- a/www/messages/ja.json
+++ b/www/messages/ja.json
@@ -77,6 +77,12 @@
       "pink": "ピンク"
     }
   },
+  "showcase": {
+    "title": "ショーケース",
+    "description": "Yamada UIで構築されたプロジェクトを発見し、次のプロジェクトのインスピレーションを得ましょう。",
+    "primaryAction": "はじめる",
+    "secondaryAction": "プロジェクトを提出する"
+  },
   "changelog": {
     "title": "変更履歴",
     "latest": "Yamada UIの最新バージョンの変更履歴をご覧ください。機能・バグ修正・改善点についてご確認ください。",
@@ -91,8 +97,9 @@
       "docs": "ドキュメント",
       "icons": "アイコン",
       "playground": "プレイグラウンド",
-      "colors": "カラー",
       "themes": "テーマ",
+      "showcase": "ショーケース",
+      "colors": "カラー",
       "github": "GitHubリポジトリ",
       "colorMode": "{colorMode}に変更する",
       "lang": "言語を変更する",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #6020 

## Description

- Add `/showcase` route with a placeholder page (`www/app/[locale]/(apps)/showcase/page.tsx`)
- Add i18n messages for the showcase page in both `en.json` and `ja.json`
- The page displays a "currently being planned" notice with a link to #5990

## Current behavior (updates)

No `/showcase` route exists. Visiting the [docs](http://localhost:3000/ja/docs/get-started).

## New behavior

- `/showcase` route is accessible with a Hero section and a "currently being planned" notice linking to #5990.
- i18n messages (`title`, `description`) added for both `en.json` and `ja.json`.
- No navigation link is added yet.

## Is this a breaking change (Yes/No):

No

## Additional Information

This is part of #5990. Subsequent PRs will add showcase card/list UI, data, and header navigation.