### PR TITLE
Fix Path Mismatch in Lefthook

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -44,7 +44,7 @@ pre-commit:
             stage_fixed: true
 
           - name: www
-            root: packages/www/
+            root: www/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
               pnpm eslint {staged_files} --max-warnings=0 --fix --cache


### PR DESCRIPTION

Closes #6031 

## Description

- Fix incorrect `root` path for `www` job in `lefthook.yaml`: `packages/www/` → `www/`

## Current behavior (updates)

- Bypass lint whether run commit in `www`

## New behavior

- Run lint when run commit in `www`

## Is this a breaking change (Yes/No):

no

## Additional Information
