### PR TITLE
docs(form): add accessibility section

### DIFF
--- a/www/contents/components/(components)/form.ja.mdx
+++ b/www/contents/components/(components)/form.ja.mdx
@@ -650,6 +650,19 @@ return (
 )
 ```
 
+## アクセシビリティ
+
+### ARIAロールと属性
+
+| コンポーネント      | ロールと属性       | 使い方                                                          |
+| ------------------- | ------------------ | --------------------------------------------------------------- |
+| `Form.Root`         | `id`               | `Form.SubmitButton`と関連付けるために使用する`id`。             |
+|                     | `aria-labelledby`  | 関連した`Form.Title`と`Form.Description`の`id`を設定します。    |
+| `Form.Title`        | `id`               | `Form.Root`や`Form.Description`と関連付けるために使用する`id`。 |
+| `Form.Description`  | `id`               | `Form.Root`と関連付けるために使用する`id`。                     |
+|                     | `aria-describedby` | 関連した`Form.Title`の`id`を設定します。                        |
+| `Form.SubmitButton` | `form`             | 関連した`Form.Root`の`id`を設定します。                         |
+
 ## Props
 
 <PropsTable name="form" />

--- a/www/contents/components/(components)/form.mdx
+++ b/www/contents/components/(components)/form.mdx
@@ -650,6 +650,19 @@ return (
 )
 ```
 
+## Accessibility
+
+### ARIA Roles and Attributes
+
+| Component           | Roles and Attributes | Usage                                                                |
+| ------------------- | -------------------- | -------------------------------------------------------------------- |
+| `Form.Root`         | `id`                 | Used to associate with `Form.SubmitButton`.                          |
+|                     | `aria-labelledby`    | Sets the `id` of the associated `Form.Title` and `Form.Description`. |
+| `Form.Title`        | `id`                 | Used to associate with `Form.Root` and `Form.Description`.           |
+| `Form.Description`  | `id`                 | Used to associate with `Form.Root`.                                  |
+|                     | `aria-describedby`   | Sets the `id` of the associated `Form.Title`.                        |
+| `Form.SubmitButton` | `form`               | Sets the `id` of the associated `Form.Root`.                         |
+
 ## Props
 
 <PropsTable name="form" />


### PR DESCRIPTION
Closes #5762 (partial) - Add Accessibility section to Form component docs (EN and JA) documenting aria-labelledby, aria-describedby, id, and form attributes.