### PR TITLE
feat(cli): add --dry-run/-n option for CLI commands

### DIFF
--- a/packages/cli/src/commands/add/index.test.ts
+++ b/packages/cli/src/commands/add/index.test.ts
@@ -608,6 +608,37 @@ describe("add", () => {
     )
   })
 
+  test("should not create component files when --dry-run", async () => {
+    setupProject(tempDir)
+
+    await add.parseAsync(
+      [
+        "button",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--dry-run",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+      ],
+      { from: "user" },
+    )
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    expect(existsSync(buttonDir)).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+  })
+
   test("should show error when all components add without overwrite and dir exists with --yes", async () => {
     setupProject(tempDir)
 

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -34,6 +34,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   install: boolean
   overwrite: boolean
   sequential: boolean
@@ -51,6 +52,7 @@ export const add = new Command("add")
   .option("-o, --overwrite", "overwrite existing files.", false)
   .option("-s, --sequential", "run tasks sequentially.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
+  .option("-n, --dry-run", "preview changes without applying them.", false)
   .option("-i, --install", "install dependencies.")
   .option("--no-install", "do not install dependencies.")
   .option("-f, --format", "format the output files.")
@@ -63,6 +65,7 @@ export const add = new Command("add")
     {
       config: configPath,
       cwd,
+      dryRun,
       format,
       install,
       lint,
@@ -233,9 +236,11 @@ export const add = new Command("add")
 
             return {
               task: async (_, task) => {
-                await generateSources(dirPath, registry, config, targetNames)
+                await generateSources(dirPath, registry, config, targetNames, {
+                  dryRun,
+                })
 
-                task.title = `Generated ${c.cyan(name)}`
+                task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan(name)}`
               },
               title: `Generating ${c.cyan(name)}`,
             }
@@ -311,7 +316,10 @@ export const add = new Command("add")
                               targetNames,
                             )
 
-                            await writeFileSafe(targetPath, content, config)
+                            await writeFileSafe(targetPath, content, {
+                              ...config,
+                              dryRun,
+                            })
                           }),
                         )
                       } else if (dirent.name !== REGISTRY_FILE_NAME) {
@@ -329,12 +337,15 @@ export const add = new Command("add")
                           targetNames,
                         )
 
-                        await writeFileSafe(targetPath, content, config)
+                        await writeFileSafe(targetPath, content, {
+                          ...config,
+                          dryRun,
+                        })
                       }
                     }),
                   )
 
-                  task.title = `Updated ${c.cyan(name)}`
+                  task.title = `${dryRun ? "Would update" : "Updated"} ${c.cyan(name)}`
                 },
                 title: `Updating ${c.cyan(name)}`,
               })
@@ -352,9 +363,12 @@ export const add = new Command("add")
 
             content = transformIndex(targetNames, content, config)
 
-            await writeFileSafe(config.paths.ui.index, content, config)
+            await writeFileSafe(config.paths.ui.index, content, {
+              ...config,
+              dryRun,
+            })
 
-            task.title = `Updated ${c.cyan(indexFileName)}`
+            task.title = `${dryRun ? "Would update" : "Updated"} ${c.cyan(indexFileName)}`
           },
           title: `Updating ${c.cyan(indexFileName)}`,
         })
@@ -368,9 +382,12 @@ export const add = new Command("add")
 
             if (config.jsx) content = transformTsToJs(content)
 
-            await writeFileSafe(config.paths.ui.index, content, config)
+            await writeFileSafe(config.paths.ui.index, content, {
+              ...config,
+              dryRun,
+            })
 
-            task.title = `Generated ${c.cyan(indexFileName)}`
+            task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan(indexFileName)}`
           },
           title: `Generating ${c.cyan(indexFileName)}`,
         })
@@ -424,10 +441,12 @@ export const add = new Command("add")
             task: async (_, task) => {
               await installDependencies(
                 notInstalledDependencies.map(getPackageNameWithVersion),
-                { cwd: targetPath },
+                { cwd: targetPath, dryRun },
               )
 
-              task.title = "Installed dependencies"
+              task.title = dryRun
+                ? "Would install dependencies"
+                : "Installed dependencies"
             },
             title: "Installing dependencies",
           })

--- a/packages/cli/src/commands/diff/index.test.ts
+++ b/packages/cli/src/commands/diff/index.test.ts
@@ -517,4 +517,49 @@ describe("diff", () => {
       expect.stringContaining("---------------------------------"),
     )
   })
+
+  test("should call updateFiles with dryRun when --dry-run", async () => {
+    setupProjectWithComponent(tempDir)
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    writeFileSync(
+      path.join(buttonDir, "registry.json"),
+      JSON.stringify({
+        dependencies: {
+          components: [],
+          externals: [],
+          hooks: [],
+          providers: [],
+        },
+        section: "components",
+        sources: [
+          {
+            name: "index.ts",
+            content: `export const Button = () => { return "old" }\n`,
+          },
+        ],
+      }),
+    )
+
+    await diff.parseAsync(
+      ["--cwd", tempDir, "--yes", "--dry-run", "--update", "--no-install"],
+      { from: "user" },
+    )
+
+    const { updateFiles } = await import("../update/update-files")
+    expect(vi.mocked(updateFiles)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ dryRun: true }),
+    )
+  })
 })

--- a/packages/cli/src/commands/diff/index.ts
+++ b/packages/cli/src/commands/diff/index.ts
@@ -32,6 +32,7 @@ interface Options {
   config: string
   cwd: string
   detail: boolean
+  dryRun: boolean
   sequential: boolean
   yes: boolean
   install?: boolean
@@ -47,6 +48,7 @@ export const diff = new Command("diff")
   .option("-s, --sequential", "run tasks sequentially.", false)
   .option("-d, --detail", "show detailed changes.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
+  .option("-n, --dry-run", "preview changes without applying them.", false)
   .option("-u, --update", "update files when there are file diff.")
   .option("--no-update", "do not update files when there are file diff.")
   .option("-i, --install", "install dependencies when updating files.")
@@ -58,6 +60,7 @@ export const diff = new Command("diff")
       config: configPath,
       cwd,
       detail,
+      dryRun,
       install,
       sequential,
       tag,
@@ -206,7 +209,7 @@ export const diff = new Command("diff")
             dependencyMap,
             registryMap,
             config,
-            { concurrent: !sequential, install, yes },
+            { concurrent: !sequential, dryRun, install, yes },
           )
 
           if (Object.keys(conflictMap).length) {

--- a/packages/cli/src/commands/init/index.test.ts
+++ b/packages/cli/src/commands/init/index.test.ts
@@ -350,4 +350,18 @@ describe("init", () => {
     // New files should exist
     expect(existsSync(path.join(outdirPath, "src", "index.ts"))).toBeTruthy()
   })
+
+  test("should not create any files when --dry-run", async () => {
+    await init.parseAsync(
+      ["--cwd", tempDir, "--yes", "--dry-run", "--no-install", "--monorepo"],
+      { from: "user" },
+    )
+
+    expect(existsSync(path.join(tempDir, "ui.json"))).toBeFalsy()
+    expect(existsSync(path.join(tempDir, "workspaces", "ui"))).toBeFalsy()
+    expect(existsSync(path.join(tempDir, "pnpm-workspace.yaml"))).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+  })
 })

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -44,6 +44,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   jsx: boolean
   overwrite: boolean
   yes: boolean
@@ -65,6 +66,7 @@ export const init = new Command("init")
   .option("-t, --tag <name>", "tag for the registries (e.g. dev, next).")
   .option("-j, --jsx", "use jsx instead of tsx.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
+  .option("-n, --dry-run", "preview changes without applying them.", false)
   .option("-m, --monorepo", "enable monorepo mode.")
   .option("--no-monorepo", "disable monorepo mode.")
   .option("-p, --package-name <name>", "package name.")
@@ -83,6 +85,7 @@ export const init = new Command("init")
     src,
     config: configPath,
     cwd,
+    dryRun,
     format,
     install,
     jsx,
@@ -226,10 +229,12 @@ export const init = new Command("init")
       await writeFileSafe(
         configPath,
         JSON.stringify(config),
-        merge(config, { format: { parser: "json" } }),
+        merge(config, { dryRun, format: { parser: "json" } }),
       )
 
-      spinner.succeed(`Generated ${c.cyan(configFileName)}`)
+      spinner.succeed(
+        `${dryRun ? "Would generate" : "Generated"} ${c.cyan(configFileName)}`,
+      )
 
       const outdirPath = path.resolve(cwd, outdir)
 
@@ -312,10 +317,10 @@ export const init = new Command("init")
                 await writeFileSafe(
                   targetPath,
                   content,
-                  merge(config, { format: { parser: "json" } }),
+                  merge(config, { dryRun, format: { parser: "json" } }),
                 )
 
-                task.title = `Generated ${c.cyan("package.json")}`
+                task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan("package.json")}`
               },
               title: `Generating ${c.cyan("package.json")}`,
             },
@@ -332,16 +337,16 @@ export const init = new Command("init")
                   writeFileSafe(
                     path.join(targetPath, indexFileName),
                     content,
-                    config,
+                    merge(config, { dryRun }),
                   ),
                   writeFileSafe(
                     path.join(targetPath, REGISTRY_FILE_NAME),
                     JSON.stringify(registry),
-                    merge(config, { format: { parser: "json" } }),
+                    merge(config, { dryRun, format: { parser: "json" } }),
                   ),
                 ])
 
-                task.title = `Generated ${c.cyan(indexFileName)}`
+                task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan(indexFileName)}`
               },
               title: `Generating ${c.cyan(indexFileName)}`,
             },
@@ -350,12 +355,12 @@ export const init = new Command("init")
                 if (outdir.includes("/")) {
                   const path = `${outdir.replace(/^\.\//, "").split("/")[0]}/**`
 
-                  await addWorkspace(cwd, path, config)
+                  await addWorkspace(cwd, path, config, { dryRun })
                 } else {
-                  await addWorkspace(cwd, outdir, config)
+                  await addWorkspace(cwd, outdir, config, { dryRun })
                 }
 
-                task.title = "Added workspace"
+                task.title = dryRun ? "Would add workspace" : "Added workspace"
               },
               title: "Adding workspace",
             },
@@ -380,10 +385,10 @@ export const init = new Command("init")
               await writeFileSafe(
                 targetPath,
                 content,
-                merge(config, { format: { parser: "json" } }),
+                merge(config, { dryRun, format: { parser: "json" } }),
               )
 
-              task.title = `Generated ${c.cyan("tsconfig.json")}`
+              task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan("tsconfig.json")}`
             },
             title: `Generating ${c.cyan("tsconfig.json")}`,
           })
@@ -451,16 +456,16 @@ export const init = new Command("init")
                   writeFileSafe(
                     path.resolve(outdirPath, indexFileName),
                     content,
-                    config,
+                    merge(config, { dryRun }),
                   ),
                   writeFileSafe(
                     path.resolve(outdirPath, REGISTRY_FILE_NAME),
                     JSON.stringify(registry),
-                    merge(config, { format: { parser: "json" } }),
+                    merge(config, { dryRun, format: { parser: "json" } }),
                   ),
                 ])
 
-                task.title = `Generated ${c.cyan(indexFileName)}`
+                task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan(indexFileName)}`
               },
               title: `Generating ${c.cyan(indexFileName)}`,
             },
@@ -517,11 +522,14 @@ export const init = new Command("init")
       if (install && (dependencies || devDependencies)) {
         spinner.start("Installing dependencies")
 
-        if (dependencies) await installDependencies(dependencies, { cwd })
+        if (dependencies)
+          await installDependencies(dependencies, { cwd, dryRun })
         if (devDependencies)
-          await installDependencies(devDependencies, { cwd, dev: true })
+          await installDependencies(devDependencies, { cwd, dev: true, dryRun })
 
-        spinner.succeed("Installed dependencies")
+        spinner.succeed(
+          dryRun ? "Would install dependencies" : "Installed dependencies",
+        )
       }
 
       if (monorepo) {

--- a/packages/cli/src/commands/theme/index.test.ts
+++ b/packages/cli/src/commands/theme/index.test.ts
@@ -352,4 +352,27 @@ describe("theme", () => {
       expect.stringContaining("unknown error"),
     )
   })
+
+  test("should not create theme files when --dry-run", async () => {
+    setupProject(tempDir)
+
+    await theme.parseAsync(
+      [
+        "./workspaces/theme",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--dry-run",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+      ],
+      { from: "user" },
+    )
+
+    expect(existsSync(path.join(tempDir, "workspaces", "theme"))).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+  })
 })

--- a/packages/cli/src/commands/theme/index.ts
+++ b/packages/cli/src/commands/theme/index.ts
@@ -43,6 +43,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   overwrite: boolean
   yes: boolean
   format?: boolean
@@ -62,6 +63,7 @@ export const theme = new Command("theme")
   .option("-o, --overwrite", "overwrite existing directory.", false)
   .option("-j, --js", "use js instead of ts.")
   .option("-y, --yes", "skip all confirmation prompts.", false)
+  .option("-n, --dry-run", "preview changes without applying them.", false)
   .option("-p, --package-name <name>", "package name (for monorepo).")
   .option("-s, --src", "use src/ directory.")
   .option("--no-src", "do not use src/ directory.")
@@ -81,6 +83,7 @@ export const theme = new Command("theme")
       src,
       config: configPath,
       cwd,
+      dryRun,
       format,
       install,
       js,
@@ -207,20 +210,19 @@ export const theme = new Command("theme")
                       ? transformTsxToJsx(content)
                       : transformTsToJs(content)
 
-                  await writeFileSafe(
-                    path.resolve(targetPath, name),
-                    content,
-                    config,
-                  )
+                  await writeFileSafe(path.resolve(targetPath, name), content, {
+                    ...config,
+                    dryRun,
+                  })
                 }),
                 writeFileSafe(
                   path.resolve(targetPath, REGISTRY_FILE_NAME),
                   JSON.stringify(registry),
-                  merge(config, { format: { parser: "json" } }),
+                  merge(config, { dryRun, format: { parser: "json" } }),
                 ),
               ])
 
-              task.title = `Generated theme`
+              task.title = dryRun ? "Would generate theme" : "Generated theme"
             },
             title: `Generating theme`,
           },
@@ -236,10 +238,10 @@ export const theme = new Command("theme")
               await writeFileSafe(
                 targetPath,
                 JSON.stringify(userConfig),
-                merge(config, { format: { parser: "json" } }),
+                merge(config, { dryRun, format: { parser: "json" } }),
               )
 
-              task.title = `Updated config`
+              task.title = dryRun ? "Would update config" : "Updated config"
             },
             title: `Updating config`,
           },
@@ -281,10 +283,10 @@ export const theme = new Command("theme")
             await writeFileSafe(
               targetPath,
               content,
-              merge(config, { format: { parser: "json" } }),
+              merge(config, { dryRun, format: { parser: "json" } }),
             )
 
-            task.title = `Generated ${c.cyan("package.json")}`
+            task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan("package.json")}`
           },
           title: `Generating ${c.cyan("package.json")}`,
         })
@@ -307,10 +309,10 @@ export const theme = new Command("theme")
             await writeFileSafe(
               targetPath,
               content,
-              merge(config, { format: { parser: "json" } }),
+              merge(config, { dryRun, format: { parser: "json" } }),
             )
 
-            task.title = `Generated ${c.cyan("tsconfig.json")}`
+            task.title = `${dryRun ? "Would generate" : "Generated"} ${c.cyan("tsconfig.json")}`
           },
           title: `Generating ${c.cyan("tsconfig.json")}`,
         })
@@ -333,9 +335,11 @@ export const theme = new Command("theme")
         if (install) {
           spinner.start("Installing dependencies")
 
-          await installDependencies([], { cwd })
+          await installDependencies([], { cwd, dryRun })
 
-          spinner.succeed("Installed dependencies")
+          spinner.succeed(
+            dryRun ? "Would install dependencies" : "Installed dependencies",
+          )
         }
 
         const packageManager = getPackageManager()

--- a/packages/cli/src/commands/tokens/index.test.ts
+++ b/packages/cli/src/commands/tokens/index.test.ts
@@ -262,6 +262,32 @@ describe("tokens", () => {
     expect(existsSync(outPath)).toBeTruthy()
   })
 
+  test("should not create typings file when --dry-run", async () => {
+    mockGetModule.mockResolvedValue(createBasicTheme())
+
+    const themeFile = path.join(tempDir, "theme.ts")
+    writeFileSync(themeFile, "export default {}")
+
+    await tokens.parseAsync(
+      [
+        themeFile,
+        "--cwd",
+        tempDir,
+        "--internal",
+        "--dry-run",
+        "--no-format",
+        "--no-lint",
+      ],
+      { from: "user" },
+    )
+
+    const outPath = path.join(tempDir, "index.types.ts")
+    expect(existsSync(outPath)).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+  })
+
   test("should handle non-Error throw", async () => {
     mockGetModule.mockRejectedValue("string error")
 

--- a/packages/cli/src/commands/tokens/index.ts
+++ b/packages/cli/src/commands/tokens/index.ts
@@ -273,6 +273,7 @@ async function getTheme(path: string, cwd: string) {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   internal: boolean
   format?: boolean
   lint?: boolean
@@ -289,10 +290,19 @@ export const tokens = new Command("tokens")
   .option("--no-format", "do not format the output file.")
   .option("-l, --lint", "lint the output file.")
   .option("--no-lint", "do not lint the output file.")
+  .option("-n, --dry-run", "preview changes without applying them.", false)
   .option("--internal", "generate internal tokens.", false)
   .action(async function (
     inputPath: string | undefined,
-    { config: configPath, cwd, format, internal, lint, out: outPath }: Options,
+    {
+      config: configPath,
+      cwd,
+      dryRun,
+      format,
+      internal,
+      lint,
+      out: outPath,
+    }: Options,
   ) {
     const spinner = ora()
 
@@ -349,15 +359,18 @@ export const tokens = new Command("tokens")
         outPath,
         content,
         config
-          ? merge(config, { lint: { filePath: inputPath } })
+          ? merge(config, { dryRun, lint: { filePath: inputPath } })
           : {
               cwd,
+              dryRun,
               format: { enabled: format },
               lint: { enabled: lint, filePath: inputPath },
             },
       )
 
-      spinner.succeed(`Generated theme typings`)
+      spinner.succeed(
+        dryRun ? "Would generate theme typings" : "Generated theme typings",
+      )
 
       end()
     } catch (e) {

--- a/packages/cli/src/commands/update/index.test.ts
+++ b/packages/cli/src/commands/update/index.test.ts
@@ -345,4 +345,59 @@ describe("update", () => {
       expect.stringContaining("---------------------------------"),
     )
   })
+
+  test("should call updateFiles with dryRun when --dry-run", async () => {
+    setupProjectWithComponent(tempDir)
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    writeFileSync(
+      path.join(buttonDir, "registry.json"),
+      JSON.stringify({
+        dependencies: {
+          components: [],
+          externals: [],
+          hooks: [],
+          providers: [],
+        },
+        section: "components",
+        sources: [
+          {
+            name: "index.ts",
+            content: `export const Button = () => { return "old" }\n`,
+          },
+        ],
+      }),
+    )
+
+    const { updateFiles } = await import("./update-files")
+
+    await update.parseAsync(
+      [
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--dry-run",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--force",
+      ],
+      { from: "user" },
+    )
+
+    expect(vi.mocked(updateFiles)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ dryRun: true }),
+    )
+  })
 })

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -22,6 +22,7 @@ import { validateDiff3 } from "./validate-diff-3"
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   force: boolean
   sequential: boolean
   yes: boolean
@@ -39,6 +40,7 @@ export const update = new Command("update")
   .option("-s, --sequential", "run tasks sequentially.", false)
   .option("-F, --force", "force update, overwriting local changes.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
+  .option("-n, --dry-run", "preview changes without applying them.", false)
   .option("-i, --install", "install dependencies.")
   .option("--no-install", "do not install dependencies.")
   .option("-f, --format", "format the output files.")
@@ -51,6 +53,7 @@ export const update = new Command("update")
     {
       config: configPath,
       cwd,
+      dryRun,
       force,
       format,
       install,
@@ -164,7 +167,7 @@ export const update = new Command("update")
           dependencyMap,
           registryMap,
           config,
-          { concurrent: !sequential, force, install, yes },
+          { concurrent: !sequential, dryRun, force, install, yes },
         )
 
         if (Object.keys(conflictMap).length) {

--- a/packages/cli/src/commands/update/update-files.test.ts
+++ b/packages/cli/src/commands/update/update-files.test.ts
@@ -510,4 +510,64 @@ describe("updateFiles", () => {
     expect(installDependencies).not.toHaveBeenCalled()
     expect(result).toStrictEqual({})
   })
+
+  test("should skip file writes and log when dryRun is true", async () => {
+    const config = createConfig(tempDir)
+    const changeMap: ChangeMap = {
+      button: {
+        "index.ts": {
+          diff: [{ added: true, count: 1, removed: false, value: "new" }],
+          local: "old",
+          remote: "new",
+        },
+      },
+    }
+    const dependencyMap: DependencyMap = { add: [], remove: [], update: [] }
+    const registryMap: RegistryMap = {
+      local: {},
+      remote: {
+        button: {
+          section: "components",
+          sources: [{ name: "index.ts", content: "new" }],
+        },
+      },
+    }
+
+    await updateFiles(changeMap, dependencyMap, registryMap, config, {
+      dryRun: true,
+      yes: true,
+    })
+
+    expect(mockWriteFileSafe).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would update:"),
+    )
+  })
+
+  test("should log install and uninstall when dryRun is true", async () => {
+    const { installDependencies, uninstallDependencies } =
+      await import("../../utils")
+    const config = createConfig(tempDir)
+    const changeMap: ChangeMap = {}
+    const dependencyMap: DependencyMap = {
+      add: ["new-pkg"],
+      remove: ["old-pkg"],
+      update: [],
+    }
+    const registryMap: RegistryMap = { local: {}, remote: {} }
+
+    await updateFiles(changeMap, dependencyMap, registryMap, config, {
+      dryRun: true,
+      yes: true,
+    })
+
+    expect(installDependencies).not.toHaveBeenCalled()
+    expect(uninstallDependencies).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would install: new-pkg"),
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would uninstall: old-pkg"),
+    )
+  })
 })

--- a/packages/cli/src/commands/update/update-files.ts
+++ b/packages/cli/src/commands/update/update-files.ts
@@ -64,6 +64,7 @@ export interface ConflictMap {
 
 export interface UpdateFilesOptions {
   concurrent?: boolean
+  dryRun?: boolean
   force?: boolean
   install?: boolean
   yes?: boolean
@@ -76,6 +77,7 @@ export async function updateFiles(
   config: Config,
   {
     concurrent = true,
+    dryRun = false,
     force = false,
     install,
     yes = false,
@@ -92,11 +94,22 @@ export async function updateFiles(
       ([componentName, changes]) =>
         ({
           task: async (_, task) => {
+            const registry = remote[componentName]!
+            const dirPath = getDirPath(registry.section, componentName, config)
+
+            if (dryRun) {
+              Object.keys(changes).forEach((name) => {
+                console.log(
+                  c.cyan(`(dry run) Would update: ${path.join(dirPath, name)}`),
+                )
+              })
+              task.title = `Would change ${c.cyan(componentName)}`
+              return
+            }
+
             const tempDirPath = await mkdtemp(
               path.join(tmpdir(), `yamada-ui-${componentName}-`),
             )
-            const registry = remote[componentName]!
-            const dirPath = getDirPath(registry.section, componentName, config)
 
             try {
               if (componentName === "index") {
@@ -223,6 +236,22 @@ export async function updateFiles(
   )
 
   await tasks.run()
+
+  if (dryRun) {
+    if (add.length || update.length)
+      console.log(
+        c.cyan(
+          `(dry run) Would install: ${[...add, ...update.map(getPackageNameWithVersion)].join(", ")}`,
+        ),
+      )
+    if (remove.length)
+      console.log(
+        c.cyan(
+          `(dry run) Would uninstall: ${remove.map(getPackageName).join(", ")}`,
+        ),
+      )
+    return conflictMap
+  }
 
   if (!install && (add.length || remove.length || update.length)) {
     const answer = await prompts({

--- a/packages/cli/src/utils/fs.test.ts
+++ b/packages/cli/src/utils/fs.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs"
 import { tmpdir } from "os"
 import path from "path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
@@ -81,6 +88,15 @@ describe("writeFileSafe", () => {
       lint: { enabled: false },
     })
     expect(readFileSync(filePath, "utf-8")).toBe("hello")
+  })
+
+  test("should skip writing and log when dryRun is true", async () => {
+    const filePath = path.join(tempDir, "a", "b", "file.txt")
+    await writeFileSafe(filePath, "hello", { dryRun: true })
+    expect(existsSync(filePath)).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
   })
 })
 

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -36,6 +36,7 @@ export async function isWriteable(directory: string) {
 
 export interface WriteFileOptions extends ObjectEncodingOptions {
   cwd?: string
+  dryRun?: boolean
   format?: FormatOptions
   lint?: LintFilesOptions
 }
@@ -55,6 +56,11 @@ export async function writeFileSafe(
   content: string,
   options?: WriteFileOptions,
 ) {
+  if (options?.dryRun) {
+    console.log(c.cyan(`(dry run) Would write: ${targetPath}`))
+    return
+  }
+
   const dirPath = path.dirname(targetPath)
 
   if (!existsSync(dirPath)) await mkdir(dirPath, { recursive: true })

--- a/packages/cli/src/utils/package.test.ts
+++ b/packages/cli/src/utils/package.test.ts
@@ -288,6 +288,24 @@ describe("installDependencies", () => {
       { cwd: "/tmp" },
     )
   })
+
+  test("should skip and log package names when dryRun is true", async () => {
+    const { execFileAsync } = vi.mocked(await import("./fs"))
+    await installDependencies(["react", "lodash"], { dryRun: true })
+    expect(execFileAsync).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would install: react, lodash"),
+    )
+  })
+
+  test("should skip and log without package names when dryRun is true", async () => {
+    const { execFileAsync } = vi.mocked(await import("./fs"))
+    await installDependencies([], { dryRun: true })
+    expect(execFileAsync).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would install dependencies"),
+    )
+  })
 })
 
 describe("uninstallDependencies", () => {
@@ -306,6 +324,20 @@ describe("uninstallDependencies", () => {
     execFileAsync.mockClear()
     await uninstallDependencies([], { cwd: "/tmp" })
     expect(execFileAsync).not.toHaveBeenCalled()
+  })
+
+  test("should skip and log when dryRun is true", async () => {
+    const { execFileAsync } = vi.mocked(await import("./fs"))
+    await uninstallDependencies(["react"], { dryRun: true })
+    expect(execFileAsync).not.toHaveBeenCalled()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would uninstall: react"),
+    )
+  })
+
+  test("should not log when empty and dryRun is true", async () => {
+    await uninstallDependencies([], { dryRun: true })
+    expect(console.log).not.toHaveBeenCalled()
   })
 })
 
@@ -404,6 +436,49 @@ describe("addWorkspace", () => {
       ),
     )
     expect(pkg.workspaces).toHaveLength(1)
+    process.env.npm_config_user_agent = original
+  })
+
+  test("should not create pnpm-workspace.yaml when dryRun is true", async () => {
+    const original = process.env.npm_config_user_agent
+    process.env.npm_config_user_agent = "pnpm/8.0.0"
+    await addWorkspace(tempDir, "packages/**", {}, { dryRun: true })
+    const { existsSync } = await import("fs")
+    expect(existsSync(path.join(tempDir, "pnpm-workspace.yaml"))).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+    process.env.npm_config_user_agent = original
+  })
+
+  test("should not update existing pnpm-workspace.yaml when dryRun is true", async () => {
+    const original = process.env.npm_config_user_agent
+    process.env.npm_config_user_agent = "pnpm/8.0.0"
+    const { readFileSync } = await import("fs")
+    const YAML = (await import("yamljs")).default
+    const yamlPath = path.join(tempDir, "pnpm-workspace.yaml")
+    const originalContent = YAML.stringify({ packages: ["existing/**"] })
+    writeFileSync(yamlPath, originalContent)
+    await addWorkspace(tempDir, "packages/**", {}, { dryRun: true })
+    expect(readFileSync(yamlPath, "utf-8")).toBe(originalContent)
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+    process.env.npm_config_user_agent = original
+  })
+
+  test("should not update package.json workspaces when dryRun is true", async () => {
+    const original = process.env.npm_config_user_agent
+    process.env.npm_config_user_agent = ""
+    const pkgPath = path.join(tempDir, "package.json")
+    writeFileSync(pkgPath, JSON.stringify({ name: "test" }))
+    await addWorkspace(tempDir, "packages/**", {}, { dryRun: true })
+    const { readFileSync } = await import("fs")
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"))
+    expect(pkg.workspaces).toBeUndefined()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
     process.env.npm_config_user_agent = original
   })
 })

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -170,12 +170,22 @@ export function packageExecuteCommands(packageManager: PackageManager) {
 
 export interface InstallDependenciesOptions extends PackageAddCommandOptions {
   cwd?: string
+  dryRun?: boolean
 }
 
 export async function installDependencies(
   dependencies?: string[],
-  { cwd, dev, exact = true }: InstallDependenciesOptions = {},
+  { cwd, dev, dryRun, exact = true }: InstallDependenciesOptions = {},
 ) {
+  if (dryRun) {
+    if (dependencies?.length) {
+      console.log(c.cyan(`(dry run) Would install: ${dependencies.join(", ")}`))
+    } else {
+      console.log(c.cyan(`(dry run) Would install dependencies`))
+    }
+    return
+  }
+
   const packageManager = getPackageManager()
 
   if (dependencies?.length) {
@@ -189,13 +199,22 @@ export async function installDependencies(
 
 export interface UninstallDependenciesOptions extends Pick<
   InstallDependenciesOptions,
-  "cwd"
+  "cwd" | "dryRun"
 > {}
 
 export async function uninstallDependencies(
   dependencies: string[],
-  { cwd }: InstallDependenciesOptions = {},
+  { cwd, dryRun }: UninstallDependenciesOptions = {},
 ) {
+  if (dryRun) {
+    if (dependencies.length) {
+      console.log(
+        c.cyan(`(dry run) Would uninstall: ${dependencies.join(", ")}`),
+      )
+    }
+    return
+  }
+
   const packageManager = getPackageManager()
 
   if (dependencies.length) {
@@ -205,10 +224,15 @@ export async function uninstallDependencies(
   }
 }
 
+export interface AddWorkspaceOptions {
+  dryRun?: boolean
+}
+
 export async function addWorkspace(
   cwd: string,
   workspacePath: string,
   config: UserConfig,
+  { dryRun }: AddWorkspaceOptions = {},
 ) {
   const packageManager = getPackageManager()
 
@@ -228,7 +252,7 @@ export async function addWorkspace(
           await writeFileSafe(
             targetPath,
             YAML.stringify(json),
-            merge(config, { format: { parser: "yaml" } }),
+            merge(config, { dryRun, format: { parser: "yaml" } }),
           )
         }
       } else {
@@ -237,7 +261,7 @@ export async function addWorkspace(
         await writeFileSafe(
           targetPath,
           content,
-          merge(config, { format: { parser: "yaml" } }),
+          merge(config, { dryRun, format: { parser: "yaml" } }),
         )
       }
 
@@ -257,7 +281,7 @@ export async function addWorkspace(
         await writeFileSafe(
           targetPath,
           content,
-          merge(config, { format: { parser: "json" } }),
+          merge(config, { dryRun, format: { parser: "json" } }),
         )
       }
 

--- a/packages/cli/src/utils/registry.test.ts
+++ b/packages/cli/src/utils/registry.test.ts
@@ -593,6 +593,25 @@ describe("generateSource", () => {
     const content = readFileSync(path.join(dirPath, "index.js"), "utf-8")
     expect(content).not.toContain(": number")
   })
+
+  test("should not create file and log when dryRun is true", async () => {
+    const config = createMockConfig()
+    const dirPath = path.join(tempDir, "button")
+
+    await generateSource(
+      dirPath,
+      "components",
+      { name: "index.ts", content: "export {}" },
+      config,
+      [],
+      { dryRun: true },
+    )
+
+    expect(existsSync(path.join(dirPath, "index.ts"))).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
+  })
 })
 
 describe("transformContentWithFormatAndLint", () => {
@@ -674,5 +693,22 @@ describe("generateSources", () => {
 
     expect(existsSync(path.join(dirPath, "index.ts"))).toBeTruthy()
     expect(existsSync(path.join(dirPath, "registry.json"))).toBeTruthy()
+  })
+
+  test("should not create files and log when dryRun is true", async () => {
+    const config = createMockConfig()
+    const dirPath = path.join(tempDir, "button")
+    const registry: Registry = {
+      section: "components",
+      sources: [{ name: "index.ts", content: "export {}" }],
+    }
+
+    await generateSources(dirPath, registry, config, [], { dryRun: true })
+
+    expect(existsSync(path.join(dirPath, "index.ts"))).toBeFalsy()
+    expect(existsSync(path.join(dirPath, "registry.json"))).toBeFalsy()
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run) Would write:"),
+    )
   })
 })

--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -401,12 +401,17 @@ export async function transformIndexWithFormatAndLint(
   return content
 }
 
+export interface GenerateSourceOptions {
+  dryRun?: boolean
+}
+
 export async function generateSource(
   dirPath: string,
   section: RegistrySection,
   { name: fileName, content, data, template }: Source,
   config: Config,
   generatedNames: string[] = [],
+  { dryRun }: GenerateSourceOptions = {},
 ) {
   fileName = transformExtension(fileName, config.jsx)
 
@@ -420,7 +425,7 @@ export async function generateSource(
         ? transformTsxToJsx(content)
         : transformTsToJs(content)
 
-    await writeFileSafe(targetPath, content, config)
+    await writeFileSafe(targetPath, content, { ...config, dryRun })
   } else if (template && data) {
     await Promise.all(
       data.map(async ({ name: fileName, ...rest }) => {
@@ -435,7 +440,10 @@ export async function generateSource(
             ? transformTsxToJsx(content)
             : transformTsToJs(content)
 
-        await writeFileSafe(path.resolve(targetPath, fileName), content, config)
+        await writeFileSafe(path.resolve(targetPath, fileName), content, {
+          ...config,
+          dryRun,
+        })
       }),
     )
   }
@@ -446,15 +454,23 @@ export async function generateSources(
   registry: Registry,
   config: Config,
   generatedNames: string[] = [],
+  { dryRun }: GenerateSourceOptions = {},
 ) {
   await Promise.all([
     ...registry.sources.map((source) =>
-      generateSource(dirPath, registry.section, source, config, generatedNames),
+      generateSource(
+        dirPath,
+        registry.section,
+        source,
+        config,
+        generatedNames,
+        { dryRun },
+      ),
     ),
     writeFileSafe(
       path.resolve(dirPath, REGISTRY_FILE_NAME),
       JSON.stringify(registry),
-      merge(config, { format: { parser: "json" } }),
+      merge(config, { dryRun, format: { parser: "json" } }),
     ),
   ])
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #6069

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description
Add a --dry-run option to all CLI commands (add, update, init, theme, tokens, diff) that simulates the command's execution without writing any files or installing any dependencies. This helps users preview what changes will be made before committing to them.

## Current behavior (updates)
Running any CLI command (e.g. `yamada-cli add button`) immediately writes files and installs dependencies with no way to preview what will happen.

## New behavior
Passing `--dry-run` (or `-n`) prints a log of every file write and dependency install that **would** occur, without actually performing any of them.

- `dryRun` follows the same pattern as existing flags (`--yes`, `--force`) and is passed via dedicated options types (`WriteFileOptions`, `InstallDependenciesOptions`, `GenerateSourceOptions`, `UpdateFilesOptions`).
- In `update-files.ts`, the early return occurs before `mkdtemp` so no temporary files are created either.


## Is this a breaking change (Yes/No):
No

## Additional Information
