### PR TITLE
fix(dependabot): correct open pull requests option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
       changesets:
         patterns:
           - "@changesets/*"
-    open-pull-request-limit: 10
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -51,4 +51,4 @@ updates:
       - "hirotomoyamada"
     labels:
       - "github-actions"
-    open-pull-request-limit: 10
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## AI used

- [x] I did not use AI to create this PR.
- [ ] (If there is no check above) I checked the generated content before submitting.

Ref: https://docs.github.com/ja/code-security/reference/supply-chain-security/dependabot-options-reference