### PR TITLE
test(use-hover): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-hover/use-hover.test.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "#test"
+import { page, render } from "#test/browser"
 import { useHover } from "./"
 
 describe("useHover", () => {
@@ -12,20 +12,23 @@ describe("useHover", () => {
       return <span ref={ref}>{hovered ? hoveredText : notHoveredText}</span>
     }
 
-    const { user } = render(<Text />)
+    const { user } = await render(<Text />)
 
-    const initialTextComponent = await screen.findByText(notHoveredText)
-    expect(initialTextComponent).toBeInTheDocument()
-    expect(screen.queryByText(hoveredText)).toBeNull()
+    await expect.element(page.getByText(notHoveredText)).toBeInTheDocument()
+    await expect
+      .element(page.getByText(/^Hovered$/).query())
+      .not.toBeInTheDocument()
 
-    await user.hover(initialTextComponent)
-    const hoveredTextComponent = await screen.findByText(hoveredText)
-    expect(hoveredTextComponent).toBeInTheDocument()
-    expect(screen.queryByText(notHoveredText)).toBeNull()
+    await user.hover(page.getByText(notHoveredText))
+    await expect.element(page.getByText(/^Hovered$/)).toBeInTheDocument()
+    await expect
+      .element(page.getByText(/^Not hovered$/).query())
+      .not.toBeInTheDocument()
 
-    await user.unhover(hoveredTextComponent)
-    const unHoveredTextComponent = await screen.findByText(notHoveredText)
-    expect(unHoveredTextComponent).toBeInTheDocument()
-    expect(screen.queryByText(hoveredText)).toBeNull()
+    await user.unhover(page.getByText(/^Hovered$/))
+    await expect.element(page.getByText(notHoveredText)).toBeInTheDocument()
+    await expect
+      .element(page.getByText(/^Hovered$/).query())
+      .not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `useHover` hook tests from jsdom (`#test`) to Vitest browser mode (`#test/browser`).

## Current behavior (updates)

Tests run in jsdom environment using `#test` imports with `screen` queries.

## New behavior

Tests run in real browser environment (Chromium, WebKit, Firefox) using `#test/browser` imports.

Key changes:
- `import { render, screen } from "#test"` → `import { page, render } from "#test/browser"`
- `render()` is now `await`-ed
- `screen.*` replaced with `page.*`
- `queryByText` replaced with `getByText(...).query()`
- `findByText` replaced with `getByText`
- Used regex patterns (`/^Hovered$/`, `/^Not hovered$/`) for exact text matching to avoid substring match issues
- Assertions use `await expect.element(...)` instead of `expect(...)`

## Is this a breaking change (Yes/No):

No

## Additional Information

Post-migration coverage:
- Statements: 88.23%
- Branches: 50%
- Functions: 80%
- Lines: 86.66%