### PR TITLE
test(use-focus): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-focus/index.test.tsx
+++ b/packages/react/src/hooks/use-focus/index.test.tsx
@@ -3,7 +3,7 @@ import type * as Utils from "../../utils"
 import type { UseFocusOnMouseDownProps, UseFocusOnShowProps } from "./"
 import { page, render } from "#test/browser"
 import { useRef } from "react"
-import { getFirstFocusableElement } from "../../utils"
+import { getFirstFocusableElement, isSafari } from "../../utils"
 import { useFocusOnPointerDown, useFocusOnShow } from "./"
 
 function getHTMLElement(testId: string): HTMLElement {
@@ -26,6 +26,7 @@ vi.mock("../../utils", async (importOriginal) => {
   return {
     ...actual,
     getFirstFocusableElement: vi.fn(actual.getFirstFocusableElement),
+    isSafari: vi.fn(actual.isSafari),
   }
 })
 
@@ -222,34 +223,13 @@ describe("useFocusOnShow", () => {
 })
 
 describe("useFocusOnPointerDown", () => {
-  const defaultPlatform = window.navigator.platform
-
-  const defaultVendor = window.navigator.vendor
-
-  beforeAll(() => {
-    Object.defineProperty(window.navigator, "platform", {
-      value: "MacOS",
-      writable: true,
-    })
-    Object.defineProperty(window.navigator, "vendor", {
-      value: "Apple Computer, Inc.",
-      writable: true,
-    })
+  beforeEach(() => {
+    vi.mocked(isSafari).mockReturnValue(true)
   })
 
   afterEach(() => {
+    vi.mocked(isSafari).mockRestore()
     vi.restoreAllMocks()
-  })
-
-  afterAll(() => {
-    Object.defineProperty(window.navigator, "platform", {
-      value: defaultPlatform,
-      writable: false,
-    })
-    Object.defineProperty(window.navigator, "vendor", {
-      value: defaultVendor,
-      writable: false,
-    })
   })
 
   const Component: FC<Omit<UseFocusOnMouseDownProps, "ref">> = (props) => {
@@ -323,33 +303,12 @@ describe("useFocusOnPointerDown", () => {
   })
 
   test("does not focus on non-safari browsers", async () => {
-    const previousPlatform = window.navigator.platform
-    const previousVendor = window.navigator.vendor
+    vi.mocked(isSafari).mockReturnValue(false)
 
-    try {
-      Object.defineProperty(window.navigator, "platform", {
-        value: "Win32",
-        writable: true,
-      })
-      Object.defineProperty(window.navigator, "vendor", {
-        value: "Google Inc.",
-        writable: true,
-      })
+    await render(<Component />)
+    const el = getHTMLElement("button")
+    el.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }))
 
-      await render(<Component />)
-      const el = getHTMLElement("button")
-      el.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }))
-
-      await expect.element(page.getByTestId("button")).not.toHaveFocus()
-    } finally {
-      Object.defineProperty(window.navigator, "platform", {
-        value: previousPlatform,
-        writable: true,
-      })
-      Object.defineProperty(window.navigator, "vendor", {
-        value: previousVendor,
-        writable: true,
-      })
-    }
+    await expect.element(page.getByTestId("button")).not.toHaveFocus()
   })
 })


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `useFocusOnShow` and `useFocusOnPointerDown` hook tests from jsdom (`#test`) to Vitest browser mode (`#test/browser`).

## Current behavior (updates)

Tests run in jsdom environment using `#test` imports with `fireEvent`, `act`, and `waitFor`.

## New behavior

Tests run in real browser environment (Chromium, WebKit, Firefox) using `#test/browser` imports.

Key changes:
- `import { act, fireEvent, render, waitFor } from "#test"` → `import { page, render } from "#test/browser"`
- `render()`/`rerender()` are now `await`-ed
- `getByTestId` destructuring replaced with `page.getByTestId(...)` locators
- `waitFor(() => expect(...).toHaveFocus())` → `await expect.element(...).toHaveFocus()`
- `fireEvent.pointerDown(el)` → `el.dispatchEvent(new PointerEvent(...))`
- Added `getHTMLElement` helper to safely get typed elements without `as` casts

## Is this a breaking change (Yes/No):

No