### PR TITLE
test(use-disclosure): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-disclosure/use-promise-disclosure.test.ts
+++ b/packages/react/src/hooks/use-disclosure/use-promise-disclosure.test.ts
@@ -1,31 +1,31 @@
-import { act, renderHook } from "#test"
+import { renderHook } from "#test/browser"
 import { usePromiseDisclosure } from "./use-promise-disclosure"
 
 describe("usePromiseDisclosure", () => {
-  test("should initialize with open as false", () => {
-    const { result } = renderHook(() => usePromiseDisclosure())
+  test("should initialize with open as false", async () => {
+    const { result } = await renderHook(() => usePromiseDisclosure())
 
     expect(result.current.open).toBeFalsy()
   })
 
-  test("should initialize with open as true", () => {
-    const { result } = renderHook(() =>
+  test("should initialize with open as true", async () => {
+    const { result } = await renderHook(() =>
       usePromiseDisclosure({ defaultOpen: true }),
     )
 
     expect(result.current.open).toBeTruthy()
   })
 
-  test("should open and close correctly with onSuccess", () => {
-    const { result } = renderHook(() => usePromiseDisclosure())
+  test("should open and close correctly with onSuccess", async () => {
+    const { act, result } = await renderHook(() => usePromiseDisclosure())
 
-    act(() => {
+    await act(() => {
       result.current.onOpen()
     })
 
     expect(result.current.open).toBeTruthy()
 
-    act(() => {
+    await act(() => {
       result.current.onSuccess()
     })
 
@@ -34,36 +34,43 @@ describe("usePromiseDisclosure", () => {
 
   test("should reject the pending promise when onClose is called", async () => {
     const error = new Error("closed")
-    const { result } = renderHook(() => usePromiseDisclosure({ error }))
+    const { act, result } = await renderHook(() =>
+      usePromiseDisclosure({ error }),
+    )
 
-    let promise: Promise<void>
+    let promise: Promise<void> | undefined
 
-    act(() => {
-      promise = result.current.onOpen() as Promise<void>
+    await act(() => {
+      const p = result.current.onOpen()
+      if (p instanceof Promise) {
+        promise = p
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        promise.catch(() => {})
+      }
     })
 
     expect(result.current.open).toBeTruthy()
 
-    act(() => {
+    await act(() => {
       result.current.onClose()
     })
 
-    await expect(promise!).rejects.toThrow("closed")
+    await expect(promise).rejects.toThrow("closed")
     expect(result.current.open).toBeFalsy()
   })
 
-  test("should handle disableCloseOnSuccess correctly", () => {
-    const { result } = renderHook(() =>
+  test("should handle disableCloseOnSuccess correctly", async () => {
+    const { act, result } = await renderHook(() =>
       usePromiseDisclosure({ disableCloseOnSuccess: true }),
     )
 
-    act(() => {
+    await act(() => {
       result.current.onOpen()
     })
 
     expect(result.current.open).toBeTruthy()
 
-    act(() => {
+    await act(() => {
       result.current.onSuccess()
     })
 


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `usePromiseDisclosure` hook tests from jsdom (`#test`) to Vitest browser mode (`#test/browser`).

## Current behavior (updates)

Tests run in jsdom environment using `#test` imports with `act` and `renderHook`.

## New behavior

Tests run in real browser environment (Chromium, WebKit, Firefox) using `#test/browser` imports.

Key changes:
- `import { act, renderHook } from "#test"` → `import { renderHook } from "#test/browser"`
- `act` obtained from `renderHook` return value
- All `renderHook`/`act` calls are now `await`-ed
- Replaced `as Promise<void>` cast with `instanceof Promise` runtime check

## Is this a breaking change (Yes/No):

No