### PR TITLE
test(use-eye-dropper): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-eye-dropper/index.test.ts
+++ b/packages/react/src/hooks/use-eye-dropper/index.test.ts
@@ -3,9 +3,7 @@ import { useEyeDropper } from "./"
 
 describe("useEyeDropper", () => {
   const defaultEyeDropper =
-    "EyeDropper" in window
-      ? (window as { [key: string]: unknown }).EyeDropper
-      : undefined
+    "EyeDropper" in window ? Reflect.get(window, "EyeDropper") : undefined
   const hasDefaultEyeDropper = "EyeDropper" in window
 
   beforeEach(() => {


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `useEyeDropper` hook tests from jsdom (`#test`) to Vitest browser mode (`#test/browser`).

## Current behavior (updates)

Tests run in jsdom environment using `#test` imports with `renderHook`.

## New behavior

Tests run in real browser environment (Chromium, WebKit, Firefox) using `#test/browser` imports.

Key changes:
- `import { renderHook } from "#test"` → `import { renderHook } from "#test/browser"`
- All `renderHook` calls are now `await`-ed
- Removed `WindowWithEyeDropper` type with `as` cast; replaced with `Reflect.deleteProperty` and `Record<string, unknown>` access

## Is this a breaking change (Yes/No):

No