### PR TITLE
test(use-event-listener): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-event-listener/index.test.ts
+++ b/packages/react/src/hooks/use-event-listener/index.test.ts
@@ -1,12 +1,12 @@
-import { renderHook } from "#test"
+import { renderHook } from "#test/browser"
 import { useEventListener, useEventListeners } from "./"
 
 describe("useEventListener", () => {
-  test("Adds event listener to target element", () => {
+  test("Adds event listener to target element", async () => {
     const target = document.createElement("div")
     const handler = vi.fn()
 
-    renderHook(() => useEventListener(target, "click", handler))
+    await renderHook(() => useEventListener(target, "click", handler))
 
     const clickEvent = new MouseEvent("click")
     target.dispatchEvent(clickEvent)
@@ -14,11 +14,11 @@ describe("useEventListener", () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
-  test("Removes event listener when unmounted", () => {
+  test("Removes event listener when unmounted", async () => {
     const target = document.createElement("div")
     const handler = vi.fn()
 
-    const { unmount } = renderHook(() =>
+    const { unmount } = await renderHook(() =>
       useEventListener(target, "click", handler),
     )
     unmount()
@@ -29,11 +29,11 @@ describe("useEventListener", () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
-  test("Removes event listener using returned cleanup function", () => {
+  test("Removes event listener using returned cleanup function", async () => {
     const target = document.createElement("div")
     const handler = vi.fn()
 
-    const { result } = renderHook(() =>
+    const { result } = await renderHook(() =>
       useEventListener(target, "click", handler),
     )
     const cleanup = result.current
@@ -48,8 +48,8 @@ describe("useEventListener", () => {
 })
 
 describe("useEventListeners", () => {
-  test("Adds and removes event listeners to multiple elements", () => {
-    const { result } = renderHook(() => useEventListeners())
+  test("Adds and removes event listeners to multiple elements", async () => {
+    const { result } = await renderHook(() => useEventListeners())
     const { add, remove } = result.current
 
     const target1 = document.createElement("button")


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate use-event-listener hook tests from jsdom to Vitest browser mode.

## Current behavior (updates)

Tests ran in jsdom environment using `#test` imports.

## New behavior

- Updated imports from `#test` to `#test/browser`
- Made all test functions `async`
- Changed all `renderHook()` calls to `await renderHook()`
- No other changes needed since tests use `document.createElement` and `dispatchEvent` directly

## Is this a breaking change (Yes/No):

No

## Additional Information

- Pre-migration: 4 tests passing (jsdom)
- Post-migration: 4 tests passing (browser mode)
- Lint: passed