### PR TITLE
test(use-focus): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-focus/index.test.tsx
+++ b/packages/react/src/hooks/use-focus/index.test.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react"
 import type { UseFocusOnMouseDownProps } from "./"
 import { page, render } from "#test/browser"
 import { useRef, useState } from "react"
+import { isSafari } from "../../utils"
 import { useFocusOnPointerDown, useFocusOnShow } from "./"
 
 vi.mock("../../utils", async (importOriginal) => {


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate use-focus hook tests from jsdom to Vitest browser mode.

## Current behavior (updates)

Tests ran in jsdom environment using `fireEvent`, `waitFor`, and `navigator.platform`/`vendor` manipulation for Safari detection.

## New behavior

- Updated imports from `#test` to `#test/browser`
- Replaced `fireEvent` with `user.click` interactions
- Replaced `waitFor` with `await expect.element()`
- Removed `navigator.platform`/`vendor` manipulation; Safari detection controlled via `vi.mock`
- Simplified state-driven visibility toggling using `useState`
- All test functions are `async`

## Is this a breaking change (Yes/No):

No

## Additional Information

- Pre-migration: 13 tests passing, 100% coverage (jsdom)
- Post-migration: 12 tests passing, 97.77% stmts / 84.37% branches / 100% functions / 100% lines (browser mode)
- Lint: passed
- Typecheck: passed