### PR TITLE
test(use-outside-click): migrate test to browser mode

### DIFF
--- a/packages/react/src/hooks/use-outside-click/index.test.tsx
+++ b/packages/react/src/hooks/use-outside-click/index.test.tsx
@@ -1,23 +1,38 @@
 import type { FC } from "react"
 import type { UseOutsideClickProps } from "./"
-import { render } from "#test"
+import { page, render } from "#test/browser"
 import { useRef } from "react"
 import { useOutsideClick } from "./"
+
+function dispatchTouchEvents(locator: ReturnType<typeof page.getByTestId>) {
+  const el = locator.element()
+  if (el instanceof HTMLElement) {
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }))
+    el.dispatchEvent(new Event("touchend", { bubbles: true }))
+  }
+}
 
 describe("useOutsideClick", () => {
   const Component: FC<Partial<UseOutsideClickProps>> = (props) => {
     const ref = useRef<HTMLDivElement>(null)
     useOutsideClick({ ref, ...props })
 
-    return <div ref={ref} data-testid="el" />
+    return (
+      <div>
+        <div ref={ref} data-testid="el">
+          inside
+        </div>
+        <div data-testid="outside">outside</div>
+      </div>
+    )
   }
 
   test("should call handler on outside click", async () => {
     const handler = vi.fn()
 
-    const { user } = render(<Component handler={handler} />)
+    const { user } = await render(<Component handler={handler} />)
 
-    await user.click(document.body)
+    await user.click(page.getByTestId("outside"))
 
     expect(handler).toHaveBeenCalledExactlyOnceWith(expect.any(Object))
   })
@@ -25,9 +40,9 @@ describe("useOutsideClick", () => {
   test("should not call handler on inside click", async () => {
     const handler = vi.fn()
 
-    const { getByTestId, user } = render(<Component handler={handler} />)
+    const { user } = await render(<Component handler={handler} />)
 
-    const el = getByTestId("el")
+    const el = page.getByTestId("el")
 
     await user.click(el)
 
@@ -37,21 +52,23 @@ describe("useOutsideClick", () => {
   test("should not call handler when disabled", async () => {
     const handler = vi.fn()
 
-    const { user } = render(<Component enabled={false} handler={handler} />)
+    const { user } = await render(
+      <Component enabled={false} handler={handler} />,
+    )
 
-    await user.click(document.body)
+    await user.click(page.getByTestId("outside"))
 
     expect(handler).not.toHaveBeenCalled()
   })
 
-  test("calls handler on touchend outside element", () => {
+  test("calls handler on touchend outside element", async () => {
     const handler = vi.fn()
 
-    render(<Component handler={handler} />)
+    await render(<Component handler={handler} />)
 
-    const touchStartEvent = new Event("touchstart")
+    const touchStartEvent = new Event("touchstart", { bubbles: true })
     document.dispatchEvent(touchStartEvent)
-    const touchEndEvent = new Event("touchend")
+    const touchEndEvent = new Event("touchend", { bubbles: true })
     document.dispatchEvent(touchEndEvent)
 
     expect(handler).toHaveBeenCalledExactlyOnceWith(expect.any(Object))
@@ -60,16 +77,13 @@ describe("useOutsideClick", () => {
   test("does not call handler on touchend inside element", async () => {
     const handler = vi.fn()
 
-    const { getByTestId, user } = render(<Component handler={handler} />)
+    const { user } = await render(<Component handler={handler} />)
 
-    const el = getByTestId("el")
-
-    const touchEndEvent = new Event("touchend", { bubbles: true })
-    el.dispatchEvent(touchEndEvent)
+    dispatchTouchEvents(page.getByTestId("el"))
 
     expect(handler).not.toHaveBeenCalled()
 
-    await user.click(document.body)
+    await user.click(page.getByTestId("outside"))
 
     expect(handler).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate use-outside-click hook tests from jsdom to Vitest browser mode.

## Current behavior (updates)

Tests ran in jsdom environment using `#test` imports.

## New behavior

- Updated imports from `#test` to `#test/browser` with `page` and `render`
- `render()` changed to `await render()`
- `getByTestId()` replaced with `page.getByTestId()`
- Outside clicks use `user.click(page.getByTestId("outside"))` with a sibling element
- Touch event dispatching extracted to a `dispatchTouchEvents` helper
- All test functions are `async`

## Is this a breaking change (Yes/No):

No

## Additional Information

- Pre-migration: 5 tests passing (jsdom)
- Post-migration: 5 tests passing x 3 browsers = 15 tests
- Coverage: 90.69% Stmts, 82.75% Branch, 87.5% Functions, 97.29% Lines
- Lint: passed
- Typecheck: passed