### PR TITLE
fix(icons): clear URL query params on search reset

### DIFF
--- a/www/app/[locale]/(apps)/icons/list.tsx
+++ b/www/app/[locale]/(apps)/icons/list.tsx
@@ -123,10 +123,11 @@ export function List({ ...rest }: ListProps) {
 
   const onReset = useCallback(() => {
     setValue("")
+    replaceQuery({ query: "" })
     setList(CONTENTS.slice(0, PER_PAGE))
     resetRef.current()
     hitsRef.current = CONTENTS
-  }, [])
+  }, [replaceQuery])
 
   const onOpen = useCallback(
     (data: Data) => {


### PR DESCRIPTION
Closes #6205

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixed `onReset` in the icons page to also clear the URL query parameter. Previously, resetting the search only cleared the local React state but left `?query=...` in the URL, causing the old filter to reappear on page refresh or when sharing the URL.

## Is this a breaking change (Yes/No):

No