### PR TITLE
Fix loading spinner appearing in search dialog for certain queries

### DIFF
--- a/www/app/[locale]/search.tsx
+++ b/www/app/[locale]/search.tsx
@@ -331,6 +331,7 @@ function SearchContentBody({
   const [hits, setHits] = useState<Hit[]>(defaultContents)
   const maxIndex = Math.ceil(hits.length / PER_PAGE) - 1
   const [count, setCount] = useState(PER_PAGE)
+  const hasNext = count < hits.length
   const list = useMemo(() => hits.slice(0, count), [hits, count])
   const resetRef = useRef<() => void>(noop)
   const [, startTransition] = useTransition()
@@ -390,6 +391,7 @@ function SearchContentBody({
   return (
     <Modal.Body asChild {...rest}>
       <InfiniteScrollArea
+        disabled={!hasNext}
         gap="sm"
         loading={<Loading.Oval fontSize="2xl" />}
         maxH={{ base: "44.5rem", sm: "full" }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #6097 <!-- Github issue # here -->

## AI used

- [x] I did not use AI to create this PR.
- [ ] (If there is no check above) I checked the generated content before submitting.

## Description

Add a control flag to prevent the loading spinner in the search dialog from persisting indefinitely.

## Current behavior (updates)

The loading indicator in the search dialog remains visible indefinitely.

## New behavior

Add a flag to manage infinite scroll loading, and set it to disabled.

## Is this a breaking change (Yes/No):

No

## Additional Information
