### PR TITLE
docs(contributing): update deprecated typescript.tsdk to js/ts.tsdk.path

### DIFF
--- a/www/contents/community/contributing.ja.mdx
+++ b/www/contents/community/contributing.ja.mdx
@@ -49,7 +49,7 @@ cd yamada-ui
 
 ```json
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "eslint.workingDirectories": [{ "mode": "auto" }]
 }
 ```

--- a/www/contents/community/contributing.mdx
+++ b/www/contents/community/contributing.mdx
@@ -51,7 +51,7 @@ To ensure the extension works correctly, please add the following settings to `.
 
 ```json
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "eslint.workingDirectories": [{ "mode": "auto" }]
 }
 ```


### PR DESCRIPTION
Closes #6333

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the VSCode settings in the contributing documentation to use the non-deprecated setting key.

## Current behavior (updates)

The contributing guide instructs users to add `"typescript.tsdk": "node_modules/typescript/lib"` to `.vscode/settings.json`. VSCode now displays a deprecation warning for this setting: _"This setting is deprecated. Use js/ts.tsdk.path instead."_ This can confuse contributors following the setup guide.

## New behavior

The documentation now uses the recommended setting `"js/ts.tsdk.path": "node_modules/typescript/lib"` in both `contributing.mdx` and `contributing.ja.mdx`.

## Is this a breaking change (Yes/No):

No

## Additional Information

N/A