### PR TITLE
fix(next): correct scroll behavior on page navigation

### DIFF
--- a/playgrounds/next/app/app/layout.tsx
+++ b/playgrounds/next/app/app/layout.tsx
@@ -33,7 +33,9 @@ export default async function RootLayout({
         <ColorModeScript type="cookie" />
         <ThemeSchemeScript type="cookie" />
 
-        <UIProvider cookie={cookieStore.toString()}>{children}</UIProvider>
+        <UIProvider config={{ resetScroll: false }} cookie={cookieStore.toString()}>
+          {children}
+        </UIProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary

This fix addresses an issue where the page would not scroll to the top upon navigation in the Next.js playground. The root cause was the custom scroll reset behavior in `UIProvider`, which conflicts with layouts using a sticky header. By disabling this custom behavior via the `config` prop, we allow Next.js's native scroll restoration to function correctly, ensuring the page content is not hidden on navigation.

## Changes

- **playgrounds/next/app/app/layout.tsx**: Disable the custom scroll reset in `UIProvider` by setting `config={{ resetScroll: false }}`. This prevents the library's scroll handling from interfering with Next.js's native scroll restoration, which correctly handles scrolling to the top of the page on navigation, even with sticky headers.

## Related Issue

Closes #6300

