### PR TITLE
Handle merge conflicts in `pnpm-lock.yaml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,17 @@ jobs:
               if git merge origin/main --no-edit; then
                 git push origin "$BRANCH"
               else
-                git merge --abort
+                CONFLICTED_FILES=$(git diff --name-only --diff-filter=U)
+
+                if [ "$CONFLICTED_FILES" = "pnpm-lock.yaml" ]; then
+                  git checkout HEAD -- pnpm-lock.yaml
+                  pnpm install --no-frozen-lockfile
+                  git add pnpm-lock.yaml
+                  git commit --no-edit
+                  git push origin "$BRANCH"
+                else
+                  git merge --abort
+                fi
               fi
             fi
           done


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes # <!-- Github issue # here -->

## AI used

- [x] I did not use AI to create this PR.
- [ ] (If there is no check above) I checked the generated content before submitting.

## Description

Currently, in the Release workflow, when updating branches such as `v2.*`, updates are not applied if a conflict occurs. However, since `pnpm-lock.yaml` is a generated file, there are no operational issues even if a conflict occurs—it can be installed, regenerated, and included in the merge commit. Therefore, I have updated the code so that if a conflict occurs only with `pnpm-lock.yaml` in a merge commit that updates a branch, it will be regenerated and included in the merge commit.

## Is this a breaking change (Yes/No):

No