### PR TITLE
chore(www): skip vercel build for draft pull requests

### DIFF
--- a/www/ignored-build-step.sh
+++ b/www/ignored-build-step.sh
@@ -8,6 +8,16 @@ if [ "$VERCEL_PROJECT_PRODUCTION_URL" != "$TARGET_URL" ]; then
   exit 0
 fi
 
+if [ -n "$VERCEL_GIT_PULL_REQUEST_ID" ] && [ -n "$GITHUB_TOKEN" ]; then
+  pr_json=$(curl -sS -f -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}/pulls/${VERCEL_GIT_PULL_REQUEST_ID}" 2>/dev/null) || true
+  if [ -n "$pr_json" ] && printf '%s' "$pr_json" | grep -qE '"draft"[[:space:]]*:[[:space:]]*true[[:space:]]*[,}]'; then
+    echo "Run was canceled because the pull request is a draft."
+    exit 0
+  fi
+fi
+
 if [ "$VERCEL_GIT_COMMIT_REF" == "$TARGET_BRANCH" ]; then
   git_diff_result=$(git diff --name-only HEAD^ HEAD)
 else


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

N/A — no linked issue.

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Skip Vercel preview builds for GitHub draft pull requests when `GITHUB_TOKEN` is configured on the project. The ignored build step calls the GitHub REST API and exits with code 0 (skip build) if the PR’s `draft` field is true.

## Current behavior (updates)

Preview deployments run for every push on PR branches, including draft PRs.

## New behavior

If `VERCEL_GIT_PULL_REQUEST_ID` and `GITHUB_TOKEN` are set, the script fetches the pull request from the GitHub API and skips the build when the PR is a draft. If the token is missing, behavior is unchanged (draft status is not detected).

**Vercel project setup:** add `GITHUB_TOKEN` (pull requests read access) for Preview deployments.

## Is this a breaking change (Yes/No):

No

## Additional Information

Uses `grep` to detect `"draft": true` in the API JSON (no Node required for parsing).
