### PR TITLE
fix(input): fix padding on input components

### DIFF
--- a/.changeset/solid-cars-buy.md
+++ b/.changeset/solid-cars-buy.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed `Input` and `Select` so padding is applied correctly.

--- a/packages/react/src/components/input/input.style.ts
+++ b/packages/react/src/components/input/input.style.ts
@@ -4,21 +4,21 @@ import { wrapWithKey } from "../../utils"
 
 export const getInputPaddingStartResetStyle = (key?: string) =>
   ({
-    "&:not([data-input-element] + &)": wrapWithKey({ ps: "0px" }, key),
+    "&:not([data-input-element] ~ &)": wrapWithKey({ ps: "0px" }, key),
   }) satisfies CSSObject
 
 export const getInputPaddingEndResetStyle = (key?: string) =>
   ({
-    "&:not(:has(+ [data-input-element]))": wrapWithKey({ pe: "0px" }, key),
+    "&:not(:has(~ [data-input-element]))": wrapWithKey({ pe: "0px" }, key),
   }) satisfies CSSObject
 
 export const getInputHeightStyle = (height?: string, key?: string) =>
   ({
-    "&:has(+ [data-input-element])": wrapWithKey({ pe: height }, key),
+    "&:has(~ [data-input-element])": wrapWithKey({ pe: height }, key),
     "& ~ [data-input-element]": { minW: height },
     "--height": height,
-    "[data-input-element] + &": wrapWithKey({ ps: height }, key),
     "[data-input-element]:has(~ &)": { minW: height },
+    "[data-input-element] ~ &": wrapWithKey({ ps: height }, key),
     minH: height,
   }) satisfies CSSObject
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

- Closes #6382 
- Closes #6383 

## AI used

- [x] I did not use AI to create this PR.
- [ ] (If there is no check above) I checked the generated content before submitting.

## Description

<!-- Add a brief description. -->
I have fixed input component having incorrect padding during SSR and for `Select` component.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information

Related: #5308

<img width="1162" height="662" alt="CleanShot 2026-04-07 at 17 21 06@2x" src="https://github.com/user-attachments/assets/b0a5e092-6f59-42a7-a8fd-1c6e8f0c2b97" />
<img width="1236" height="720" alt="CleanShot 2026-04-07 at 17 21 29@2x" src="https://github.com/user-attachments/assets/65523f5a-4dfe-4f88-ba24-ba8c7b56dba9" />
