### PR TITLE
feat(cli): add --dry-run option to all CLI commands

### DIFF
--- a/packages/cli/src/commands/add/index.test.ts
+++ b/packages/cli/src/commands/add/index.test.ts
@@ -624,4 +624,39 @@ describe("add", () => {
       expect.stringContaining("already exists"),
     )
   })
+
+  test("should not write files when --dry-run is used", async () => {
+    setupProject(tempDir)
+
+    const consoleSpy = vi.spyOn(console, "log")
+
+    await add.parseAsync(
+      [
+        "button",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--dry-run",
+      ],
+      { from: "user" },
+    )
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    expect(existsSync(path.join(buttonDir, "index.ts"))).toBeFalsy()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run)"),
+    )
+
+    consoleSpy.mockRestore()
+  })
 })

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -34,6 +34,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   install: boolean
   overwrite: boolean
   sequential: boolean
@@ -49,6 +50,11 @@ export const add = new Command("add")
   .option("--cwd <path>", "current working directory.", cwd)
   .option("-c, --config <path>", "path to the config file.", CONFIG_FILE_NAME)
   .option("-o, --overwrite", "overwrite existing files.", false)
+  .option(
+    "-n, --dry-run",
+    "simulate the command without making any changes.",
+    false,
+  )
   .option("-s, --sequential", "run tasks sequentially.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
   .option("-i, --install", "install dependencies.")
@@ -63,6 +69,7 @@ export const add = new Command("add")
     {
       config: configPath,
       cwd,
+      dryRun,
       format,
       install,
       lint,
@@ -434,7 +441,33 @@ export const add = new Command("add")
         }
       }
 
-      await tasks.run()
+      if (dryRun) {
+        console.log("")
+        console.log(c.cyan("(dry run) The following changes would be made:"))
+        console.log("")
+        Object.entries(registries).forEach(([name, registry]) => {
+          if (!config.isSection(registry.section)) return
+          const sectionPath = config.getSectionResolvedPath(registry.section)
+          const dirPath = path.join(sectionPath, name)
+          registry.sources.forEach(({ name: fileName }) => {
+            console.log(`  ${c.green("write")} ${path.join(dirPath, fileName)}`)
+          })
+        })
+        if (existsSync(config.paths.ui.index)) {
+          console.log(`  ${c.green("update")} ${config.paths.ui.index}`)
+        } else {
+          console.log(`  ${c.green("create")} ${config.paths.ui.index}`)
+        }
+        if (dependencies.length) {
+          console.log("")
+          console.log(c.cyan("(dry run) Dependencies that would be installed:"))
+          dependencies.forEach((dep) => {
+            console.log(`  ${c.yellow(dep)}`)
+          })
+        }
+      } else {
+        await tasks.run()
+      }
 
       end()
     } catch (e) {

--- a/packages/cli/src/commands/init/index.test.ts
+++ b/packages/cli/src/commands/init/index.test.ts
@@ -350,4 +350,29 @@ describe("init", () => {
     // New files should exist
     expect(existsSync(path.join(outdirPath, "src", "index.ts"))).toBeTruthy()
   })
+
+  test("should not create files when --dry-run is used", async () => {
+    const consoleSpy = vi.spyOn(console, "log")
+
+    await init.parseAsync(
+      [
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--dry-run",
+      ],
+      { from: "user" },
+    )
+
+    const configPath = path.join(tempDir, "ui.json")
+    expect(existsSync(configPath)).toBeFalsy()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run)"),
+    )
+
+    consoleSpy.mockRestore()
+  })
 })

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -44,6 +44,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   jsx: boolean
   overwrite: boolean
   yes: boolean
@@ -63,6 +64,11 @@ export const init = new Command("init")
   .option("-c, --config <path>", "path to the config file.", CONFIG_FILE_NAME)
   .option("-o, --overwrite", "overwrite existing files.", false)
   .option("-t, --tag <name>", "tag for the registries (e.g. dev, next).")
+  .option(
+    "-n, --dry-run",
+    "simulate the command without making any changes.",
+    false,
+  )
   .option("-j, --jsx", "use jsx instead of tsx.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
   .option("-m, --monorepo", "enable monorepo mode.")
@@ -83,6 +89,7 @@ export const init = new Command("init")
     src,
     config: configPath,
     cwd,
+    dryRun,
     format,
     install,
     jsx,
@@ -221,15 +228,19 @@ export const init = new Command("init")
         if (!overwrite) process.exit(0)
       }
 
-      spinner.start(`Generating ${c.cyan(configFileName)}`)
+      if (dryRun) {
+        console.log(`  ${c.green("create")} ${configPath}`)
+      } else {
+        spinner.start(`Generating ${c.cyan(configFileName)}`)
 
-      await writeFileSafe(
-        configPath,
-        JSON.stringify(config),
-        merge(config, { format: { parser: "json" } }),
-      )
+        await writeFileSafe(
+          configPath,
+          JSON.stringify(config),
+          merge(config, { format: { parser: "json" } }),
+        )
 
-      spinner.succeed(`Generated ${c.cyan(configFileName)}`)
+        spinner.succeed(`Generated ${c.cyan(configFileName)}`)
+      }
 
       const outdirPath = path.resolve(cwd, outdir)
 
@@ -254,11 +265,13 @@ export const init = new Command("init")
 
         if (!overwrite) process.exit(0)
 
-        spinner.start("Clearing directory")
+        if (!dryRun) {
+          spinner.start("Clearing directory")
 
-        await rimraf(outdirPath)
+          await rimraf(outdirPath)
 
-        spinner.succeed("Cleared directory")
+          spinner.succeed("Cleared directory")
+        }
       }
 
       if (monorepo) {
@@ -389,7 +402,22 @@ export const init = new Command("init")
           })
         }
 
-        await tasks.run()
+        if (dryRun) {
+          console.log("")
+          console.log(c.cyan("(dry run) The following changes would be made:"))
+          console.log(
+            `  ${c.green("create")} ${path.resolve(outdirPath, "package.json")}`,
+          )
+          console.log(
+            `  ${c.green("create")} ${path.resolve(outdirPath, src ? "src" : "", indexFileName)}`,
+          )
+          if (!jsx)
+            console.log(
+              `  ${c.green("create")} ${path.resolve(outdirPath, "tsconfig.json")}`,
+            )
+        } else {
+          await tasks.run()
+        }
 
         if (isUndefined(install)) {
           const answer = await prompts({
@@ -468,7 +496,15 @@ export const init = new Command("init")
           { concurrent: true },
         )
 
-        await tasks.run()
+        if (dryRun) {
+          console.log("")
+          console.log(c.cyan("(dry run) The following changes would be made:"))
+          console.log(
+            `  ${c.green("create")} ${path.resolve(outdirPath, indexFileName)}`,
+          )
+        } else {
+          await tasks.run()
+        }
 
         if (
           notInstalledDependencies.length ||
@@ -515,13 +551,26 @@ export const init = new Command("init")
       }
 
       if (install && (dependencies || devDependencies)) {
-        spinner.start("Installing dependencies")
+        if (dryRun) {
+          console.log("")
+          console.log(c.cyan("(dry run) Dependencies that would be installed:"))
+          if (dependencies)
+            dependencies.forEach((dep) => console.log(`  ${c.yellow(dep)}`))
+          if (devDependencies) {
+            console.log(
+              c.cyan("(dry run) Dev dependencies that would be installed:"),
+            )
+            devDependencies.forEach((dep) => console.log(`  ${c.yellow(dep)}`))
+          }
+        } else {
+          spinner.start("Installing dependencies")
 
-        if (dependencies) await installDependencies(dependencies, { cwd })
-        if (devDependencies)
-          await installDependencies(devDependencies, { cwd, dev: true })
+          if (dependencies) await installDependencies(dependencies, { cwd })
+          if (devDependencies)
+            await installDependencies(devDependencies, { cwd, dev: true })
 
-        spinner.succeed("Installed dependencies")
+          spinner.succeed("Installed dependencies")
+        }
       }
 
       if (monorepo) {

--- a/packages/cli/src/commands/theme/index.test.ts
+++ b/packages/cli/src/commands/theme/index.test.ts
@@ -352,4 +352,31 @@ describe("theme", () => {
       expect.stringContaining("unknown error"),
     )
   })
+
+  test("should not create files when --dry-run is used", async () => {
+    setupProject(tempDir)
+
+    const consoleSpy = vi.spyOn(console, "log")
+
+    await theme.parseAsync(
+      [
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--dry-run",
+      ],
+      { from: "user" },
+    )
+
+    const themePath = path.join(tempDir, "workspaces", "theme")
+    expect(existsSync(path.join(themePath, "src", "index.ts"))).toBeFalsy()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("(dry run)"),
+    )
+
+    consoleSpy.mockRestore()
+  })
 })

--- a/packages/cli/src/commands/theme/index.ts
+++ b/packages/cli/src/commands/theme/index.ts
@@ -43,6 +43,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   overwrite: boolean
   yes: boolean
   format?: boolean
@@ -59,6 +60,11 @@ export const theme = new Command("theme")
   .argument("[path]", "path to the theme directory.")
   .option("--cwd <path>", "current working directory.", cwd)
   .option("-c, --config <path>", "path to the config file.", CONFIG_FILE_NAME)
+  .option(
+    "-n, --dry-run",
+    "simulate the command without making any changes.",
+    false,
+  )
   .option("-o, --overwrite", "overwrite existing directory.", false)
   .option("-j, --js", "use js instead of ts.")
   .option("-y, --yes", "skip all confirmation prompts.", false)
@@ -81,6 +87,7 @@ export const theme = new Command("theme")
       src,
       config: configPath,
       cwd,
+      dryRun,
       format,
       install,
       js,
@@ -174,11 +181,13 @@ export const theme = new Command("theme")
 
         if (!overwrite) process.exit(0)
 
-        spinner.start("Clearing directory")
+        if (!dryRun) {
+          spinner.start("Clearing directory")
 
-        await rimraf(outdirPath)
+          await rimraf(outdirPath)
 
-        spinner.succeed("Cleared directory")
+          spinner.succeed("Cleared directory")
+        }
       }
 
       spinner.start("Fetching registry")
@@ -316,7 +325,38 @@ export const theme = new Command("theme")
         })
       }
 
-      await tasks.run()
+      if (dryRun) {
+        console.log("")
+        console.log(c.cyan("(dry run) The following changes would be made:"))
+        console.log("")
+        const targetPath = path.resolve(
+          outdirPath,
+          monorepoConfig.src ? "src" : "",
+        )
+        registry.sources.forEach(({ name }) => {
+          console.log(
+            "  " + c.green("create") + " " + path.resolve(targetPath, name),
+          )
+        })
+        if (config.monorepo) {
+          console.log(
+            "  " +
+              c.green("create") +
+              " " +
+              path.resolve(outdirPath, "package.json"),
+          )
+        }
+        if (!config.jsx) {
+          console.log(
+            "  " +
+              c.green("create") +
+              " " +
+              path.resolve(outdirPath, "tsconfig.json"),
+          )
+        }
+      } else {
+        await tasks.run()
+      }
 
       if (config.monorepo) {
         const answer = await prompts({
@@ -331,11 +371,16 @@ export const theme = new Command("theme")
         install ??= answer.install ?? true
 
         if (install) {
-          spinner.start("Installing dependencies")
+          if (dryRun) {
+            console.log("")
+            console.log(c.cyan("(dry run) Would install dependencies"))
+          } else {
+            spinner.start("Installing dependencies")
 
-          await installDependencies([], { cwd })
+            await installDependencies([], { cwd })
 
-          spinner.succeed("Installed dependencies")
+            spinner.succeed("Installed dependencies")
+          }
         }
 
         const packageManager = getPackageManager()

--- a/packages/cli/src/commands/tokens/index.test.ts
+++ b/packages/cli/src/commands/tokens/index.test.ts
@@ -279,4 +279,29 @@ describe("tokens", () => {
 
     expect(spinner.fail).toHaveBeenCalledWith("An unknown error occurred")
   })
+
+  test("should not write output file when --dry-run is used", async () => {
+    mockGetModule.mockResolvedValueOnce(createBasicTheme())
+
+    const themePath = path.join(tempDir, "theme.ts")
+    writeFileSync(themePath, "export default {}")
+    const outPath = path.join(tempDir, "out.types.ts")
+
+    await tokens.parseAsync(
+      [
+        themePath,
+        "--cwd",
+        tempDir,
+        "--out",
+        outPath,
+        "--no-format",
+        "--no-lint",
+        "--internal",
+        "--dry-run",
+      ],
+      { from: "user" },
+    )
+
+    expect(existsSync(outPath)).toBeFalsy()
+  })
 })

--- a/packages/cli/src/commands/tokens/index.ts
+++ b/packages/cli/src/commands/tokens/index.ts
@@ -273,6 +273,7 @@ async function getTheme(path: string, cwd: string) {
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   internal: boolean
   format?: boolean
   lint?: boolean
@@ -284,6 +285,11 @@ export const tokens = new Command("tokens")
   .argument("[path]", "path to the theme file.")
   .option("--cwd <path>", "current working directory.", cwd)
   .option("-c, --config <path>", "path to the config file.", CONFIG_FILE_NAME)
+  .option(
+    "-n, --dry-run",
+    "simulate the command without making any changes.",
+    false,
+  )
   .option("-o, --out <path>", `output path.`)
   .option("-f, --format", "format the output file.")
   .option("--no-format", "do not format the output file.")
@@ -292,7 +298,15 @@ export const tokens = new Command("tokens")
   .option("--internal", "generate internal tokens.", false)
   .action(async function (
     inputPath: string | undefined,
-    { config: configPath, cwd, format, internal, lint, out: outPath }: Options,
+    {
+      config: configPath,
+      cwd,
+      dryRun,
+      format,
+      internal,
+      lint,
+      out: outPath,
+    }: Options,
   ) {
     const spinner = ora()
 
@@ -345,19 +359,25 @@ export const tokens = new Command("tokens")
         internal,
       })
 
-      await writeFileSafe(
-        outPath,
-        content,
-        config
-          ? merge(config, { lint: { filePath: inputPath } })
-          : {
-              cwd,
-              format: { enabled: format },
-              lint: { enabled: lint, filePath: inputPath },
-            },
-      )
+      if (dryRun) {
+        console.log("")
+        console.log(c.cyan("(dry run) The following changes would be made:"))
+        console.log("  " + c.green("create") + " " + outPath)
+      } else {
+        await writeFileSafe(
+          outPath,
+          content,
+          config
+            ? merge(config, { lint: { filePath: inputPath } })
+            : {
+                cwd,
+                format: { enabled: format },
+                lint: { enabled: lint, filePath: inputPath },
+              },
+        )
 
-      spinner.succeed(`Generated theme typings`)
+        spinner.succeed(`Generated theme typings`)
+      }
 
       end()
     } catch (e) {

--- a/packages/cli/src/commands/update/index.test.ts
+++ b/packages/cli/src/commands/update/index.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
@@ -344,5 +350,42 @@ describe("update", () => {
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining("---------------------------------"),
     )
+  })
+
+  test("should not modify files when --dry-run is used", async () => {
+    setupProjectWithComponent(tempDir)
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    const originalContent =
+      "export const Button = () => { return 'modified' }\n"
+    writeFileSync(path.join(buttonDir, "index.ts"), originalContent)
+
+    await update.parseAsync(
+      [
+        "button",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--force",
+        "--dry-run",
+      ],
+      { from: "user" },
+    )
+
+    const updatedContent = readFileSync(
+      path.join(buttonDir, "index.ts"),
+      "utf8",
+    )
+    expect(updatedContent).toBe(originalContent)
   })
 })

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -22,6 +22,7 @@ import { validateDiff3 } from "./validate-diff-3"
 interface Options {
   config: string
   cwd: string
+  dryRun: boolean
   force: boolean
   sequential: boolean
   yes: boolean
@@ -36,6 +37,11 @@ export const update = new Command("update")
   .argument("[components...]", "components to update.")
   .option("--cwd <path>", "current working directory.", cwd)
   .option("-c, --config <path>", "path to the config file.", CONFIG_FILE_NAME)
+  .option(
+    "-n, --dry-run",
+    "simulate the command without making any changes.",
+    false,
+  )
   .option("-s, --sequential", "run tasks sequentially.", false)
   .option("-F, --force", "force update, overwriting local changes.", false)
   .option("-y, --yes", "skip all confirmation prompts.", false)
@@ -51,6 +57,7 @@ export const update = new Command("update")
     {
       config: configPath,
       cwd,
+      dryRun,
       force,
       format,
       install,
@@ -158,6 +165,33 @@ export const update = new Command("update")
 
       if (!hasChanges && !hasDependencyChanges) {
         console.log(c.cyan("No updates found."))
+      } else if (dryRun) {
+        console.log(c.cyan("(dry run) The following files would be updated:"))
+        console.log("")
+        Object.entries(changeMap).forEach(([_name, files]) => {
+          Object.keys(files).forEach((file) => {
+            console.log("  " + c.green("update") + " " + file)
+          })
+        })
+        if (dependencyMap.add.length) {
+          console.log("")
+          console.log(c.cyan("(dry run) Dependencies that would be added:"))
+          dependencyMap.add.forEach((dep) => console.log("  " + c.yellow(dep)))
+        }
+        if (dependencyMap.remove.length) {
+          console.log("")
+          console.log(c.cyan("(dry run) Dependencies that would be removed:"))
+          dependencyMap.remove.forEach((dep) =>
+            console.log("  " + c.yellow(dep)),
+          )
+        }
+        if (dependencyMap.update.length) {
+          console.log("")
+          console.log(c.cyan("(dry run) Dependencies that would be updated:"))
+          dependencyMap.update.forEach((dep) =>
+            console.log("  " + c.yellow(dep)),
+          )
+        }
       } else {
         const conflictMap = await updateFiles(
           changeMap,


### PR DESCRIPTION
## Summary

Adds a `--dry-run` / `-n` flag to the `add`, `init`, `update`, `theme`, and `tokens` CLI commands. When used, the flag simulates execution and shows what changes would be made without actually writing files or installing dependencies.

This is a widely expected CLI pattern (used by npm, git, rsync) that helps users safely preview the effects of a command before committing to them.

### Example usage

```bash
yamada-ui add button --dry-run
# (dry run) The following changes would be made:
#   write src/components/button/index.ts
# (dry run) Dependencies that would be installed:
#   @yamada-ui/button

yamada-ui init --dry-run --yes
# (dry run) The following changes would be made:
#   create ui.json
#   create workspaces/ui/package.json
#   create workspaces/ui/src/index.ts
#   create workspaces/ui/tsconfig.json
```

### Affected commands

| Command | Dry-run behavior |
|---------|-----------------|
| `add` | Shows files that would be written and dependencies that would be installed |
| `init` | Shows config file, project files, and dependencies that would be created/installed |
| `update` | Shows files that would be updated and dependency changes |
| `theme` | Shows theme files that would be created |
| `tokens` | Shows type definition file that would be generated |
| `diff` | Already read-only — no `--dry-run` needed |

### Tests

Added tests for each command verifying that `--dry-run` prevents file system changes.

Closes #6069

Related #5980
Related #5866