### PR TITLE
docs(agents): add PR review branch protection rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,3 +208,14 @@ Read the [template](./.github/pull_request_template.md) and use its structure fo
 - The template includes an "AI used" section. If AI generated the PR, uncheck "I did not use AI" and check "I checked the generated content before submitting."
 
 After creating a PR, the [Quality](./.github/workflows/quality.yml) GitHub Action runs automatically to validate format, lint, typecheck, and tests. Monitor it to ensure there are no issues. If problems are found, fix them and resubmit.
+
+## Reviewing PRs
+
+The following branch protection rules are enforced on GitHub. Keep them in mind when reviewing and merging PRs.
+
+- **Require status checks to pass**: All required status checks (including Quality) must be green before merging.
+- **Require branches to be up to date before merging**: The PR branch must be up to date with the base branch. If it is behind, update it before merging.
+- **Dismiss stale pull request approvals when new commits are pushed**: Any new commit dismisses previous approvals. A re-review is required after pushing new changes.
+- **Require review from specific teams**: At least one approval from each of the `prime` and `standard` teams is required. `hirotomoyamada` and `claude-for-yamada-ui` belong to both teams, so a single approval from either of them satisfies both team requirements.
+- **Require review from Code Owners**: At least one approval from a Code Owner listed in [CODEOWNERS](./.github/CODEOWNERS) is required for the files changed in the PR.
+- **Require conversation resolution before merging**: All review comments and conversations must be resolved before merging.


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a `Reviewing PRs` section to `AGENTS.md` that documents the branch protection rules enforced on GitHub, so contributors (and agents) understand what must be satisfied before merging a PR.

## Current behavior (updates)

`AGENTS.md` explains how to create PRs but does not describe the branch protection rules that must be satisfied when reviewing and merging them.

## New behavior

Adds a new `Reviewing PRs` section listing the six branch protection rules:

- Require status checks to pass
- Require branches to be up to date before merging
- Dismiss stale pull request approvals when new commits are pushed
- Require review from specific teams (`prime` and `standard`; members of both teams can satisfy both with a single approval)
- Require review from Code Owners
- Require conversation resolution before merging

## Is this a breaking change (Yes/No):

No. Documentation-only change.

## Additional Information