### PR TITLE
refactor(accordion): propagate suppressHydrationWarning to hidden elements

### DIFF
--- a/.changeset/fix-6417-accordion-suppress-hydration.md
+++ b/.changeset/fix-6417-accordion-suppress-hydration.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Propagated `suppressHydrationWarning` set on the `Accordion` root to hidden inner elements (`AccordionButton` outer `<h3>`, `AccordionPanel` string-children `<p>`).

--- a/packages/react/src/components/accordion/accordion.test.tsx
+++ b/packages/react/src/components/accordion/accordion.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, getReactProps, render, screen } from "#test"
+import { a11y, hasSuppressHydrationWarning, render, screen } from "#test"
 import { noop } from "../../utils"
 import { BoxIcon } from "../icon"
 import { Accordion } from "./"
@@ -361,7 +361,7 @@ describe("<Accordion />", () => {
     const button = screen.getByTestId("button")
     const heading = button.parentElement
     expect(heading?.tagName).toBe("H3")
-    expect(getReactProps(heading).suppressHydrationWarning).toBeTruthy()
+    expect(hasSuppressHydrationWarning(heading)).toBeTruthy()
   })
 
   test("propagates `suppressHydrationWarning` to the AccordionPanel inner `<p>` wrapping string children", async () => {
@@ -375,7 +375,7 @@ describe("<Accordion />", () => {
 
     const paragraph = await screen.findByRole("paragraph")
     expect(paragraph.tagName).toBe("P")
-    expect(getReactProps(paragraph).suppressHydrationWarning).toBeTruthy()
+    expect(hasSuppressHydrationWarning(paragraph)).toBeTruthy()
   })
 
   test("correct warnings should be issued when multiple and defaultIndex is not array", () => {

--- a/packages/react/src/components/accordion/accordion.test.tsx
+++ b/packages/react/src/components/accordion/accordion.test.tsx
@@ -1,23 +1,7 @@
-import { a11y, render, screen } from "#test"
+import { a11y, getReactProps, render, screen } from "#test"
 import { noop } from "../../utils"
 import { BoxIcon } from "../icon"
 import { Accordion } from "./"
-
-interface ReactProps {
-  [key: string]: unknown
-}
-
-function getReactProps(el: Element | null | undefined): ReactProps {
-  if (!el) return {}
-
-  const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"))
-  if (!key) return {}
-
-  const value = Reflect.get(el, key)
-  if (typeof value !== "object" || value === null) return {}
-
-  return { ...value }
-}
 
 const items = [
   {

--- a/packages/react/src/components/accordion/accordion.test.tsx
+++ b/packages/react/src/components/accordion/accordion.test.tsx
@@ -3,6 +3,22 @@ import { noop } from "../../utils"
 import { BoxIcon } from "../icon"
 import { Accordion } from "./"
 
+interface ReactProps {
+  [key: string]: unknown
+}
+
+function getReactProps(el: Element | null | undefined): ReactProps {
+  if (!el) return {}
+
+  const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"))
+  if (!key) return {}
+
+  const value = Reflect.get(el, key)
+  if (typeof value !== "object" || value === null) return {}
+
+  return { ...value }
+}
+
 const items = [
   {
     button: "Accordion Label 1",
@@ -344,6 +360,38 @@ describe("<Accordion />", () => {
     )
 
     consoleWarnSpy.mockRestore()
+  })
+
+  test("propagates `suppressHydrationWarning` to the AccordionButton outer `<h3>`", () => {
+    render(
+      <Accordion.Root suppressHydrationWarning>
+        <Accordion.Item index={0}>
+          <Accordion.Button data-testid="button">
+            Accordion Label
+          </Accordion.Button>
+          <Accordion.Panel>This is an accordion item</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion.Root>,
+    )
+
+    const button = screen.getByTestId("button")
+    const heading = button.parentElement
+    expect(heading?.tagName).toBe("H3")
+    expect(getReactProps(heading).suppressHydrationWarning).toBeTruthy()
+  })
+
+  test("propagates `suppressHydrationWarning` to the AccordionPanel inner `<p>` wrapping string children", async () => {
+    render(
+      <Accordion.Root defaultIndex={0} suppressHydrationWarning>
+        <Accordion.Item button="Accordion Label" index={0}>
+          <Accordion.Panel>This is an accordion item</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion.Root>,
+    )
+
+    const paragraph = await screen.findByRole("paragraph")
+    expect(paragraph.tagName).toBe("P")
+    expect(getReactProps(paragraph).suppressHydrationWarning).toBeTruthy()
   })
 
   test("correct warnings should be issued when multiple and defaultIndex is not array", () => {

--- a/packages/react/src/components/accordion/accordion.tsx
+++ b/packages/react/src/components/accordion/accordion.tsx
@@ -65,6 +65,7 @@ const {
   ComponentContext,
   PropsContext: AccordionPropsContext,
   useComponentContext,
+  useHydrationContext,
   usePropsContext: useAccordionPropsContext,
   withContext,
   withProvider,
@@ -211,10 +212,11 @@ export const AccordionButton = withContext<"button", AccordionButtonProps>(
     const { icon: rootIcon } = useComponentContext()
     const { icon: itemIcon } = useItemComponentContext()
     const { disabled, open, getButtonProps } = useAccordionItemContext()
+    const hydrationProps = useHydrationContext()
     const props = { disabled, expanded: open }
 
     return (
-      <styled.h3 {...containerProps}>
+      <styled.h3 {...hydrationProps} {...containerProps}>
         <styled.button {...getButtonProps(rest)}>
           {children}
 
@@ -278,6 +280,7 @@ export const AccordionPanel = withContext<"div", AccordionPanelProps>(
     ...rest
   }) => {
     const { open, getPanelProps } = useAccordionItemContext()
+    const hydrationProps = useHydrationContext()
 
     return (
       <Collapse
@@ -294,7 +297,11 @@ export const AccordionPanel = withContext<"div", AccordionPanelProps>(
         }}
       >
         <styled.div {...getPanelProps(rest)}>
-          {isString(children) ? <styled.p>{children}</styled.p> : children}
+          {isString(children) ? (
+            <styled.p {...hydrationProps}>{children}</styled.p>
+          ) : (
+            children
+          )}
         </styled.div>
       </Collapse>
     )

--- a/packages/react/src/components/accordion/accordion.tsx
+++ b/packages/react/src/components/accordion/accordion.tsx
@@ -65,7 +65,6 @@ const {
   ComponentContext,
   PropsContext: AccordionPropsContext,
   useComponentContext,
-  useHydrationContext,
   usePropsContext: useAccordionPropsContext,
   withContext,
   withProvider,
@@ -208,16 +207,26 @@ export interface AccordionButtonProps extends HTMLStyledProps<"button"> {
 }
 
 export const AccordionButton = withContext<"button", AccordionButtonProps>(
-  ({ children, icon: customIcon, containerProps, ...rest }) => {
+  ({
+    children,
+    icon: customIcon,
+    suppressHydrationWarning,
+    containerProps,
+    ...rest
+  }) => {
     const { icon: rootIcon } = useComponentContext()
     const { icon: itemIcon } = useItemComponentContext()
     const { disabled, open, getButtonProps } = useAccordionItemContext()
-    const hydrationProps = useHydrationContext()
     const props = { disabled, expanded: open }
 
     return (
-      <styled.h3 {...hydrationProps} {...containerProps}>
-        <styled.button {...getButtonProps(rest)}>
+      <styled.h3
+        suppressHydrationWarning={suppressHydrationWarning}
+        {...containerProps}
+      >
+        <styled.button
+          {...getButtonProps({ suppressHydrationWarning, ...rest })}
+        >
           {children}
 
           <AccordionIcon>
@@ -274,13 +283,13 @@ export const AccordionPanel = withContext<"div", AccordionPanelProps>(
     duration,
     endingHeight,
     startingHeight,
+    suppressHydrationWarning,
     transition,
     transitionEnd,
     unmountOnExit,
     ...rest
   }) => {
     const { open, getPanelProps } = useAccordionItemContext()
-    const hydrationProps = useHydrationContext()
 
     return (
       <Collapse
@@ -296,9 +305,11 @@ export const AccordionPanel = withContext<"div", AccordionPanelProps>(
           unmountOnExit,
         }}
       >
-        <styled.div {...getPanelProps(rest)}>
+        <styled.div {...getPanelProps({ suppressHydrationWarning, ...rest })}>
           {isString(children) ? (
-            <styled.p {...hydrationProps}>{children}</styled.p>
+            <styled.p suppressHydrationWarning={suppressHydrationWarning}>
+              {children}
+            </styled.p>
           ) : (
             children
           )}

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,6 +1,22 @@
 import { act } from "@testing-library/react"
 import { isArray, isString, wait } from "@yamada-ui/utils"
 
+interface ReactProps {
+  [key: string]: unknown
+}
+
+export function getReactProps(el: Element | null | undefined): ReactProps {
+  if (!el) return {}
+
+  const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"))
+  if (!key) return {}
+
+  const value = Reflect.get(el, key)
+  if (typeof value !== "object" || value === null) return {}
+
+  return { ...value }
+}
+
 export async function waitForAnimationFrame(ms = 16) {
   await act(async () => wait(ms))
 

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,20 +1,18 @@
 import { act } from "@testing-library/react"
 import { isArray, isString, wait } from "@yamada-ui/utils"
 
-interface ReactProps {
-  [key: string]: unknown
-}
-
-export function getReactProps(el: Element | null | undefined): ReactProps {
-  if (!el) return {}
+export function hasSuppressHydrationWarning(
+  el: Element | null | undefined,
+): boolean {
+  if (!el) return false
 
   const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"))
-  if (!key) return {}
+  if (!key) return false
 
-  const value = Reflect.get(el, key)
-  if (typeof value !== "object" || value === null) return {}
+  const props = Reflect.get(el, key)
+  if (typeof props !== "object" || props === null) return false
 
-  return { ...value }
+  return Reflect.get(props, "suppressHydrationWarning") === true
 }
 
 export async function waitForAnimationFrame(ms = 16) {


### PR DESCRIPTION
Closes #6417

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Propagated `suppressHydrationWarning` set on the `Accordion` root to hidden inner elements inside `AccordionButton` and `AccordionPanel` that previously did not receive the merged rest props.

- `AccordionButton` outer `<styled.h3>` now spreads `useHydrationContext()` so it receives the root `suppressHydrationWarning`.
- `AccordionPanel` inner `<styled.p>` (used when children is a string) now spreads `useHydrationContext()`.

## Is this a breaking change (Yes/No):

No