### PR TITLE
fix(radio): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/radio-merge-props.md
+++ b/.changeset/radio-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `Radio` root component so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/radio/radio.test.tsx
+++ b/packages/react/src/components/radio/radio.test.tsx
@@ -195,4 +195,33 @@ describe("<Radio />", () => {
     expect(onChangeMock).toHaveBeenCalledWith("2")
     expect(result.current.value).toBe("2")
   })
+
+  test("merges user-provided `rootProps` with internal props instead of overwriting", () => {
+    const onClick = vi.fn()
+
+    render(
+      <RadioGroup.Root>
+        <Radio
+          value="1"
+          rootProps={{
+            className: "from-user",
+            style: { backgroundColor: "blue", color: "red" },
+            onClick,
+          }}
+        >
+          radio
+        </Radio>
+      </RadioGroup.Root>,
+    )
+
+    const root = screen.getByRole("radio").parentElement
+
+    expect(root).toHaveClass("ui-radio__root", "from-user")
+    expect(root).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(root).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(root!)
+
+    expect(onClick).toHaveBeenCalledWith(expect.anything())
+  })
 })

--- a/packages/react/src/components/radio/radio.tsx
+++ b/packages/react/src/components/radio/radio.tsx
@@ -7,7 +7,7 @@ import type { UseInputBorderProps } from "../input"
 import type { RadioStyle } from "./radio.style"
 import type { UseRadioProps } from "./use-radio"
 import { useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { useInputBorder } from "../input"
 import { radioStyle } from "./radio.style"
 import { useRadio } from "./use-radio"
@@ -77,7 +77,7 @@ export const Radio = withProvider<"label", RadioProps>(
     }, [getIndicatorProps, indicatorProps])
 
     return (
-      <styled.label {...getRootProps({ ...varProps, ...rootProps })}>
+      <styled.label {...mergeProps(getRootProps(varProps), rootProps)()}>
         {input}
         {indicator}
         {children ? <RadioLabel {...labelProps}>{children}</RadioLabel> : null}


### PR DESCRIPTION
Closes #6433

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces unsafe object spread with `mergeProps` in `Radio` root so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

Follows the reference pattern established in `sidebar.tsx`.

## Current behavior (updates)

Passing `className` / `style` / `onClick` to `Radio` (via `rootProps`) would replace context-side values instead of merging with them, breaking the component's internal wiring (slot className, CSS variables, and handlers).

## New behavior

User-provided props are now merged with context props, preserving internal className, styles, refs, and handlers. Added a regression test that asserts both the slot className and the user className are present, that both color and background-color styles are preserved, and that the user-provided `onClick` fires.

## Is this a breaking change (Yes/No):

No

## Additional Information