### PR TITLE
fix(calendar): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/calendar-merge-props.md
+++ b/.changeset/calendar-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `Calendar` sub-components so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/calendar/calendar.test.tsx
+++ b/packages/react/src/components/calendar/calendar.test.tsx
@@ -1038,6 +1038,218 @@ describe("<Calendar />", () => {
       expect.stringContaining("September"),
     )
   })
+
+  test("should merge `prevButtonProps` from root with user props on `Calendar.PrevButton` without overwriting `className`, `style`, and event handlers", () => {
+    const onRootClick = vi.fn()
+    const onUserClick = vi.fn()
+
+    render(
+      <Calendar.Root
+        prevButtonProps={{
+          className: "from-root",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick: onRootClick,
+        }}
+      >
+        <Calendar.Navigation>
+          <Calendar.PrevButton
+            className="from-user"
+            style={{ borderColor: "green" }}
+            onClick={onUserClick}
+          />
+          <Calendar.NextButton />
+        </Calendar.Navigation>
+        <Calendar.Month />
+      </Calendar.Root>,
+    )
+
+    const prevButton = screen.getByRole("button", {
+      name: /previous month/i,
+    })
+
+    expect(prevButton).toHaveClass("from-root", "from-user")
+    expect(prevButton).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(prevButton).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+    expect(prevButton).toHaveStyle({ borderColor: "rgb(0, 128, 0)" })
+
+    fireEvent.click(prevButton)
+
+    expect(onRootClick).toHaveBeenCalledTimes(1)
+    expect(onUserClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("should merge `nextButtonProps` from root with user props on `Calendar.NextButton` without overwriting `className`, `style`, and event handlers", () => {
+    const onRootClick = vi.fn()
+    const onUserClick = vi.fn()
+
+    render(
+      <Calendar.Root
+        nextButtonProps={{
+          className: "from-root",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick: onRootClick,
+        }}
+      >
+        <Calendar.Navigation>
+          <Calendar.PrevButton />
+          <Calendar.NextButton
+            className="from-user"
+            style={{ borderColor: "green" }}
+            onClick={onUserClick}
+          />
+        </Calendar.Navigation>
+        <Calendar.Month />
+      </Calendar.Root>,
+    )
+
+    const nextButton = screen.getByRole("button", { name: /next month/i })
+
+    expect(nextButton).toHaveClass("from-root", "from-user")
+    expect(nextButton).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(nextButton).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+    expect(nextButton).toHaveStyle({ borderColor: "rgb(0, 128, 0)" })
+
+    fireEvent.click(nextButton)
+
+    expect(onRootClick).toHaveBeenCalledTimes(1)
+    expect(onUserClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("should merge `buttonProps` from root with `prevButtonProps` and user props on `Calendar.PrevButton`", () => {
+    const onButtonClick = vi.fn()
+    const onPrevClick = vi.fn()
+    const onUserClick = vi.fn()
+
+    render(
+      <Calendar.Root
+        buttonProps={{
+          className: "from-button",
+          onClick: onButtonClick,
+        }}
+        prevButtonProps={{
+          className: "from-prev",
+          onClick: onPrevClick,
+        }}
+      >
+        <Calendar.Navigation>
+          <Calendar.PrevButton className="from-user" onClick={onUserClick} />
+          <Calendar.NextButton />
+        </Calendar.Navigation>
+        <Calendar.Month />
+      </Calendar.Root>,
+    )
+
+    const prevButton = screen.getByRole("button", {
+      name: /previous month/i,
+    })
+
+    expect(prevButton).toHaveClass("from-button", "from-prev", "from-user")
+
+    fireEvent.click(prevButton)
+
+    expect(onButtonClick).toHaveBeenCalledTimes(1)
+    expect(onPrevClick).toHaveBeenCalledTimes(1)
+    expect(onUserClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("should merge `navigationProps` from root with user props on `Calendar.Navigation` without overwriting `className`, `style`, and event handlers", () => {
+    const onRootClick = vi.fn()
+    const onUserClick = vi.fn()
+
+    render(
+      <Calendar.Root
+        navigationProps={{
+          className: "from-root",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick: onRootClick,
+        }}
+      >
+        <Calendar.Navigation
+          className="from-user"
+          data-testid="navigation"
+          onClick={onUserClick}
+        />
+        <Calendar.Month />
+      </Calendar.Root>,
+    )
+
+    const navigation = screen.getByTestId("navigation")
+
+    expect(navigation).toHaveClass("from-root", "from-user")
+    expect(navigation).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(navigation).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(navigation)
+
+    expect(onRootClick).toHaveBeenCalledTimes(1)
+    expect(onUserClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("should merge `monthProps` from root with user props on `Calendar.Month` without overwriting `className`, `style`, and event handlers", () => {
+    const onRootClick = vi.fn()
+    const onUserClick = vi.fn()
+
+    render(
+      <Calendar.Root
+        monthProps={{
+          className: "from-root",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick: onRootClick,
+        }}
+      >
+        <Calendar.Navigation />
+        <Calendar.Month className="from-user" onClick={onUserClick} />
+      </Calendar.Root>,
+    )
+
+    const grid = screen.getByRole("grid")
+
+    expect(grid).toHaveClass("from-root", "from-user")
+    expect(grid).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(grid).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(grid)
+
+    expect(onRootClick).toHaveBeenCalledTimes(1)
+    expect(onUserClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("should merge `controlProps` from root with user props on `Calendar.Control` without overwriting `className`, `style`, and event handlers", () => {
+    const onRootClick = vi.fn()
+    const onUserClick = vi.fn()
+
+    render(
+      <Calendar.Root
+        controlProps={{
+          className: "from-root",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick: onRootClick,
+        }}
+      >
+        <Calendar.Navigation>
+          <Calendar.PrevButton />
+          <Calendar.Control
+            className="from-user"
+            data-testid="control"
+            onClick={onUserClick}
+          />
+          <Calendar.NextButton />
+        </Calendar.Navigation>
+        <Calendar.Month />
+      </Calendar.Root>,
+    )
+
+    const control = screen.getByTestId("control")
+
+    expect(control).toHaveClass("from-root", "from-user")
+    expect(control).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(control).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(control)
+
+    expect(onRootClick).toHaveBeenCalledTimes(1)
+    expect(onUserClick).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("isSameYear", () => {

--- a/packages/react/src/components/calendar/calendar.tsx
+++ b/packages/react/src/components/calendar/calendar.tsx
@@ -10,7 +10,7 @@ import type {
   UseCalendarReturn,
 } from "./use-calendar"
 import { useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { runIfFn } from "../../utils"
 import { resetFieldProps } from "../field"
 import { ChevronLeftIcon, ChevronRightIcon } from "../icon"
@@ -354,7 +354,7 @@ export const CalendarNavigation = withContext<"div", CalendarNavigationProps>(
   }, [children])
 
   return {
-    ...getNavigationProps({ ...navigationProps, ...rest }),
+    ...getNavigationProps(mergeProps(navigationProps, rest)()),
     children: computedChildren,
   }
 })
@@ -388,8 +388,7 @@ export const CalendarControl = withContext<"div", CalendarControlProps>(
   }, [children, month])
 
   return {
-    ...controlProps,
-    ...rest,
+    ...mergeProps(controlProps, rest)(),
     children: (
       <>
         {computedChildren}
@@ -412,7 +411,7 @@ export const CalendarPrevButton = withContext<
 
     return {
       children,
-      ...getPrevButtonProps({ ...buttonProps, ...prevButtonProps, ...rest }),
+      ...getPrevButtonProps(mergeProps(buttonProps, prevButtonProps, rest)()),
     }
   },
 )
@@ -430,7 +429,7 @@ export const CalendarNextButton = withContext<
 
     return {
       children,
-      ...getNextButtonProps({ ...buttonProps, ...nextButtonProps, ...rest }),
+      ...getNextButtonProps(mergeProps(buttonProps, nextButtonProps, rest)()),
     }
   },
 )
@@ -448,25 +447,28 @@ export const CalendarYearSelect = withContext<"div", CalendarYearSelectProps>(
   (props) => {
     const { yearItems, getYearSelectProps, selectProps, yearSelectProps } =
       useComponentContext()
-    const { contentProps, rootProps, ...rest } = {
-      ...selectProps,
-      ...yearSelectProps,
-      ...props,
-    }
+    const { contentProps, rootProps, ...rest } = useMemo(
+      () => mergeProps(selectProps, yearSelectProps, props)(),
+      [selectProps, yearSelectProps, props],
+    )
 
     return (
       <Select.Root
         variant="plain"
         items={yearItems}
         minH="{cell-size}"
-        contentProps={{ minW: "{select-content-size}", ...contentProps }}
-        rootProps={{
-          fontSize: "{select-font-size}",
-          w: "{select-root-size}",
-          ...rootProps,
-        }}
-        {...resetFieldProps}
-        {...getYearSelectProps(rest)}
+        contentProps={mergeProps(
+          { minW: "{select-content-size}" },
+          contentProps,
+        )()}
+        rootProps={mergeProps(
+          {
+            fontSize: "{select-font-size}",
+            w: "{select-root-size}",
+          },
+          rootProps,
+        )()}
+        {...mergeProps(resetFieldProps, getYearSelectProps(rest))()}
       />
     )
   },
@@ -479,25 +481,28 @@ export const CalendarMonthSelect = withContext<"div", CalendarMonthSelectProps>(
   (props) => {
     const { monthItems, getMonthSelectProps, monthSelectProps, selectProps } =
       useComponentContext()
-    const { contentProps, rootProps, ...rest } = {
-      ...selectProps,
-      ...monthSelectProps,
-      ...props,
-    }
+    const { contentProps, rootProps, ...rest } = useMemo(
+      () => mergeProps(selectProps, monthSelectProps, props)(),
+      [selectProps, monthSelectProps, props],
+    )
 
     return (
       <Select.Root
         variant="plain"
         items={monthItems}
         minH="{cell-size}"
-        contentProps={{ minW: "{select-content-size}", ...contentProps }}
-        rootProps={{
-          fontSize: "{select-font-size}",
-          w: "{select-root-size}",
-          ...rootProps,
-        }}
-        {...resetFieldProps}
-        {...getMonthSelectProps(rest)}
+        contentProps={mergeProps(
+          { minW: "{select-content-size}" },
+          contentProps,
+        )()}
+        rootProps={mergeProps(
+          {
+            fontSize: "{select-font-size}",
+            w: "{select-root-size}",
+          },
+          rootProps,
+        )()}
+        {...mergeProps(resetFieldProps, getMonthSelectProps(rest))()}
       />
     )
   },
@@ -569,7 +574,7 @@ export const CalendarMonth = withContext<"table", CalendarMonthProps>(
   )
 
   return {
-    ...getMonthProps({ ...monthProps, ...rest }),
+    ...getMonthProps(mergeProps(monthProps, rest)()),
     children,
   }
 })


### PR DESCRIPTION
Closes #6432

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces unsafe object spread with `mergeProps` across `Calendar` sub-components so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

Follows the reference pattern established in `sidebar.tsx`.

## Current behavior (updates)

Passing `className` / `style` / `onClick` to Calendar sub-components would replace context-side values instead of merging with them, breaking the component's internal wiring.

## New behavior

User-provided props are now merged with context props, preserving internal className, styles, refs, and handlers. Added regression tests.

## Is this a breaking change (Yes/No):

No

## Additional Information