### PR TITLE
fix(checkbox): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/checkbox-merge-props.md
+++ b/.changeset/checkbox-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `Checkbox` root component so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/checkbox/checkbox.test.tsx
+++ b/packages/react/src/components/checkbox/checkbox.test.tsx
@@ -240,4 +240,30 @@ describe("<CheckboxGroup />", () => {
     })
     expect(result.current.value).toStrictEqual(["1"])
   })
+
+  test("merges user-provided `rootProps` with internal props instead of overwriting", () => {
+    const onClick = vi.fn()
+
+    render(
+      <Checkbox
+        rootProps={{
+          className: "from-user",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick,
+        }}
+      >
+        checkbox
+      </Checkbox>,
+    )
+
+    const root = screen.getByRole("checkbox").parentElement
+
+    expect(root).toHaveClass("ui-checkbox__root", "from-user")
+    expect(root).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(root).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(root!)
+
+    expect(onClick).toHaveBeenCalledWith(expect.anything())
+  })
 })

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -7,7 +7,7 @@ import type { UseInputBorderProps } from "../input"
 import type { CheckboxStyle } from "./checkbox.style"
 import type { UseCheckboxProps } from "./use-checkbox"
 import { useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { CheckIcon, MinusIcon } from "../icon"
 import { useInputBorder } from "../input"
 import { checkboxStyle } from "./checkbox.style"
@@ -107,7 +107,7 @@ export const Checkbox = withProvider<"label", CheckboxProps>(
     }, [getIndicatorProps, indicatorProps, icon])
 
     return (
-      <styled.label {...getRootProps({ ...varProps, ...rootProps })}>
+      <styled.label {...mergeProps(getRootProps(varProps), rootProps)()}>
         {input}
         {indicator}
         {children ? (


### PR DESCRIPTION
Closes #6435

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces unsafe object spread with `mergeProps` in `Checkbox` root so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

Follows the reference pattern established in `sidebar.tsx` and matches the recent fixes for `Radio` (#6433) and `Tree`.

## Current behavior (updates)

Passing `className` / `style` / `onClick` to `Checkbox` would replace context-side values instead of merging with them.

## New behavior

User-provided props are now merged with context props, preserving internal className, styles, refs, and handlers. Added regression tests.

## Is this a breaking change (Yes/No):

No

## Additional Information