### PR TITLE
fix(radio-card): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/radio-card-root-merge-props.md
+++ b/.changeset/radio-card-root-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `RadioCardRoot` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/radio-card/radio-card.test.tsx
+++ b/packages/react/src/components/radio-card/radio-card.test.tsx
@@ -1,4 +1,5 @@
-import { a11y, render, screen } from "#test"
+import { a11y, fireEvent, render, screen } from "#test"
+import { vi } from "vitest"
 import { RadioCard, RadioCardGroup } from "."
 
 const items = [
@@ -94,5 +95,31 @@ describe("<RadioCard />", () => {
     const radio = screen.getByRole("radio")
     const indicator = radio.parentElement?.querySelector("[data-indicator]")
     expect(indicator).toBeNull()
+  })
+
+  test("merges user-provided `rootProps` with internal props instead of overwriting", () => {
+    const onClick = vi.fn()
+
+    render(
+      <RadioCard.Root
+        label="Radio Card"
+        value="1"
+        rootProps={{
+          className: "from-user",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick,
+        }}
+      />,
+    )
+
+    const root = screen.getByRole("radio").parentElement
+
+    expect(root).toHaveClass("ui-radio-card__root", "from-user")
+    expect(root).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(root).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(root!)
+
+    expect(onClick).toHaveBeenCalledWith(expect.anything())
   })
 })

--- a/packages/react/src/components/radio-card/radio-card.tsx
+++ b/packages/react/src/components/radio-card/radio-card.tsx
@@ -7,7 +7,7 @@ import type { UseInputBorderProps } from "../input"
 import type { UseRadioProps } from "../radio"
 import type { RadioCardStyle } from "./radio-card.style"
 import { useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { useInputBorder } from "../input"
 import { useRadio } from "../radio"
 import { radioCardStyle } from "./radio-card.style"
@@ -133,7 +133,7 @@ export const RadioCardRoot = withProvider<"label", RadioCardRootProps>(
     ])
 
     return (
-      <styled.label {...getRootProps({ ...varProps, ...rootProps })}>
+      <styled.label {...mergeProps(getRootProps(varProps), rootProps)()}>
         <styled.input {...getInputProps(inputProps)} />
         {withIndicator ? (
           <RadioCardIndicator {...getIndicatorProps(indicatorProps)} />


### PR DESCRIPTION
Closes #6434

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces unsafe object spread with `mergeProps` in `RadioCardRoot` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

Follows the reference pattern established in `sidebar.tsx` and the sibling fix in `radio.tsx` (#6433).

## Current behavior (updates)

Passing `className` / `style` / `onClick` via `rootProps` to `RadioCardRoot` would replace context-side values instead of merging with them.

## New behavior

User-provided props are now merged with context props, preserving internal className, styles, refs, and handlers. Added a regression test that renders a `RadioCard.Root` with `rootProps={{ className, style, onClick }}` and asserts that both the internal and user-provided values are present.

## Is this a breaking change (Yes/No):

No

## Additional Information