### PR TITLE
fix(checkbox-card): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/checkbox-card-root-merge-props.md
+++ b/.changeset/checkbox-card-root-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `CheckboxCardRoot` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/checkbox-card/checkbox-card.test.tsx
+++ b/packages/react/src/components/checkbox-card/checkbox-card.test.tsx
@@ -1,4 +1,5 @@
-import { a11y, render, screen } from "#test"
+import { a11y, fireEvent, render, screen } from "#test"
+import { vi } from "vitest"
 import { CheckboxCard, CheckboxCardGroup } from "."
 
 const items = [
@@ -96,5 +97,31 @@ describe("<CheckboxCard />", () => {
     const checkbox = screen.getByRole("checkbox")
     const indicator = checkbox.parentElement?.querySelector("[data-indicator]")
     expect(indicator).toBeNull()
+  })
+
+  test("merges user-provided `rootProps` with internal props instead of overwriting", () => {
+    const onClick = vi.fn()
+
+    render(
+      <CheckboxCard.Root
+        label="Checkbox Card"
+        value="1"
+        rootProps={{
+          className: "from-user",
+          style: { backgroundColor: "blue", color: "red" },
+          onClick,
+        }}
+      />,
+    )
+
+    const root = screen.getByRole("checkbox").parentElement
+
+    expect(root).toHaveClass("ui-checkbox-card__root", "from-user")
+    expect(root).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(root).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(root!)
+
+    expect(onClick).toHaveBeenCalledWith(expect.anything())
   })
 })

--- a/packages/react/src/components/checkbox-card/checkbox-card.tsx
+++ b/packages/react/src/components/checkbox-card/checkbox-card.tsx
@@ -7,7 +7,7 @@ import type { UseCheckboxProps } from "../checkbox"
 import type { UseInputBorderProps } from "../input"
 import type { CheckboxCardStyle } from "./checkbox-card.style"
 import { useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { useCheckbox } from "../checkbox"
 import { CheckIcon, MinusIcon } from "../icon"
 import { useInputBorder } from "../input"
@@ -159,7 +159,7 @@ export const CheckboxCardRoot = withProvider<"label", CheckboxCardRootProps>(
     ])
 
     return (
-      <styled.label {...getRootProps({ ...varProps, ...rootProps })}>
+      <styled.label {...mergeProps(getRootProps(varProps), rootProps)()}>
         <styled.input {...getInputProps(inputProps)} />
         {withIndicator ? (
           <CheckboxCardIndicator {...getIndicatorProps(indicatorProps)}>


### PR DESCRIPTION
Closes #6436

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces unsafe object spread with `mergeProps` in `CheckboxCardRoot` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

Follows the reference pattern established in `sidebar.tsx`.

## Current behavior (updates)

Passing `className` / `style` / `onClick` to `CheckboxCardRoot` would replace context-side values instead of merging with them.

## New behavior

User-provided props are now merged with context props, preserving internal className, styles, refs, and handlers. Added regression tests.

## Is this a breaking change (Yes/No):

No

## Additional Information