### PR TITLE
fix(input): merge user props with context props in InputElement and InputAddon

### DIFF
--- a/.changeset/input-element-addon-merge-props.md
+++ b/.changeset/input-element-addon-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `InputElement` and `InputAddon` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/input/input-addon.tsx
+++ b/packages/react/src/components/input/input-addon.tsx
@@ -3,7 +3,7 @@
 import type { HTMLStyledProps, ThemeProps } from "../../core"
 import type { InputProps } from "./input"
 import type { InputAddonStyle } from "./input-addon.style"
-import { createComponent } from "../../core"
+import { createComponent, mergeProps } from "../../core"
 import { inputAddonStyle } from "./input-addon.style"
 import { useInputBorder } from "./use-input-border"
 
@@ -29,6 +29,6 @@ export const InputAddon = withContext("div")(
   ({ errorBorderColor, focusBorderColor, ...rest }) => {
     const varProps = useInputBorder({ errorBorderColor, focusBorderColor })
 
-    return { ...varProps, ...rest }
+    return mergeProps(varProps, rest)()
   },
 )

--- a/packages/react/src/components/input/input-element.tsx
+++ b/packages/react/src/components/input/input-element.tsx
@@ -3,7 +3,7 @@
 import type { HTMLStyledProps, ThemeProps } from "../../core"
 import type { InputProps } from "./input"
 import type { InputElementStyle } from "./input-element.style"
-import { createComponent } from "../../core"
+import { createComponent, mergeProps } from "../../core"
 import { inputElementStyle } from "./input-element.style"
 import { useInputBorder } from "./use-input-border"
 
@@ -29,6 +29,6 @@ export const InputElement = withContext("div")(
   ({ errorBorderColor, focusBorderColor, ...rest }) => {
     const varProps = useInputBorder({ errorBorderColor, focusBorderColor })
 
-    return { ...varProps, ...rest }
+    return mergeProps(varProps, rest)()
   },
 )

--- a/packages/react/src/components/input/input.test.tsx
+++ b/packages/react/src/components/input/input.test.tsx
@@ -1,4 +1,5 @@
-import { a11y, render, screen } from "#test"
+import { a11y, fireEvent, render, screen } from "#test"
+import { vi } from "vitest"
 import { Input, InputGroup } from "./"
 
 describe("<Input />", () => {
@@ -123,5 +124,61 @@ describe("<Input />", () => {
     render(<Input focusBorderColor="blue.500" />)
 
     expect(screen.getByRole("textbox")).toBeInTheDocument()
+  })
+
+  test("merges user-provided props with internal props in `InputGroup.Element`", () => {
+    const onClick = vi.fn()
+
+    render(
+      <InputGroup.Root>
+        <InputGroup.Element
+          className="from-user"
+          style={{ backgroundColor: "blue", color: "red" }}
+          errorBorderColor="red.500"
+          onClick={onClick}
+        >
+          Hello
+        </InputGroup.Element>
+        <Input />
+      </InputGroup.Root>,
+    )
+
+    const element = screen.getByText("Hello")
+
+    expect(element).toHaveClass("ui-input-element", "from-user")
+    expect(element).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(element).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(element)
+
+    expect(onClick).toHaveBeenCalledWith(expect.anything())
+  })
+
+  test("merges user-provided props with internal props in `InputGroup.Addon`", () => {
+    const onClick = vi.fn()
+
+    render(
+      <InputGroup.Root>
+        <Input />
+        <InputGroup.Addon
+          className="from-user"
+          style={{ backgroundColor: "blue", color: "red" }}
+          errorBorderColor="red.500"
+          onClick={onClick}
+        >
+          World
+        </InputGroup.Addon>
+      </InputGroup.Root>,
+    )
+
+    const addon = screen.getByText("World")
+
+    expect(addon).toHaveClass("ui-input-addon", "from-user")
+    expect(addon).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(addon).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(addon)
+
+    expect(onClick).toHaveBeenCalledWith(expect.anything())
   })
 })


### PR DESCRIPTION
Closes #6437

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces unsafe object spread with `mergeProps` in `InputElement` and `InputAddon` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

Follows the reference pattern established in `sidebar.tsx`.

## Current behavior (updates)

Passing `className` / `style` / `onClick` to `InputElement` or `InputAddon` would replace context-side values instead of merging with them.

## New behavior

User-provided props are now merged with context props, preserving internal className, styles, refs, and handlers. Added regression tests.

## Is this a breaking change (Yes/No):

No

## Additional Information