### PR TITLE
refactor(indicator): propagate suppressHydrationWarning to hidden elements

### DIFF
--- a/.changeset/indicator-suppress-hydration-hidden.md
+++ b/.changeset/indicator-suppress-hydration-hidden.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Propagate `suppressHydrationWarning` to the hidden overflow span in `Indicator`.

--- a/packages/react/src/components/indicator/indicator.test.tsx
+++ b/packages/react/src/components/indicator/indicator.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, render, screen } from "#test"
+import { a11y, hasSuppressHydrationWarning, render, screen } from "#test"
 import { Indicator } from "."
 
 describe("<Indicator />", () => {
@@ -221,5 +221,40 @@ describe("<Indicator />", () => {
     )
     const label = screen.getByTestId("indicator")
     expect(label).toHaveClass("custom-label")
+  })
+
+  test("propagates `suppressHydrationWarning` to the overflow span when `label > overflowCount`", () => {
+    render(
+      <Indicator
+        label={100}
+        overflowCount={99}
+        suppressHydrationWarning
+        labelProps={{ "data-testid": "indicator" }}
+      >
+        <div />
+      </Indicator>,
+    )
+
+    const label = screen.getByTestId("indicator")
+    const overflowSpan = label.querySelector("span")
+    expect(overflowSpan).toHaveTextContent("+")
+    expect(hasSuppressHydrationWarning(overflowSpan)).toBeTruthy()
+  })
+
+  test("does not set `suppressHydrationWarning` on the overflow span when omitted from the root", () => {
+    render(
+      <Indicator
+        label={100}
+        overflowCount={99}
+        labelProps={{ "data-testid": "indicator" }}
+      >
+        <div />
+      </Indicator>,
+    )
+
+    const label = screen.getByTestId("indicator")
+    const overflowSpan = label.querySelector("span")
+    expect(overflowSpan).toHaveTextContent("+")
+    expect(hasSuppressHydrationWarning(overflowSpan)).toBeFalsy()
   })
 })

--- a/packages/react/src/components/indicator/indicator.tsx
+++ b/packages/react/src/components/indicator/indicator.tsx
@@ -102,6 +102,7 @@ export const Indicator = withProvider(
     overflowCount = 99,
     placement,
     showZero = true,
+    suppressHydrationWarning,
     floatProps,
     labelProps,
     ...rest
@@ -115,16 +116,18 @@ export const Indicator = withProvider(
         return (
           <>
             {overflowCount}
-            <styled.span>+</styled.span>
+            <styled.span suppressHydrationWarning={suppressHydrationWarning}>
+              +
+            </styled.span>
           </>
         )
       } else {
         return label
       }
-    }, [numeric, label, overflowCount])
+    }, [numeric, label, overflowCount, suppressHydrationWarning])
 
     return (
-      <styled.div {...rest}>
+      <styled.div suppressHydrationWarning={suppressHydrationWarning} {...rest}>
         {children}
 
         {!disabled ? (


### PR DESCRIPTION
Closes #6420

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Propagate `suppressHydrationWarning` to the hidden overflow `<span>` rendered inside `Indicator` when the numeric label exceeds `overflowCount`. Without this, users who passed `suppressHydrationWarning` on the `Indicator` root would still see hydration warnings originating from the overflow span.

## Current behavior (updates)

The overflow `<styled.span>` inside `Indicator`'s `computedLabel` did not receive any props from the root, so `suppressHydrationWarning` set on the root was never forwarded to it.

## New behavior

`Indicator` now destructures `suppressHydrationWarning` from its own props, explicitly forwards it to both the root `<styled.div>` and the hidden overflow `<styled.span>`, and re-includes it in the `useMemo` dependency array. Tests cover both the positive and negative propagation cases.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Follows the same pattern established for `Accordion` in #6575.