### PR TITLE
refactor(native-accordion): propagate suppressHydrationWarning to hidden elements

### DIFF
--- a/.changeset/native-accordion-suppress-hydration-hidden.md
+++ b/.changeset/native-accordion-suppress-hydration-hidden.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Propagate `suppressHydrationWarning` to the hidden inner panel `<div>` in `NativeAccordion`.

--- a/packages/react/src/components/native-accordion/native-accordion.test.tsx
+++ b/packages/react/src/components/native-accordion/native-accordion.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, render, screen } from "#test"
+import { a11y, hasSuppressHydrationWarning, render, screen } from "#test"
 import { BoxIcon } from "../icon"
 import { NativeAccordion } from "./"
 
@@ -160,6 +160,40 @@ describe("<NativeAccordion />", () => {
 
     await user.click(button)
     expect(item).not.toHaveAttribute("open")
+  })
+
+  test("propagates `suppressHydrationWarning` to the NativeAccordionPanel inner `<div>`", () => {
+    render(
+      <NativeAccordion.Root suppressHydrationWarning>
+        <NativeAccordion.Item button="Accordion Label">
+          <NativeAccordion.Panel data-testid="panel">
+            This is an accordion item
+          </NativeAccordion.Panel>
+        </NativeAccordion.Item>
+      </NativeAccordion.Root>,
+    )
+
+    const panel = screen.getByTestId("panel")
+    const inner = panel.firstElementChild
+    expect(inner?.tagName).toBe("DIV")
+    expect(hasSuppressHydrationWarning(inner)).toBeTruthy()
+  })
+
+  test("does not set `suppressHydrationWarning` on the NativeAccordionPanel inner `<div>` when omitted", () => {
+    render(
+      <NativeAccordion.Root>
+        <NativeAccordion.Item button="Accordion Label">
+          <NativeAccordion.Panel data-testid="panel">
+            This is an accordion item
+          </NativeAccordion.Panel>
+        </NativeAccordion.Item>
+      </NativeAccordion.Root>,
+    )
+
+    const panel = screen.getByTestId("panel")
+    const inner = panel.firstElementChild
+    expect(inner?.tagName).toBe("DIV")
+    expect(hasSuppressHydrationWarning(inner)).toBeFalsy()
   })
 
   test("renders item with custom icon", async () => {

--- a/packages/react/src/components/native-accordion/native-accordion.tsx
+++ b/packages/react/src/components/native-accordion/native-accordion.tsx
@@ -207,12 +207,14 @@ export interface NativeAccordionPanelProps extends HTMLStyledProps {}
 export const NativeAccordionPanel = withContext<
   "div",
   NativeAccordionPanelProps
->(({ children, ...rest }) => {
+>(({ children, suppressHydrationWarning, ...rest }) => {
   const { getPanelProps } = useItemComponentContext()
 
   return (
-    <styled.div {...getPanelProps(rest)}>
-      <styled.div>{children}</styled.div>
+    <styled.div {...getPanelProps({ suppressHydrationWarning, ...rest })}>
+      <styled.div suppressHydrationWarning={suppressHydrationWarning}>
+        {children}
+      </styled.div>
     </styled.div>
   )
 }, "panel")()


### PR DESCRIPTION
Closes #6421

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Propagate `suppressHydrationWarning` from `NativeAccordion.Root` to the hidden inner `<div>`
wrapper rendered inside `NativeAccordionPanel`, so users can suppress hydration mismatch
warnings on every DOM node rendered by the component (not only the outer panel wrapper).

This follows the same canonical pattern that was already applied to `Accordion` in PR #6575:

1. Destructure `suppressHydrationWarning` from the slot component's own props. The
   `createSlotComponent` / `withContext` infrastructure merges the root's
   `suppressHydrationWarning` into each slot component's props, so destructuring from props
   is sufficient (no `useHydrationContext` is needed).
2. Spread it on the hidden inner `<styled.div>` wrapper.
3. Re-include it on the outer/visible element via `getPanelProps({ suppressHydrationWarning, ...rest })`
   so that direct usage (`<NativeAccordion.Panel suppressHydrationWarning>`) still reaches
   the visible element.

## Current behavior (updates)

Setting `suppressHydrationWarning` on `NativeAccordion.Root` (or on
`NativeAccordion.Panel` directly) did not propagate to the hidden inner `<div>` wrapper
inside `NativeAccordionPanel`. This caused React hydration mismatch warnings to still be
emitted for that inner wrapper even when the user had explicitly opted in to
`suppressHydrationWarning`.

## New behavior

`NativeAccordionPanel` now destructures `suppressHydrationWarning` from its props and
applies it to both the outer panel `<div>` (via `getPanelProps`) and the hidden inner
`<div>` wrapper, so hydration warnings are suppressed on every DOM node rendered by the
component.

Two new tests verify:

- `suppressHydrationWarning` on `NativeAccordion.Root` propagates to the inner `<div>`.
- The inner `<div>` does not receive `suppressHydrationWarning` when the root omits it.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Reference: PR #6575 applied the same pattern to `Accordion`.