### PR TITLE
refactor(sidebar): propagate suppressHydrationWarning to hidden elements

### DIFF
--- a/.changeset/sidebar-suppress-hydration-hidden.md
+++ b/.changeset/sidebar-suppress-hydration-hidden.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Propagate `suppressHydrationWarning` to the hidden handle `<button>` in `Sidebar`.

--- a/packages/react/src/components/sidebar/sidebar.test.tsx
+++ b/packages/react/src/components/sidebar/sidebar.test.tsx
@@ -1,4 +1,11 @@
-import { a11y, fireEvent, render, screen, waitFor } from "#test"
+import {
+  a11y,
+  fireEvent,
+  hasSuppressHydrationWarning,
+  render,
+  screen,
+  waitFor,
+} from "#test"
 import { useRef } from "react"
 import { Sidebar } from "."
 import { Button } from "../button"
@@ -685,5 +692,33 @@ describe("<Sidebar />", () => {
     const link = screen.getByRole("link", { name: "1-1" })
 
     expect(link).toHaveAttribute("data-selected")
+  })
+
+  test("propagates `suppressHydrationWarning` to the `SidebarHandle` `<button>`", () => {
+    const { container } = render(
+      <Sidebar.Root suppressHydrationWarning>
+        <Sidebar.SidePanel>
+          <Sidebar.Handle />
+        </Sidebar.SidePanel>
+      </Sidebar.Root>,
+    )
+
+    const handle = container.querySelector(".ui-sidebar__handle")
+    expect(handle?.tagName).toBe("BUTTON")
+    expect(hasSuppressHydrationWarning(handle)).toBeTruthy()
+  })
+
+  test("does not set `suppressHydrationWarning` on the `SidebarHandle` `<button>` when the root omits it", () => {
+    const { container } = render(
+      <Sidebar.Root>
+        <Sidebar.SidePanel>
+          <Sidebar.Handle />
+        </Sidebar.SidePanel>
+      </Sidebar.Root>,
+    )
+
+    const handle = container.querySelector(".ui-sidebar__handle")
+    expect(handle?.tagName).toBe("BUTTON")
+    expect(hasSuppressHydrationWarning(handle)).toBeFalsy()
   })
 })

--- a/packages/react/src/components/sidebar/sidebar.tsx
+++ b/packages/react/src/components/sidebar/sidebar.tsx
@@ -732,12 +732,17 @@ export const SidebarContent = withContext<"ul", SidebarContentProps>(
 export interface SidebarHandleProps extends HTMLStyledProps<"button"> {}
 
 export const SidebarHandle = withContext<"button", SidebarHandleProps>(
-  (props) => {
+  ({ suppressHydrationWarning, ...rest }) => {
     const { handleProps } = useSidePanelComponentContext()
 
     return (
-      <SidebarTrigger {...mergeProps(handleProps, props)()}>
-        <styled.button tabIndex={-1} />
+      <SidebarTrigger
+        {...mergeProps(handleProps, { suppressHydrationWarning, ...rest })()}
+      >
+        <styled.button
+          suppressHydrationWarning={suppressHydrationWarning}
+          tabIndex={-1}
+        />
       </SidebarTrigger>
     )
   },


### PR DESCRIPTION
Closes #6425

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Propagates `suppressHydrationWarning` from `SidebarHandle` to its hidden inner
`<button>` so the hidden element honors the root's hydration behavior, matching
the canonical pattern used in `Accordion` (#6575).

## Current behavior (updates)

`SidebarHandle` rendered a hidden inner `<styled.button tabIndex={-1} />` that
did not receive `suppressHydrationWarning`, so the hidden element still emitted
hydration warnings even when the root set `suppressHydrationWarning`.

## New behavior

`SidebarHandle` destructures `suppressHydrationWarning` from its own props and
spreads it on both the outer `SidebarTrigger` (via `mergeProps`) and the hidden
inner `<styled.button>`. `createSlotComponent` already merges the root's
`suppressHydrationWarning` into each slot component's props, so direct usage of
`Sidebar.Handle` also works.

Tests were added to `sidebar.test.tsx` to cover both propagation and the
negative case when the root omits the prop.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Lint, typecheck, and `src/components/sidebar/` tests all pass locally.