### PR TITLE
fix(skills/create-issue): auto-check ai-used "checked the generated content" box

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -111,7 +111,7 @@ Use tools to interact with the user throughout the process.
      [--assignee @me]  # Only if PR intent is Yes
    ```
 
-   **For the `ai-used` checkboxes field in the template:** because this skill is AI-driven by definition, render "I checked the generated content before submitting." as `[x]` (checked) and "I did not use AI to create this issue." as `[ ]` (unchecked) in `--body`.
+   **For the `ai-used` checkboxes field in the template:** because this skill is AI-driven by definition, copy the options exactly as written in the template into `--body`, with the "checked the generated content" option set to `[x]` and the "did not use AI" option set to `[ ]`.
    - Wait for user approval
    - Apply any requested changes and re-present before proceeding
 

--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -111,7 +111,7 @@ Use tools to interact with the user throughout the process.
      [--assignee @me]  # Only if PR intent is Yes
    ```
 
-   **For the `ai-used` checkboxes field in the template:** copy the options as-is into `--body`, leaving all boxes unchecked (`[ ]`). After the issue is created, remind the user to check the appropriate box themselves on the GitHub issue page.
+   **For the `ai-used` checkboxes field in the template:** because this skill is AI-driven by definition, render "I checked the generated content before submitting." as `[x]` (checked) and "I did not use AI to create this issue." as `[ ]` (unchecked) in `--body`.
    - Wait for user approval
    - Apply any requested changes and re-present before proceeding
 


### PR DESCRIPTION
Closes #6603

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the `create-issue` skill so that the `ai-used` checkbox "I checked the generated content before submitting." is rendered as `[x]` (checked) in the issue body, since the skill is AI-driven by definition.

## Current behavior (updates)

Step 8 of `.agents/skills/create-issue/SKILL.md` instructed Claude to leave both `ai-used` boxes unchecked and remind the user to manually check one after the issue is created. This was fragile — users could easily forget — and the answer is always known up front when invoking this skill.

## New behavior

The skill now renders "I checked the generated content before submitting." as `[x]` and "I did not use AI to create this issue." as `[ ]` in `--body`. No post-creation manual step is required.

## Is this a breaking change (Yes/No):

No

## Additional Information

N/A