### PR TITLE
fix(accordion): drop redundant suppressHydrationWarning on static wrappers

### DIFF
--- a/.changeset/fix-accordion-suppress-hydration-redundant.md
+++ b/.changeset/fix-accordion-suppress-hydration-redundant.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Removed redundant `suppressHydrationWarning` forwarding to the static `<h3>` and `<p>` wrapper elements inside `AccordionButton` and `AccordionPanel`. React's `suppressHydrationWarning` does not propagate to children and has no effect on these static wrappers; the legitimate forwarding via `getButtonProps` and `getPanelProps` is preserved.

--- a/packages/react/src/components/accordion/accordion.test.tsx
+++ b/packages/react/src/components/accordion/accordion.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, hasSuppressHydrationWarning, render, screen } from "#test"
+import { a11y, render, screen } from "#test"
 import { noop } from "../../utils"
 import { BoxIcon } from "../icon"
 import { Accordion } from "./"
@@ -344,38 +344,6 @@ describe("<Accordion />", () => {
     )
 
     consoleWarnSpy.mockRestore()
-  })
-
-  test("propagates `suppressHydrationWarning` to the AccordionButton outer `<h3>`", () => {
-    render(
-      <Accordion.Root suppressHydrationWarning>
-        <Accordion.Item index={0}>
-          <Accordion.Button data-testid="button">
-            Accordion Label
-          </Accordion.Button>
-          <Accordion.Panel>This is an accordion item</Accordion.Panel>
-        </Accordion.Item>
-      </Accordion.Root>,
-    )
-
-    const button = screen.getByTestId("button")
-    const heading = button.parentElement
-    expect(heading?.tagName).toBe("H3")
-    expect(hasSuppressHydrationWarning(heading)).toBeTruthy()
-  })
-
-  test("propagates `suppressHydrationWarning` to the AccordionPanel inner `<p>` wrapping string children", async () => {
-    render(
-      <Accordion.Root defaultIndex={0} suppressHydrationWarning>
-        <Accordion.Item button="Accordion Label" index={0}>
-          <Accordion.Panel>This is an accordion item</Accordion.Panel>
-        </Accordion.Item>
-      </Accordion.Root>,
-    )
-
-    const paragraph = await screen.findByRole("paragraph")
-    expect(paragraph.tagName).toBe("P")
-    expect(hasSuppressHydrationWarning(paragraph)).toBeTruthy()
   })
 
   test("correct warnings should be issued when multiple and defaultIndex is not array", () => {

--- a/packages/react/src/components/accordion/accordion.test.tsx
+++ b/packages/react/src/components/accordion/accordion.test.tsx
@@ -328,6 +328,43 @@ describe("<Accordion />", () => {
     expect(item3).toHaveFocus()
   })
 
+  test("forwards `suppressHydrationWarning` to the AccordionButton `<button>` via getButtonProps", () => {
+    render(
+      <Accordion.Root suppressHydrationWarning>
+        <Accordion.Item index={0}>
+          <Accordion.Button data-testid="button">
+            Accordion Label
+          </Accordion.Button>
+          <Accordion.Panel>This is an accordion item</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion.Root>,
+    )
+
+    const button = screen.getByTestId("button")
+    const key = Object.keys(button).find((k) => k.startsWith("__reactProps$"))
+    expect(key).toBeDefined()
+    const props = Reflect.get(button, key!)
+    expect(props.suppressHydrationWarning).toBeTruthy()
+  })
+
+  test("forwards `suppressHydrationWarning` to the AccordionPanel `<div>` via getPanelProps", () => {
+    render(
+      <Accordion.Root defaultIndex={0} suppressHydrationWarning>
+        <Accordion.Item button="Accordion Label" index={0}>
+          <Accordion.Panel data-testid="panel">
+            This is an accordion item
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion.Root>,
+    )
+
+    const panel = screen.getByTestId("panel")
+    const key = Object.keys(panel).find((k) => k.startsWith("__reactProps$"))
+    expect(key).toBeDefined()
+    const props = Reflect.get(panel, key!)
+    expect(props.suppressHydrationWarning).toBeTruthy()
+  })
+
   test("correct warnings should be issued when multiple and toggle", () => {
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(noop)
 

--- a/packages/react/src/components/accordion/accordion.tsx
+++ b/packages/react/src/components/accordion/accordion.tsx
@@ -220,10 +220,7 @@ export const AccordionButton = withContext<"button", AccordionButtonProps>(
     const props = { disabled, expanded: open }
 
     return (
-      <styled.h3
-        suppressHydrationWarning={suppressHydrationWarning}
-        {...containerProps}
-      >
+      <styled.h3 {...containerProps}>
         <styled.button
           {...getButtonProps({ suppressHydrationWarning, ...rest })}
         >
@@ -306,13 +303,7 @@ export const AccordionPanel = withContext<"div", AccordionPanelProps>(
         }}
       >
         <styled.div {...getPanelProps({ suppressHydrationWarning, ...rest })}>
-          {isString(children) ? (
-            <styled.p suppressHydrationWarning={suppressHydrationWarning}>
-              {children}
-            </styled.p>
-          ) : (
-            children
-          )}
+          {isString(children) ? <styled.p>{children}</styled.p> : children}
         </styled.div>
       </Collapse>
     )

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,20 +1,6 @@
 import { act } from "@testing-library/react"
 import { isArray, isString, wait } from "@yamada-ui/utils"
 
-export function hasSuppressHydrationWarning(
-  el: Element | null | undefined,
-): boolean {
-  if (!el) return false
-
-  const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"))
-  if (!key) return false
-
-  const props = Reflect.get(el, key)
-  if (typeof props !== "object" || props === null) return false
-
-  return Reflect.get(props, "suppressHydrationWarning") === true
-}
-
 export async function waitForAnimationFrame(ms = 16) {
   await act(async () => wait(ms))
 


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Follow-up to #6575. That PR forwarded `suppressHydrationWarning` from `Accordion.Root` into the static `<h3>` wrapper of `AccordionButton` and the static `<p>` wrapper that `AccordionPanel` renders for string children. React's `suppressHydrationWarning` only suppresses mismatches on the element's own attributes and direct text content, **does not propagate to children**, and is meaningless on a static wrapper that has no dynamic attributes — so those two forwards have no effect at runtime and are dead props.

The legitimate forwarding paths are kept untouched: `getButtonProps({ suppressHydrationWarning, ... })` on `AccordionButton`'s `<button>` and `getPanelProps({ suppressHydrationWarning, ... })` on `AccordionPanel`'s `<div>` both inject dynamic attributes (`id`, `aria-*`, etc.) that genuinely can mismatch between SSR and hydration.

The two tests added by #6575 asserted the dead props on the static wrappers, so they are removed along with the now-unused `hasSuppressHydrationWarning` test helper.

## Current behavior (updates)

`suppressHydrationWarning` is forwarded onto `<styled.h3>` (in `AccordionButton`) and `<styled.p>` (in `AccordionPanel`), where React ignores it because neither element has dynamic attributes or direct dynamic text.

## New behavior

`suppressHydrationWarning` is no longer forwarded to those static wrappers. The prop continues to flow through `getButtonProps` / `getPanelProps` to the elements that actually need it.

## Is this a breaking change (Yes/No):

No.