### PR TITLE
fix(textarea): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/gentle-canvas-merge.md
+++ b/.changeset/gentle-canvas-merge.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use mergeProps in Textarea so that user-provided className, style, css, ref, and on* event handlers are merged with context props instead of being silently overwritten.

--- a/packages/react/src/components/textarea/textarea.test.tsx
+++ b/packages/react/src/components/textarea/textarea.test.tsx
@@ -1,4 +1,5 @@
-import { a11y, render, screen } from "#test"
+import { a11y, fireEvent, render, screen } from "#test"
+import { InputPropsContext } from "../input"
 import { Textarea } from "./"
 
 describe("<Textarea />", () => {
@@ -71,5 +72,37 @@ describe("<Textarea />", () => {
       value: fontsData,
       writable: true,
     })
+  })
+
+  test("merges `className`, `style`, and event handlers from context and props", () => {
+    const onContextClick = vi.fn()
+    const onPropsClick = vi.fn()
+
+    render(
+      <InputPropsContext
+        value={{
+          className: "from-context",
+          style: { color: "red" },
+          onClick: onContextClick,
+        }}
+      >
+        <Textarea
+          className="from-props"
+          style={{ backgroundColor: "blue" }}
+          onClick={onPropsClick}
+        />
+      </InputPropsContext>,
+    )
+
+    const textarea = screen.getByRole("textbox")
+
+    expect(textarea).toHaveClass("from-context", "from-props")
+    expect(textarea).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(textarea).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(textarea)
+
+    expect(onContextClick).toHaveBeenCalledTimes(1)
+    expect(onPropsClick).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -5,7 +5,7 @@ import type { FieldProps } from "../field"
 import type { UseInputBorderProps } from "../input"
 import type { TextareaStyle } from "./textarea.style"
 import type { UseTextareaProps } from "./use-textarea"
-import { createComponent } from "../../core"
+import { createComponent, mergeProps } from "../../core"
 import { useFieldProps } from "../field"
 import { useInputBorder, useInputPropsContext } from "../input"
 import { textareaStyle } from "./textarea.style"
@@ -36,7 +36,7 @@ export const Textarea = withContext("textarea")(
   (props) => {
     const context = useInputPropsContext()
 
-    return { rows: 2, ...context, ...props }
+    return mergeProps({ rows: 2 }, context, props)()
   },
   (props) => {
     const {


### PR DESCRIPTION
Closes #6447

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use `mergeProps` in `Textarea` so user props are merged with context props instead of being overwritten.

## Current behavior (updates)

`Textarea` merged defaults/context/user props with object spread, so context props could overwrite user-provided `className`, `style`, `css`, `ref`, and `on*` handlers.

## New behavior

`Textarea` now uses the canonical `mergeProps({ rows: 2 }, context, props)()` pattern to merge these props correctly. Added a regression test to verify `className`, `style`, and click handler merging from context and user props.

## Is this a breaking change (Yes/No):

No

## Additional Information

Added changeset: `.changeset/gentle-canvas-merge.md`.
