### PR TITLE
fix(popover): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/calm-waves-popover.md
+++ b/.changeset/calm-waves-popover.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `Popover` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/popover/popover.test.tsx
+++ b/packages/react/src/components/popover/popover.test.tsx
@@ -259,8 +259,35 @@ describe("<Popover />", () => {
     )
     expect(screen.getByTestId("fn-child")).toHaveTextContent("open")
   })
-})
 
+  test("should merge `onOpen` and `onClose` from props context and root props", async () => {
+    const onContextOpen = vi.fn()
+    const onContextClose = vi.fn()
+    const onRootOpen = vi.fn()
+    const onRootClose = vi.fn()
+    const { user } = render(
+      <Popover.PropsContext
+        value={{ onClose: onContextClose, onOpen: onContextOpen }}
+      >
+        <Component onClose={onRootClose} onOpen={onRootOpen} />
+      </Popover.PropsContext>,
+    )
+
+    const triggerButton = await screen.findByRole("button", {
+      name: "Popover Trigger",
+    })
+
+    await user.click(triggerButton)
+
+    expect(onContextOpen).toHaveBeenCalledTimes(1)
+    expect(onRootOpen).toHaveBeenCalledTimes(1)
+
+    await user.keyboard("{escape}")
+
+    expect(onContextClose).toHaveBeenCalledTimes(1)
+    expect(onRootClose).toHaveBeenCalledTimes(1)
+  })
+})
 describe("usePopupAnimationProps", () => {
   test("returns scale animation props by default", () => {
     const { result } = renderHook(() => usePopupAnimationProps())

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -15,7 +15,7 @@ import type { PopoverStyle } from "./popover.style"
 import type { UsePopoverProps, UsePopoverReturn } from "./use-popover"
 import { AnimatePresence } from "motion/react"
 import { useMemo } from "react"
-import { createSlotComponent } from "../../core"
+import { createSlotComponent, mergeProps } from "../../core"
 import { useValue } from "../../hooks/use-value"
 import { cast, runIfFn } from "../../utils"
 import { fadeScaleVariants } from "../fade-scale"
@@ -185,7 +185,7 @@ export { PopoverPropsContext, usePopoverPropsContext }
 export const PopoverRoot: FC<PopoverRootProps> = (props) => {
   const styleProps = usePopoverStyleProps(props)
   const [styleContext, { animationScheme, children, duration, ...rest }] =
-    useRootComponentProps({ ...props, ...styleProps })
+    useRootComponentProps(mergeProps(props, styleProps)())
   const {
     open,
     getAnchorProps,


### PR DESCRIPTION
Closes #6448

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use `mergeProps` in `PopoverRoot` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with style props instead of being silently overwritten by plain object spread.

## Current behavior (updates)

`PopoverRoot` uses `{ ...props, ...styleProps }` which drops user-provided `className`/`style`/event handlers when both sides set them.

## New behavior

Uses `mergeProps(props, styleProps)()` to safely merge all overlapping props.

## Is this a breaking change (Yes/No):

No

## Additional Information

Part of tracking issue #6430.