### PR TITLE
fix(sidebar): merge user props with context props in SidebarItemTooltip via mergeProps

### DIFF
--- a/.changeset/soft-tooltip-merge.md
+++ b/.changeset/soft-tooltip-merge.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Use `mergeProps` in `SidebarItemTooltip` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with context/getter props instead of being silently overwritten.

--- a/packages/react/src/components/sidebar/sidebar.test.tsx
+++ b/packages/react/src/components/sidebar/sidebar.test.tsx
@@ -631,6 +631,57 @@ describe("<Sidebar />", () => {
     expect(screen.getByRole("link", { name: "3" })).toBeInTheDocument()
   })
 
+  test("should merge `tooltipProps` from side panel and item without overwriting user props", async () => {
+    const onSidePanelClick = vi.fn()
+    const onItemClick = vi.fn()
+
+    render(
+      <Sidebar.Root
+        disclosure={{ desktop: { defaultOpen: false } }}
+        mode="icon"
+      >
+        <Sidebar.SidePanel
+          tooltipProps={{
+            className: "from-side-panel",
+            style: { color: "red" },
+            onClick: onSidePanelClick,
+          }}
+        >
+          <Sidebar.Content>
+            <Sidebar.Item
+              label="tooltip-item"
+              value="/tooltip-item"
+              tooltipProps={{
+                className: "from-item",
+                style: { backgroundColor: "blue" },
+                onClick: onItemClick,
+              }}
+            />
+          </Sidebar.Content>
+        </Sidebar.SidePanel>
+      </Sidebar.Root>,
+    )
+
+    fireEvent.pointerEnter(screen.getByRole("link", { name: "tooltip-item" }), {
+      pointerType: "mouse",
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toBeInTheDocument()
+    })
+
+    const tooltip = screen.getByRole("tooltip")
+
+    expect(tooltip).toHaveClass("from-side-panel", "from-item")
+    expect(tooltip).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(tooltip).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(tooltip)
+
+    expect(onSidePanelClick).toHaveBeenCalledTimes(1)
+    expect(onItemClick).toHaveBeenCalledTimes(1)
+  })
+
   test("should load async children when defaultExpandedValue triggers later", async () => {
     const asyncChildren = vi.fn(() =>
       Promise.resolve([{ label: "lazy-1", value: "/lazy/1" }]),

--- a/packages/react/src/components/sidebar/sidebar.tsx
+++ b/packages/react/src/components/sidebar/sidebar.tsx
@@ -1359,7 +1359,7 @@ interface SidebarItemTooltipProps extends TooltipProps {}
 
 const SidebarItemTooltip: FC<SidebarItemTooltipProps> = (props) => {
   const { tooltipProps } = useItemComponentContext()
-  const { children, disabled, ...rest } = { ...tooltipProps, ...props }
+  const { children, disabled, ...rest } = mergeProps(tooltipProps, props)()
   const { mode, placement } = useComponentContext()
   const offcanvas = mode === "offcanvas"
 


### PR DESCRIPTION
Closes #6450

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use `mergeProps` in `SidebarItemTooltip` so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with tooltip context props instead of being silently overwritten by plain object spread.

## Current behavior (updates)

`SidebarItemTooltip` uses `{ ...tooltipProps, ...props }` which drops context-side values when users pass the same props.

## New behavior

Uses `mergeProps(tooltipProps, props)()` to safely merge all overlapping props.

## Is this a breaking change (Yes/No):

No

## Additional Information

Part of tracking issue #6430.