### PR TITLE
fix(pagination): merge user props with context props via mergeProps

### DIFF
--- a/.changeset/rapid-pandas-sing.md
+++ b/.changeset/rapid-pandas-sing.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fix Pagination item triggers overwrite user props by merging props via mergeProps.

--- a/packages/react/src/components/pagination/pagination.test.tsx
+++ b/packages/react/src/components/pagination/pagination.test.tsx
@@ -38,6 +38,77 @@ describe("<Pagination />", () => {
     ).toBeNull()
   })
 
+  test("merges `controlProps` with `controlPrevProps` without overwriting props", () => {
+    const onControlClick = vi.fn()
+    const onControlPrevClick = vi.fn()
+
+    render(
+      <Pagination.Root
+        defaultPage={2}
+        total={10}
+        controlPrevProps={{
+          className: "from-control-prev",
+          style: { backgroundColor: "blue" },
+          onClick: onControlPrevClick,
+        }}
+        controlProps={{
+          className: "from-control",
+          style: { color: "red" },
+          onClick: onControlClick,
+        }}
+      />,
+    )
+
+    const prevButton = screen.getByRole("button", {
+      name: /Go to previous page/i,
+    })
+
+    expect(prevButton).toHaveClass("from-control", "from-control-prev")
+    expect(prevButton).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(prevButton).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(prevButton)
+
+    expect(onControlClick).toHaveBeenCalledTimes(1)
+    expect(onControlPrevClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("merges `edgeProps` with `edgeStartProps` without overwriting props", () => {
+    const onEdgeClick = vi.fn()
+    const onEdgeStartClick = vi.fn()
+
+    render(
+      <Pagination.Root
+        defaultPage={2}
+        total={10}
+        withEdges
+        edgeProps={{
+          className: "from-edge",
+          style: { color: "red" },
+          onClick: onEdgeClick,
+        }}
+        edgeStartProps={{
+          className: "from-edge-start",
+          style: { backgroundColor: "blue" },
+          onClick: onEdgeStartClick,
+        }}
+      />,
+    )
+
+    const startButton = screen.getByRole("button", {
+      name: /Go to first page/i,
+    })
+
+    expect(startButton).toHaveClass("from-edge", "from-edge-start")
+    expect(startButton).toHaveStyle({ color: "rgb(255, 0, 0)" })
+    expect(startButton).toHaveStyle({ backgroundColor: "rgb(0, 0, 255)" })
+
+    fireEvent.click(startButton)
+
+    expect(onEdgeClick).toHaveBeenCalledTimes(1)
+    expect(onEdgeStartClick).toHaveBeenCalledTimes(1)
+  })
+
   test("navigates to next page when next trigger is clicked", () => {
     const onChange = vi.fn()
     render(<Pagination.Root defaultPage={1} total={10} onChange={onChange} />)

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -11,7 +11,7 @@ import type { ReactNodeOrFunction } from "../../utils"
 import type { PaginationStyle } from "./pagination.style"
 import type { Page, UsePaginationProps } from "./use-pagination"
 import { cloneElement, isValidElement, useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { useI18n } from "../../providers/i18n-provider"
 import { isNumber, runIfFn } from "../../utils"
 import { ButtonGroup } from "../button"
@@ -194,8 +194,7 @@ export const PaginationRoot = withProvider<
             <PaginationStartTrigger>
               <PaginationItem
                 icon={<ChevronsLeftIcon />}
-                {...edgeProps}
-                {...edgeStartProps}
+                {...mergeProps(edgeProps, edgeStartProps)()}
               />
             </PaginationStartTrigger>,
           )
@@ -204,8 +203,7 @@ export const PaginationRoot = withProvider<
             <PaginationPrevTrigger>
               <PaginationItem
                 icon={<ChevronLeftIcon />}
-                {...controlProps}
-                {...controlPrevProps}
+                {...mergeProps(controlProps, controlPrevProps)()}
               />
             </PaginationPrevTrigger>,
           )
@@ -233,8 +231,7 @@ export const PaginationRoot = withProvider<
             <PaginationNextTrigger>
               <PaginationItem
                 icon={<ChevronRightIcon />}
-                {...controlProps}
-                {...controlNextProps}
+                {...mergeProps(controlProps, controlNextProps)()}
               />
             </PaginationNextTrigger>,
           )
@@ -243,8 +240,7 @@ export const PaginationRoot = withProvider<
             <PaginationEndTrigger>
               <PaginationItem
                 icon={<ChevronsRightIcon />}
-                {...edgeProps}
-                {...edgeEndProps}
+                {...mergeProps(edgeProps, edgeEndProps)()}
               />
             </PaginationEndTrigger>,
           )


### PR DESCRIPTION
Closes #6451

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use `mergeProps` in `Pagination` trigger items so that user-provided `className`, `style`, `css`, `ref`, and `on*` event handlers are merged with edge/control props instead of being silently overwritten by JSX double spread.

## Current behavior (updates)

`PaginationRoot` uses JSX double spread (`{...edgeProps} {...edgeStartProps}`, etc.) which drops the first spread's values when both set the same prop.

## New behavior

Uses `mergeProps(edgeProps, edgeStartProps)()` etc. to safely merge all overlapping props.

## Is this a breaking change (Yes/No):

No

## Additional Information

Part of tracking issue #6430.