### PR TITLE
docs(agents): remove manual format/lint/typecheck from workflow

### DIFF
--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-issue
-description: Fix a GitHub issue end-to-end following yamada-ui conventions. Analyzes the issue, implements the fix, writes tests, runs quality checks, and creates a PR.
+description: Fix a GitHub issue end-to-end following yamada-ui conventions. Analyzes the issue, implements the fix, writes tests, and creates a PR.
 argument-hint: "<issue-number-or-url>"
 ---
 
@@ -99,15 +99,7 @@ pnpm react test:jsdom --run src/hooks/<name>/
 
 ---
 
-## Step 6: Run Quality Checks
-
-Run quality checks for **all** affected packages. If changes touch multiple packages, run checks for each.
-
-**Fix all failures before proceeding.**
-
----
-
-## Step 7: Create a Changeset (if needed)
+## Step 6: Create a Changeset (if needed)
 
 Follow the changeset rules in AGENTS.md. Name the file with a randomly-generated phrase (e.g., `purple-foxes-smile.md`), matching the project's existing convention. Check for name collisions.
 
@@ -115,7 +107,7 @@ If changes span multiple packages, list all affected packages in the changeset f
 
 ---
 
-## Step 8: Commit
+## Step 7: Commit
 
 Run `git status --short` to review all changes. Verify no unexpected files appear.
 
@@ -123,7 +115,7 @@ Stage only the specific files you changed. Commit with a conventional commit mes
 
 ---
 
-## Step 9: Push & Create PR
+## Step 8: Push & Create PR
 
 **Before pushing, ask the user for confirmation.** Show them:
 
@@ -153,6 +145,5 @@ After creating the PR, check CI status and inform the user if it fails.
 - **Issue is unclear**: Stop after Step 1 and explain what information is missing. Do not guess.
 - **Multiple unrelated areas affected**: Fix only what the issue describes. Mention other issues but do not fix them.
 - **Generated files need updating**: Run the appropriate generation command rather than editing generated files manually.
-- **Quality checks fail**: Fix all failures before committing.
 - **Branch already exists**: Ask the user before reusing or deleting an existing branch.
 - **Uncommitted changes**: Never silently switch branches with dirty working tree. Alert the user first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Yamada UI is a React UI component library built with CSS-in-JS (Emotion).
 - **Tests are required**: Always write tests when fixing bugs or adding new features.
 - **Accessibility is required**: All components must support ARIA attributes, keyboard navigation, and screen readers. Report any concerns.
 - **Do not bundle multiple fixes**: If you encounter a separate issue while working on a fix, do not fix it in the same PR. Create a separate issue and submit a separate PR.
+- **Do not run format, lint, or typecheck unless explicitly asked**: Format and lint are handled by lefthook on commit, and all three are validated by the Quality GitHub Action on PR. Only run tests locally to verify the changes work correctly.
 
 ## Codebase structure
 


### PR DESCRIPTION
## Summary

- AGENTS.md の Critical Rules に「format/lint/typecheck は明示的に指示されない限り実行しない」ルールを追加
- fix-issue スキルから「Run Quality Checks」ステップを削除し、Step 番号を繰り上げ
- lefthook (commit 時) と Quality GitHub Action (PR 時) で二重に担保されているため、手動実行は不要

## Test plan

- [ ] AGENTS.md の Critical Rules セクションに新ルールが表示されることを確認
- [ ] fix-issue スキルの Step 番号が連続していることを確認