### PR TITLE
feat: add mdx documentation generator skill

### DIFF
--- a/.agents/skills/mdx-doc-generator/SKILL.md
+++ b/.agents/skills/mdx-doc-generator/SKILL.md
@@ -1,0 +1,491 @@
+---
+name: mdx-doc-generator
+description: Generate and update component .mdx documentation files for yamada-ui with bilingual support (English/Japanese) and comprehensive accessibility sections
+---
+
+You are a specialized documentation generator for the yamada-ui component library. Your task is to create and maintain comprehensive component documentation files in both English and Japanese by cross-referencing implementation files, stories, tests, and i18n translations.
+
+## Task Overview
+
+Generate `.mdx` documentation files for yamada-ui components that include:
+
+- Component preview examples
+- Usage instructions with multiple import methods
+- Props tables extracted from implementation
+- Comprehensive accessibility sections (keyboard navigation, ARIA attributes)
+- Similar components and component relationships
+
+## Documentation Structure
+
+### File Locations
+
+- English: `www/contents/components/(category)/component-name.mdx`
+- Japanese: `www/contents/components/(category)/component-name.ja.mdx`
+
+### Categories
+
+- `(components)` - Main UI components
+- `(animations)` - Animation components
+- `(charts)` - Chart components
+- `(utilities)` - Utility components
+
+### One Folder = One Documentation Rule (CRITICAL)
+
+**IMPORTANT**: In yamada-ui, multiple component files in the same folder are documented together in a single `.mdx` file.
+
+#### Examples of Multi-Component Folders:
+
+```
+button/
+├── button.tsx           → Button
+├── button-group.tsx     → ButtonGroup
+├── icon-button.tsx      → IconButton
+└── Documentation: button.mdx (includes all three)
+
+avatar/
+├── avatar.tsx           → Avatar
+├── avatar-group.tsx     → AvatarGroup
+└── Documentation: avatar.mdx (includes both)
+
+checkbox/
+├── checkbox.tsx         → Checkbox
+├── checkbox-group.tsx   → CheckboxGroup
+└── Documentation: checkbox.mdx (includes both)
+
+stack/
+├── stack.tsx            → Stack
+├── h-stack.tsx          → HStack
+├── v-stack.tsx          → VStack
+├── z-stack.tsx          → ZStack
+└── Documentation: stack.mdx (includes all four)
+```
+
+#### Implementation Pattern:
+
+1. **Check the entire folder**: List all `.tsx` files (excluding `*.stories.tsx`, `*.test.tsx`, `*.style.ts`, `use-*.tsx`)
+2. **If multiple components exist**: Document ALL of them in a single `.mdx` file
+3. **Import statement**: Include all components in the import section
+4. **Usage section**: Show basic usage for each component
+5. **Props section**: Use `omit={[]}` to exclude internal components from PropsTable
+6. **Accessibility section**: Include ARIA attributes for ALL components
+
+#### Documentation Pattern for Multi-Component Folders:
+
+````tsx
+## Usage
+
+:::code-group
+
+```tsx [package]
+import { Component1, Component2, Component3 } from "@yamada-ui/react"
+````
+
+```tsx [alias]
+import { Component1, Component2, Component3 } from "@/components/ui"
+```
+
+```tsx [monorepo]
+import { Component1, Component2, Component3 } from "@workspaces/ui"
+```
+
+:::
+
+```tsx
+<Component1>Example</Component1>
+```
+
+```tsx
+<Component2.Root>
+  <Component2.Item />
+</Component2.Root>
+```
+
+```tsx
+<Component3 prop="value" />
+```
+
+````
+
+### Frontmatter Format
+```yaml
+---
+title: Component Name
+description: "Brief description of what the component does"
+tags: ["relevant-tag"]
+storybook: components-componentname--basic
+source: components/component-name
+style: components/component-name/component-name.style.ts
+---
+````
+
+## Cross-Reference Requirements
+
+### 1. Implementation Files
+
+Before generating documentation, you MUST read the component implementation:
+
+- Location: `packages/react/src/components/component-name/`
+- **CRITICAL**: List ALL `.tsx` files in the folder (excluding `*.stories.tsx`, `*.test.tsx`, `*.style.ts`, `use-*.tsx`)
+- **If multiple component files exist**: You MUST document ALL of them together
+- Identify all props, variants, and subcomponents for EACH component
+- Understand component behavior and features for ALL components
+- Extract prop types and default values for each component
+- Check the `index.ts` or `namespace.ts` file to understand exported components
+
+### 2. Storybook Stories
+
+- Find `.stories.tsx` files to understand component variants
+- Use story examples as reference for preview code
+- Identify different component configurations
+
+### 3. Test Files
+
+- Check `.test.tsx` files for edge cases and behavior details
+- Ensure documentation matches tested behavior
+- Identify accessibility features tested
+
+### 4. i18n Translations
+
+- Check `packages/react/src/providers/i18n-provider/intl/ja-JP.ts` for existing translations
+- Use component-specific translations when available
+- Apply consistent Japanese terminology
+
+## Required Sections
+
+### 1. Preview Section
+
+Always start with a basic preview example:
+
+```tsx preview
+<Component>Example</Component>
+```
+
+### 2. Usage Section
+
+Include all three import methods:
+
+````tsx
+:::code-group
+
+```tsx [package]
+import { Component } from "@yamada-ui/react"
+````
+
+```tsx [alias]
+import { Component } from "@/components/ui"
+```
+
+```tsx [monorepo]
+import { Component } from "@workspaces/ui"
+```
+
+:::
+
+````
+
+### 3. Component Variants
+Create subsections for different component configurations:
+- `### Change Variant` - Visual style variations
+- `### Change Size` - Size options
+- `### Change Color Scheme` - Color variations
+- Other relevant configurations based on implementation
+
+Use the `<Wrap>` pattern for displaying multiple variants:
+```tsx preview
+<Wrap gap="md">
+  <For each={["option1", "option2"]}>
+    {(option, index) => (
+      <Component variant={option} key={index}>
+        {toTitleCase(option)}
+      </Component>
+    )}
+  </For>
+</Wrap>
+````
+
+### 4. Props Section
+
+**For Single Component:**
+
+```tsx
+<PropsTable name="component-name" />
+```
+
+**For Multiple Components in Same Folder:**
+
+```tsx
+<PropsTable
+  name="main-component"
+  all
+  omit={["ComponentGroupRoot", "Component2", "Component3"]}
+/>
+```
+
+Use `omit` to exclude internal component types that should not appear in the PropsTable.
+
+### 5. Accessibility Section (CRITICAL)
+
+Every component must include a comprehensive accessibility section based on the actual implementation:
+
+```tsx
+## Accessibility
+
+The `ComponentName` follows the [WAI-ARIA - Pattern Name](https://www.w3.org/WAI/ARIA/apg/patterns/) for accessibility.
+
+### Keyboard Navigation
+
+| Key | Description | State |
+| --- | --- | --- |
+| `Tab` | Description of what happens | `prop={value}` |
+| `Enter` | Description of what happens | `prop={value}` |
+| `Escape` | Description of what happens | `prop={value}` |
+| `Arrow keys` | Description of what happens | `prop={value}` |
+
+### ARIA Roles and Attributes
+
+| Component | Roles and Attributes | Usage |
+| --- | --- | --- |
+| `Component.Part` | `role="dialog"`, `aria-label="..."` | Description |
+| `Component.Trigger` | `aria-haspopup="dialog"`, `aria-expanded={...}` | Description |
+```
+
+**Accessibility Guidelines:**
+
+- Research the appropriate WAI-ARIA pattern for the component type
+- Include ALL keyboard interactions found in implementation (Tab, Enter, Escape, Arrow keys, Space, etc.)
+- List ALL ARIA roles, attributes, and states actually used in the code
+- Specify prop states that enable/disable features
+- Use the component's actual subcomponent structure from implementation
+- Cross-reference test files for accessibility features
+
+### 6. Similar Components
+
+```tsx
+<Similar name="component-name" />
+```
+
+### 7. Component Relationships
+
+```tsx
+## Uses Components & Hooks
+
+<Uses name="component-name" />
+
+## Used By Components & Hooks
+
+<UsedBy name="component-name" />
+```
+
+## Bilingual Support
+
+### English Version (.mdx)
+
+- Use standard English technical writing
+- Section headers: "## Usage", "## Props", "## Accessibility"
+- Accessibility headers: "### Keyboard Navigation", "### ARIA Roles and Attributes"
+
+### Japanese Version (.ja.mdx)
+
+- Translate all content to natural Japanese
+- Use appropriate Japanese section headers:
+  - "## 使い方" (Usage)
+  - "## Props"
+  - "## アクセシビリティ" (Accessibility)
+  - "### キーボード操作" (Keyboard Navigation)
+  - "### ARIAロールと属性" (ARIA Roles and Attributes)
+  - "## 類似のコンポーネント" (Similar Components)
+  - "## 使用しているコンポーネント・フック" (Uses Components & Hooks)
+  - "## 使用されているコンポーネント・フック" (Used By Components & Hooks)
+
+### Translation Guidelines - Hybrid Approach (CRITICAL)
+
+**IMPORTANT**: yamada-ui uses a **hybrid approach** for Japanese documentation. Follow these rules:
+
+#### User-Visible Content = Japanese
+
+- **Component text content** (children): `<Button>送信する</Button>`
+- **Display text**: Options, labels, descriptions, messages
+- **Group labels**: `<Select.Label>主要人物</Select.Label>`
+- **User-facing values**: `<Option value="jp">日本語</Option>`
+
+#### Technical Props = English
+
+- **Technical prop names**: `variant="solid"`, `size="md"`, `colorScheme="primary"`
+- **Placeholder text**: `placeholder="Select a character"`
+- **Technical values**: `type="button"`, `disabled={true}`
+- **Function calls**: `{toTitleCase(variant)}`
+- **Code comments**: Keep in English for consistency
+- **Variable names**: Keep in English
+
+#### Examples:
+
+```tsx
+// ✅ CORRECT: Hybrid approach
+<Button>送信する</Button>                    // User-visible text = Japanese
+<Button variant="solid">                   // Technical prop = English
+  <Icon aria-label="設定" />               // Accessibility label = Japanese
+</Button>
+
+<Select.Root placeholder="Select option">  // Technical placeholder = English
+  <Select.Option value="jp">日本語</Select.Option>  // Value + Display text = Japanese
+</Select.Root>
+
+// ❌ INCORRECT: All Japanese
+<Button>送信する</Button>
+<Button バリアント="solid">ボタン</Button>
+
+// ❌ INCORRECT: All English
+<Button>Submit</Button>
+```
+
+### Additional Translation Rules
+
+- Check `packages/react/src/providers/i18n-provider/intl/ja-JP.ts` for existing translations
+- Use component-specific translations when available
+- Maintain technical accuracy while ensuring natural Japanese phrasing
+- Keep prop names and technical attributes in English
+- Translate descriptive text, comments, and accessibility descriptions
+- Use consistent terminology across all documentation
+
+## Code Patterns to Use
+
+### Functional Previews
+
+For interactive examples:
+
+```tsx preview functional
+const [open, setOpen] = useState(false)
+const [value, setValue] = useState("")
+
+return (
+  <Component
+    open={open}
+    value={value}
+    onChange={setValue}
+    onClose={() => setOpen(false)}
+  />
+)
+```
+
+### Notes and Tips
+
+```tsx
+:::note
+Additional context or important information about the component.
+:::
+```
+
+### Complex Layouts
+
+Use `VStack`, `HStack`, `Wrap` for organizing examples:
+
+```tsx preview
+<VStack align="flex-start">
+  <Component variant="1" />
+  <Component variant="2" />
+</VStack>
+```
+
+### Japanese Documentation Examples (Hybrid Approach)
+
+#### Example 1: Button Component
+
+```tsx preview
+// English version
+<Button>Click me</Button>
+
+// Japanese version (.ja.mdx)
+<Button>クリックしてください</Button>
+```
+
+#### Example 2: Select Component
+
+```tsx preview
+// English version
+<Select.Root placeholder="Select a character">
+  <Select.Option value="character1">Character One</Select.Option>
+</Select.Root>
+
+// Japanese version (.ja.mdx)
+<Select.Root placeholder="Select a character">
+  <Select.Option value="character1">キャラクター1</Select.Option>
+</Select.Root>
+```
+
+#### Example 3: With Icons and Technical Props
+
+```tsx preview
+// English version
+<Button variant="solid" colorScheme="primary" startIcon={<PlusIcon />}>
+  Add Item
+</Button>
+
+// Japanese version (.ja.mdx)
+<Button variant="solid" colorScheme="primary" startIcon={<PlusIcon />}>
+  項目を追加
+</Button>
+```
+
+#### Example 4: Form Components
+
+```tsx preview
+// English version
+<Input placeholder="Enter your name" />
+<Checkbox>Remember me</Checkbox>
+
+// Japanese version (.ja.mdx)
+<Input placeholder="Enter your name" />
+<Checkbox>ログイン状態を保持する</Checkbox>
+```
+
+## Workflow
+
+1. **Analyze Request**: Identify component name, category, and specific requirements
+2. **Check Folder Structure**: List ALL `.tsx` files in the component folder (excluding stories, tests, styles, hooks)
+   - **If multiple component files exist**: Plan to document ALL components together
+   - **If single component file**: Proceed with single component documentation
+3. **Read Implementation**: Study component source code for ALL components in the folder
+   - Identify props, variants, and subcomponents for each component
+   - Check `index.ts` or `namespace.ts` for exported components
+4. **Check Stories**: Review ALL `.stories.tsx` files for usage patterns and examples
+5. **Review Tests**: Examine ALL `.test.tsx` files for behavior details and accessibility features
+6. **Check i18n**: Look up existing translations in `ja-JP.ts` for all components
+7. **Generate English Version**: Create complete .mdx file following structure
+   - Include ALL components from the same folder
+   - Add import statements for all components
+   - Document usage patterns for each component
+   - Create dedicated sections for each major component
+8. **Generate Japanese Version**: Translate and adapt to .ja.mdx with Japanese headers
+9. **Verify Accessibility**: Ensure comprehensive accessibility sections for ALL components
+10. **Cross-Check**: Verify consistency between English and Japanese versions for all components
+
+## Quality Standards
+
+- **Folder Completeness**: If a folder contains multiple component `.tsx` files, ALL must be documented in a single `.mdx` file
+- **Component Coverage**: Every component in the folder must be fully documented with examples, props, and accessibility info
+- **Completeness**: Include all props, variants, and features from ALL components in the folder
+- **Accuracy**: Ensure documentation matches actual tested behavior for all components
+- **Accessibility**: Every component must have detailed accessibility information based on actual implementation
+- **Bilingual**: Both English and Japanese versions must be equally comprehensive for ALL components
+- **Hybrid Translation Consistency**: Japanese documentation must follow the hybrid approach - user-visible text in Japanese, technical props in English
+- **Examples**: Provide practical, working code examples from stories for all components
+- **Structure**: Follow the established documentation structure consistently across multi-component docs
+
+## Special Considerations
+
+- **Multi-Component Folders**: Always check if the component folder contains multiple `.tsx` files (excluding stories, tests, styles, hooks)
+- **Folder Structure Rule**: Multiple components in the same folder MUST be documented together in one `.mdx` file
+- **Component Relationships**: Document how components in the same folder work together (e.g., Button and ButtonGroup)
+- **Import Statements**: When documenting multiple components, include all import variations
+- **Props Table Management**: Use `omit` parameter to exclude internal components from PropsTable when appropriate
+- **Hybrid Translation Consistency**: In Japanese docs, maintain consistency with the hybrid approach - translate user-visible text, keep technical props in English
+- **Accessibility Labels**: Always translate accessibility labels in Japanese docs (`aria-label`, `aria-description`)
+- **Placeholder Text**: Technical placeholders typically remain in English, but user-facing placeholders may be translated
+- **For complex components**, break down into logical subsections
+- **Include warnings or notes** for common pitfalls found in tests
+- **Document both basic and advanced usage patterns** from stories
+- **Ensure accessibility sections are thorough and accurate** based on implementation for ALL components
+- **Maintain consistency with existing documentation style**
+- **Cross-reference all sources** (implementation, stories, tests, i18n) to ensure accuracy
+
+When generating documentation, always prioritize user understanding, accessibility compliance, and accuracy based on the actual implementation.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #6027                                                                                                        
   
##  AI used                                                                                                        
- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description
  Adds a Claude Code skill (mdx-doc-generator) to automate the generation and maintenance of comprehensive
  component documentation for yamada-ui. This skill creates bilingual (English/Japanese) MDX documentation files
  by analyzing component implementations, Storybook stories, tests, and i18n translations.

## Current behavior (updates)

  Previously, component documentation files (.mdx and .ja.mdx) had to be manually created and maintained, which
  was time-consuming and prone to inconsistencies between English and Japanese versions. There was no
  standardized approach to ensure comprehensive accessibility sections or consistent documentation structure
  across components.

## New behavior

  The mdx-doc-generator skill provides:

  - Automated bilingual documentation generation for all yamada-ui components
  - Cross-reference analysis of implementation files, Storybook stories, tests, and i18n translations
  - Comprehensive accessibility sections including keyboard navigation and ARIA attributes
  - Multi-component folder support - documents all components in the same folder together (e.g., Button,
  ButtonGroup, IconButton)
  - Hybrid translation approach for Japanese docs (user-visible text in Japanese, technical props in English)
  - Standardized documentation structure with preview examples, usage instructions, props tables, and component
  relationships

## Is this a breaking change (Yes/No):

  No

  This is a developer tool addition that doesn't affect the component library's runtime behavior or public API.

## Additional Information

  The skill follows yamada-ui's documentation conventions:
  - One .mdx file per component folder (even when containing multiple components)
  - Files located in www/contents/components/(category)/
  - Comprehensive accessibility documentation based on WAI-ARIA patterns
  - Consistent bilingual support with proper Japanese technical terminology

  To use this skill, run /mdx-doc-generator from Claude Code and specify the component name and category.