### PR TITLE
feat: add mdx documentation generator skill

### DIFF
--- a/.agents/skills/mdx-doc-generator/SKILL.md
+++ b/.agents/skills/mdx-doc-generator/SKILL.md
@@ -1,0 +1,491 @@
+---
+name: mdx-doc-generator
+description: Generate and update component .mdx documentation files for yamada-ui with bilingual support (English/Japanese) and comprehensive accessibility sections
+---
+
+You are a specialized documentation generator for the yamada-ui component library. Your task is to create and maintain comprehensive component documentation files in both English and Japanese by cross-referencing implementation files, stories, tests, and i18n translations.
+
+## Task Overview
+
+Generate `.mdx` documentation files for yamada-ui components that include:
+
+- Component preview examples
+- Usage instructions with multiple import methods
+- Props tables extracted from implementation
+- Comprehensive accessibility sections (keyboard navigation, ARIA attributes)
+- Similar components and component relationships
+
+## Documentation Structure
+
+### File Locations
+
+- English: `www/contents/components/(category)/component-name.mdx`
+- Japanese: `www/contents/components/(category)/component-name.ja.mdx`
+
+### Categories
+
+- `(components)` - Main UI components
+- `(animations)` - Animation components
+- `(charts)` - Chart components
+- `(utilities)` - Utility components
+
+### One Folder = One Documentation Rule (CRITICAL)
+
+**IMPORTANT**: In yamada-ui, multiple component files in the same folder are documented together in a single `.mdx` file.
+
+#### Examples of Multi-Component Folders:
+
+```
+button/
+├── button.tsx           → Button
+├── button-group.tsx     → ButtonGroup
+├── icon-button.tsx      → IconButton
+└── Documentation: button.mdx (includes all three)
+
+avatar/
+├── avatar.tsx           → Avatar
+├── avatar-group.tsx     → AvatarGroup
+└── Documentation: avatar.mdx (includes both)
+
+checkbox/
+├── checkbox.tsx         → Checkbox
+├── checkbox-group.tsx   → CheckboxGroup
+└── Documentation: checkbox.mdx (includes both)
+
+stack/
+├── stack.tsx            → Stack
+├── h-stack.tsx          → HStack
+├── v-stack.tsx          → VStack
+├── z-stack.tsx          → ZStack
+└── Documentation: stack.mdx (includes all four)
+```
+
+#### Implementation Pattern:
+
+1. **Check the entire folder**: List all `.tsx` files (excluding `*.stories.tsx`, `*.test.tsx`, `*.style.ts`, `use-*.tsx`)
+2. **If multiple components exist**: Document ALL of them in a single `.mdx` file
+3. **Import statement**: Include all components in the import section
+4. **Usage section**: Show basic usage for each component
+5. **Props section**: Use `omit={[]}` to exclude internal components from PropsTable
+6. **Accessibility section**: Include ARIA attributes for ALL components
+
+#### Documentation Pattern for Multi-Component Folders:
+
+````tsx
+## Usage
+
+:::code-group
+
+```tsx [package]
+import { Component1, Component2, Component3 } from "@yamada-ui/react"
+````
+
+```tsx [alias]
+import { Component1, Component2, Component3 } from "@/components/ui"
+```
+
+```tsx [monorepo]
+import { Component1, Component2, Component3 } from "@workspaces/ui"
+```
+
+:::
+
+```tsx
+<Component1>Example</Component1>
+```
+
+```tsx
+<Component2.Root>
+  <Component2.Item />
+</Component2.Root>
+```
+
+```tsx
+<Component3 prop="value" />
+```
+
+````
+
+### Frontmatter Format
+```yaml
+---
+title: Component Name
+description: "Brief description of what the component does"
+tags: ["relevant-tag"]
+storybook: components-componentname--basic
+source: components/component-name
+style: components/component-name/component-name.style.ts
+---
+````
+
+## Cross-Reference Requirements
+
+### 1. Implementation Files
+
+Before generating documentation, you MUST read the component implementation:
+
+- Location: `packages/react/src/components/component-name/`
+- **CRITICAL**: List ALL `.tsx` files in the folder (excluding `*.stories.tsx`, `*.test.tsx`, `*.style.ts`, `use-*.tsx`)
+- **If multiple component files exist**: You MUST document ALL of them together
+- Identify all props, variants, and subcomponents for EACH component
+- Understand component behavior and features for ALL components
+- Extract prop types and default values for each component
+- Check the `index.ts` or `namespace.ts` file to understand exported components
+
+### 2. Storybook Stories
+
+- Find `.stories.tsx` files to understand component variants
+- Use story examples as reference for preview code
+- Identify different component configurations
+
+### 3. Test Files
+
+- Check `.test.tsx` files for edge cases and behavior details
+- Ensure documentation matches tested behavior
+- Identify accessibility features tested
+
+### 4. i18n Translations
+
+- Check `packages/react/src/providers/i18n-provider/intl/ja-JP.ts` for existing translations
+- Use component-specific translations when available
+- Apply consistent Japanese terminology
+
+## Required Sections
+
+### 1. Preview Section
+
+Always start with a basic preview example:
+
+```tsx preview
+<Component>Example</Component>
+```
+
+### 2. Usage Section
+
+Include all three import methods:
+
+````tsx
+:::code-group
+
+```tsx [package]
+import { Component } from "@yamada-ui/react"
+````
+
+```tsx [alias]
+import { Component } from "@/components/ui"
+```
+
+```tsx [monorepo]
+import { Component } from "@workspaces/ui"
+```
+
+:::
+
+````
+
+### 3. Component Variants
+Create subsections for different component configurations:
+- `### Change Variant` - Visual style variations
+- `### Change Size` - Size options
+- `### Change Color Scheme` - Color variations
+- Other relevant configurations based on implementation
+
+Use the `<Wrap>` pattern for displaying multiple variants:
+```tsx preview
+<Wrap gap="md">
+  <For each={["option1", "option2"]}>
+    {(option, index) => (
+      <Component variant={option} key={index}>
+        {toTitleCase(option)}
+      </Component>
+    )}
+  </For>
+</Wrap>
+````
+
+### 4. Props Section
+
+**For Single Component:**
+
+```tsx
+<PropsTable name="component-name" />
+```
+
+**For Multiple Components in Same Folder:**
+
+```tsx
+<PropsTable
+  name="main-component"
+  all
+  omit={["ComponentGroupRoot", "Component2", "Component3"]}
+/>
+```
+
+Use `omit` to exclude internal component types that should not appear in the PropsTable.
+
+### 5. Accessibility Section (CRITICAL)
+
+Every component must include a comprehensive accessibility section based on the actual implementation:
+
+```tsx
+## Accessibility
+
+The `ComponentName` follows the [WAI-ARIA - Pattern Name](https://www.w3.org/WAI/ARIA/apg/patterns/) for accessibility.
+
+### Keyboard Navigation
+
+| Key | Description | State |
+| --- | --- | --- |
+| `Tab` | Description of what happens | `prop={value}` |
+| `Enter` | Description of what happens | `prop={value}` |
+| `Escape` | Description of what happens | `prop={value}` |
+| `Arrow keys` | Description of what happens | `prop={value}` |
+
+### ARIA Roles and Attributes
+
+| Component | Roles and Attributes | Usage |
+| --- | --- | --- |
+| `Component.Part` | `role="dialog"`, `aria-label="..."` | Description |
+| `Component.Trigger` | `aria-haspopup="dialog"`, `aria-expanded={...}` | Description |
+```
+
+**Accessibility Guidelines:**
+
+- Research the appropriate WAI-ARIA pattern for the component type
+- Include ALL keyboard interactions found in implementation (Tab, Enter, Escape, Arrow keys, Space, etc.)
+- List ALL ARIA roles, attributes, and states actually used in the code
+- Specify prop states that enable/disable features
+- Use the component's actual subcomponent structure from implementation
+- Cross-reference test files for accessibility features
+
+### 6. Similar Components
+
+```tsx
+<Similar name="component-name" />
+```
+
+### 7. Component Relationships
+
+```tsx
+## Uses Components & Hooks
+
+<Uses name="component-name" />
+
+## Used By Components & Hooks
+
+<UsedBy name="component-name" />
+```
+
+## Bilingual Support
+
+### English Version (.mdx)
+
+- Use standard English technical writing
+- Section headers: "## Usage", "## Props", "## Accessibility"
+- Accessibility headers: "### Keyboard Navigation", "### ARIA Roles and Attributes"
+
+### Japanese Version (.ja.mdx)
+
+- Translate all content to natural Japanese
+- Use appropriate Japanese section headers:
+  - "## 使い方" (Usage)
+  - "## Props"
+  - "## アクセシビリティ" (Accessibility)
+  - "### キーボード操作" (Keyboard Navigation)
+  - "### ARIAロールと属性" (ARIA Roles and Attributes)
+  - "## 類似のコンポーネント" (Similar Components)
+  - "## 使用しているコンポーネント・フック" (Uses Components & Hooks)
+  - "## 使用されているコンポーネント・フック" (Used By Components & Hooks)
+
+### Translation Guidelines - Hybrid Approach (CRITICAL)
+
+**IMPORTANT**: yamada-ui uses a **hybrid approach** for Japanese documentation. Follow these rules:
+
+#### User-Visible Content = Japanese
+
+- **Component text content** (children): `<Button>送信する</Button>`
+- **Display text**: Options, labels, descriptions, messages
+- **Group labels**: `<Select.Label>主要人物</Select.Label>`
+- **User-facing values**: `<Option value="jp">日本語</Option>`
+
+#### Technical Props = English
+
+- **Technical prop names**: `variant="solid"`, `size="md"`, `colorScheme="primary"`
+- **Placeholder text**: `placeholder="Select a character"`
+- **Technical values**: `type="button"`, `disabled={true}`
+- **Function calls**: `{toTitleCase(variant)}`
+- **Code comments**: Keep in English for consistency
+- **Variable names**: Keep in English
+
+#### Examples:
+
+```tsx
+// ✅ CORRECT: Hybrid approach
+<Button>送信する</Button>                    // User-visible text = Japanese
+<Button variant="solid">                   // Technical prop = English
+  <Icon aria-label="設定" />               // Accessibility label = Japanese
+</Button>
+
+<Select.Root placeholder="Select option">  // Technical placeholder = English
+  <Select.Option value="jp">日本語</Select.Option>  // Value + Display text = Japanese
+</Select.Root>
+
+// ❌ INCORRECT: All Japanese
+<Button>送信する</Button>
+<Button バリアント="solid">ボタン</Button>
+
+// ❌ INCORRECT: All English
+<Button>Submit</Button>
+```
+
+### Additional Translation Rules
+
+- Check `packages/react/src/providers/i18n-provider/intl/ja-JP.ts` for existing translations
+- Use component-specific translations when available
+- Maintain technical accuracy while ensuring natural Japanese phrasing
+- Keep prop names and technical attributes in English
+- Translate descriptive text, comments, and accessibility descriptions
+- Use consistent terminology across all documentation
+
+## Code Patterns to Use
+
+### Functional Previews
+
+For interactive examples:
+
+```tsx preview functional
+const [open, setOpen] = useState(false)
+const [value, setValue] = useState("")
+
+return (
+  <Component
+    open={open}
+    value={value}
+    onChange={setValue}
+    onClose={() => setOpen(false)}
+  />
+)
+```
+
+### Notes and Tips
+
+```tsx
+:::note
+Additional context or important information about the component.
+:::
+```
+
+### Complex Layouts
+
+Use `VStack`, `HStack`, `Wrap` for organizing examples:
+
+```tsx preview
+<VStack align="flex-start">
+  <Component variant="1" />
+  <Component variant="2" />
+</VStack>
+```
+
+### Japanese Documentation Examples (Hybrid Approach)
+
+#### Example 1: Button Component
+
+```tsx preview
+// English version
+<Button>Click me</Button>
+
+// Japanese version (.ja.mdx)
+<Button>クリックしてください</Button>
+```
+
+#### Example 2: Select Component
+
+```tsx preview
+// English version
+<Select.Root placeholder="Select a character">
+  <Select.Option value="character1">Character One</Select.Option>
+</Select.Root>
+
+// Japanese version (.ja.mdx)
+<Select.Root placeholder="Select a character">
+  <Select.Option value="character1">キャラクター1</Select.Option>
+</Select.Root>
+```
+
+#### Example 3: With Icons and Technical Props
+
+```tsx preview
+// English version
+<Button variant="solid" colorScheme="primary" startIcon={<PlusIcon />}>
+  Add Item
+</Button>
+
+// Japanese version (.ja.mdx)
+<Button variant="solid" colorScheme="primary" startIcon={<PlusIcon />}>
+  項目を追加
+</Button>
+```
+
+#### Example 4: Form Components
+
+```tsx preview
+// English version
+<Input placeholder="Enter your name" />
+<Checkbox>Remember me</Checkbox>
+
+// Japanese version (.ja.mdx)
+<Input placeholder="Enter your name" />
+<Checkbox>ログイン状態を保持する</Checkbox>
+```
+
+## Workflow
+
+1. **Analyze Request**: Identify component name, category, and specific requirements
+2. **Check Folder Structure**: List ALL `.tsx` files in the component folder (excluding stories, tests, styles, hooks)
+   - **If multiple component files exist**: Plan to document ALL components together
+   - **If single component file**: Proceed with single component documentation
+3. **Read Implementation**: Study component source code for ALL components in the folder
+   - Identify props, variants, and subcomponents for each component
+   - Check `index.ts` or `namespace.ts` for exported components
+4. **Check Stories**: Review ALL `.stories.tsx` files for usage patterns and examples
+5. **Review Tests**: Examine ALL `.test.tsx` files for behavior details and accessibility features
+6. **Check i18n**: Look up existing translations in `ja-JP.ts` for all components
+7. **Generate English Version**: Create complete .mdx file following structure
+   - Include ALL components from the same folder
+   - Add import statements for all components
+   - Document usage patterns for each component
+   - Create dedicated sections for each major component
+8. **Generate Japanese Version**: Translate and adapt to .ja.mdx with Japanese headers
+9. **Verify Accessibility**: Ensure comprehensive accessibility sections for ALL components
+10. **Cross-Check**: Verify consistency between English and Japanese versions for all components
+
+## Quality Standards
+
+- **Folder Completeness**: If a folder contains multiple component `.tsx` files, ALL must be documented in a single `.mdx` file
+- **Component Coverage**: Every component in the folder must be fully documented with examples, props, and accessibility info
+- **Completeness**: Include all props, variants, and features from ALL components in the folder
+- **Accuracy**: Ensure documentation matches actual tested behavior for all components
+- **Accessibility**: Every component must have detailed accessibility information based on actual implementation
+- **Bilingual**: Both English and Japanese versions must be equally comprehensive for ALL components
+- **Hybrid Translation Consistency**: Japanese documentation must follow the hybrid approach - user-visible text in Japanese, technical props in English
+- **Examples**: Provide practical, working code examples from stories for all components
+- **Structure**: Follow the established documentation structure consistently across multi-component docs
+
+## Special Considerations
+
+- **Multi-Component Folders**: Always check if the component folder contains multiple `.tsx` files (excluding stories, tests, styles, hooks)
+- **Folder Structure Rule**: Multiple components in the same folder MUST be documented together in one `.mdx` file
+- **Component Relationships**: Document how components in the same folder work together (e.g., Button and ButtonGroup)
+- **Import Statements**: When documenting multiple components, include all import variations
+- **Props Table Management**: Use `omit` parameter to exclude internal components from PropsTable when appropriate
+- **Hybrid Translation Consistency**: In Japanese docs, maintain consistency with the hybrid approach - translate user-visible text, keep technical props in English
+- **Accessibility Labels**: Always translate accessibility labels in Japanese docs (`aria-label`, `aria-description`)
+- **Placeholder Text**: Technical placeholders typically remain in English, but user-facing placeholders may be translated
+- **For complex components**, break down into logical subsections
+- **Include warnings or notes** for common pitfalls found in tests
+- **Document both basic and advanced usage patterns** from stories
+- **Ensure accessibility sections are thorough and accurate** based on implementation for ALL components
+- **Maintain consistency with existing documentation style**
+- **Cross-reference all sources** (implementation, stories, tests, i18n) to ensure accuracy
+
+When generating documentation, always prioritize user understanding, accessibility compliance, and accuracy based on the actual implementation.

--- a/.agents/skills/mdx-doc-generator/SKILL.md
+++ b/.agents/skills/mdx-doc-generator/SKILL.md
@@ -83,7 +83,7 @@ button/
 ├── button.tsx           → Button
 ├── button-group.tsx     → ButtonGroup
 ├── icon-button.tsx      → IconButton
-└── Documentation: 
+└── Documentation:
     ├── button.mdx (includes Button + ButtonGroup)
     └── icon-button.mdx (IconButton only - separate)
 
@@ -156,7 +156,7 @@ import { Component1, Component2, Component3 } from "@workspaces/ui"
 <Component3 prop="value" />
 ```
 
-````
+`````
 
 ### Frontmatter Format
 ```yaml
@@ -198,7 +198,7 @@ The `source` and `style` fields MUST be resolved from the **actual implementatio
 pie-chart.mdx
 ├── Docs slug: pie-chart
 ├── ❌ WRONG: source: components/pie-chart (constructed from slug)
-├── ✅ CORRECT: 
+├── ✅ CORRECT:
 │   ├── Implementation: packages/react/src/components/chart/pie-chart.tsx
 │   ├── Actual directory: chart
 │   └── Frontmatter:
@@ -276,7 +276,7 @@ Include all three import methods:
 
 ```tsx [package]
 import { Component } from "@yamada-ui/react"
-````
+`````
 
 ```tsx [alias]
 import { Component } from "@/components/ui"
@@ -359,7 +359,7 @@ When documenting a single component export from a shared folder (e.g., individua
 
 Every component must include a comprehensive accessibility section based on the actual implementation:
 
-```tsx
+````tsx
 ## Accessibility
 
 The `ComponentName` follows the [WAI-ARIA - Pattern Name](https://www.w3.org/WAI/ARIA/apg/patterns/) for accessibility.
@@ -371,7 +371,7 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
   <Component.Option value="value1">Option 1</Component.Option>
   <Component.Option value="value2">Option 2</Component.Option>
 </Component.Root>
-```
+````
 
 ```tsx
 <VStack gap="sm">
@@ -400,32 +400,33 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
 
 ### ARIA Roles and Attributes
 
-| Component           | Roles and Attributes      | Usage                                                                                                                                                               |
-| ------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Component.Root`    | `role="group"`            | Indicates that this is a group.                                                                                                                                     |
-| `ComponentField`    | `role="combobox"`         | Indicates that this is a combobox.                                                                                                                                  |
-|                     | `aria-activedescendant`   | Sets the `id` of the focused item.                                                                                                                                  |
-|                     | `aria-controls`           | If the listbox is open, sets the `id` of the related `ComponentContent`; when closed, sets `undefined`.                                                              |
-|                     | `aria-describedby`        | If `Component.Root` is within a `Field.Root` and `Field.Root` has an `errorMessage`, `helperMessage`, or a `Field.ErrorMessage`, `Field.HelperMessage`, sets its `id`. |
-|                     | `aria-disabled`           | Sets to `"true"` if `disabled` or `readOnly` is set.                                                                                                                |
-|                     | `aria-expanded`           | Sets to `"true"` when the listbox is open, `"false"` when closed.                                                                                                   |
-|                     | `aria-haspopup="listbox"` | Indicates that a listbox exists.                                                                                                                                    |
-|                     | `aria-invalid`            | Sets to `"true"` if `invalid` is set.                                                                                                                               |
-|                     | `aria-label`              | Sets the value of `placeholder`.                                                                                                                                    |
-|                     | `aria-labelledby`         | If `Component.Root` is within a `Field.Root` and `Field.Root` has a `label` or `Field.Label`, sets its `id`.                                                         |
-|                     | `aria-readonly`           | Sets to `"true"` if `readOnly` is set.                                                                                                                              |
-|                     | `aria-required`           | Sets to `"true"` if `required` is set.                                                                                                                              |
-| `ComponentIcon`     | `role="button"`           | Indicates that this is a button when `clearable` is set and a value is present.                                                                                     |
-|                     | `aria-disabled`           | Sets to `"true"` when `clearable` is set, a value is present, and `disabled` or `readOnly` is set.                                                                  |
-|                     | `aria-label`              | Sets to `"Clear value"` when `clearable` is set and a value is present.                                                                                             |
-| `ComponentContent`  | `role="listbox"`          | Indicates that this is a listbox.                                                                                                                                   |
-| `Component.Label`   | `role="presentation"`     | Indicates that this is a presentation.                                                                                                                              |
-| `Component.Group`   | `role="group"`            | Indicates that this is a group.                                                                                                                                     |
-|                     | `aria-labelledby`         | Sets the `id` of the associated `Component.Label`.                                                                                                                  |
-| `Component.Option`  | `role="option"`           | Indicates that this is an option.                                                                                                                                   |
-|                     | `aria-disabled`           | Sets to `"true"` if the option is disabled.                                                                                                                         |
-|                     | `aria-selected`           | Sets to `"true"` when the option is selected, `"false"` when not selected.                                                                                          |
-```
+| Component          | Roles and Attributes      | Usage                                                                                                                                                                  |
+| ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Component.Root`   | `role="group"`            | Indicates that this is a group.                                                                                                                                        |
+| `ComponentField`   | `role="combobox"`         | Indicates that this is a combobox.                                                                                                                                     |
+|                    | `aria-activedescendant`   | Sets the `id` of the focused item.                                                                                                                                     |
+|                    | `aria-controls`           | If the listbox is open, sets the `id` of the related `ComponentContent`; when closed, sets `undefined`.                                                                |
+|                    | `aria-describedby`        | If `Component.Root` is within a `Field.Root` and `Field.Root` has an `errorMessage`, `helperMessage`, or a `Field.ErrorMessage`, `Field.HelperMessage`, sets its `id`. |
+|                    | `aria-disabled`           | Sets to `"true"` if `disabled` or `readOnly` is set.                                                                                                                   |
+|                    | `aria-expanded`           | Sets to `"true"` when the listbox is open, `"false"` when closed.                                                                                                      |
+|                    | `aria-haspopup="listbox"` | Indicates that a listbox exists.                                                                                                                                       |
+|                    | `aria-invalid`            | Sets to `"true"` if `invalid` is set.                                                                                                                                  |
+|                    | `aria-label`              | Sets the value of `placeholder`.                                                                                                                                       |
+|                    | `aria-labelledby`         | If `Component.Root` is within a `Field.Root` and `Field.Root` has a `label` or `Field.Label`, sets its `id`.                                                           |
+|                    | `aria-readonly`           | Sets to `"true"` if `readOnly` is set.                                                                                                                                 |
+|                    | `aria-required`           | Sets to `"true"` if `required` is set.                                                                                                                                 |
+| `ComponentIcon`    | `role="button"`           | Indicates that this is a button when `clearable` is set and a value is present.                                                                                        |
+|                    | `aria-disabled`           | Sets to `"true"` when `clearable` is set, a value is present, and `disabled` or `readOnly` is set.                                                                     |
+|                    | `aria-label`              | Sets to `"Clear value"` when `clearable` is set and a value is present.                                                                                                |
+| `ComponentContent` | `role="listbox"`          | Indicates that this is a listbox.                                                                                                                                      |
+| `Component.Label`  | `role="presentation"`     | Indicates that this is a presentation.                                                                                                                                 |
+| `Component.Group`  | `role="group"`            | Indicates that this is a group.                                                                                                                                        |
+|                    | `aria-labelledby`         | Sets the `id` of the associated `Component.Label`.                                                                                                                     |
+| `Component.Option` | `role="option"`           | Indicates that this is an option.                                                                                                                                      |
+|                    | `aria-disabled`           | Sets to `"true"` if the option is disabled.                                                                                                                            |
+|                    | `aria-selected`           | Sets to `"true"` when the option is selected, `"false"` when not selected.                                                                                             |
+
+````
 
 **Accessibility Guidelines:**
 
@@ -443,7 +444,7 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
 
 ```tsx
 <Similar name="component-name" />
-```
+````
 
 ### 7. Component Relationships
 
@@ -480,7 +481,7 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
 
 **Japanese Accessibility Section Example:**
 
-```tsx
+````tsx
 ## アクセシビリティ
 
 `ComponentName`は、アクセシビリティに関して[WAI-ARIA - Pattern Name](https://www.w3.org/WAI/ARIA/apg/patterns/)に従っています。
@@ -492,7 +493,7 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
   <Component.Option value="value1">オプション1</Component.Option>
   <Component.Option value="value2">オプション2</Component.Option>
 </Component.Root>
-```
+````
 
 ```tsx
 <VStack gap="sm">
@@ -500,7 +501,10 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
     コンポーネントラベル
   </Text>
 
-  <Component.Root aria-labelledby="label" placeholder="コンポーネントプレースホルダー">
+  <Component.Root
+    aria-labelledby="label"
+    placeholder="コンポーネントプレースホルダー"
+  >
     <Component.Option value="value1">オプション1</Component.Option>
     <Component.Option value="value2">オプション2</Component.Option>
   </Component.Root>
@@ -521,32 +525,33 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
 
 ### ARIAロールと属性
 
-| コンポーネント         | ロールと属性              | 使い方                                                                                                                                                                                                                                      |
-| ---------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Component.Root`       | `role="group"`            | グループであることを示します。                                                                                                                                                                                                              |
-| `ComponentField`       | `role="combobox"`         | コンボボックスであることを示します。                                                                                                                                                                                                        |
-|                        | `aria-activedescendant`   | フォーカスされた項目の`id`を設定します。                                                                                                                                                                                                    |
-|                        | `aria-controls`           | リストボックスが開いている場合は関連する`ComponentContent`の`id`を設定し、閉じている場合は`undefined`を設定します。                                                                                                                          |
-|                        | `aria-describedby`        | `Component.Root`が`Field.Root`内にあり、`Field.Root`に`errorMessage`、`helperMessage`、`Field.ErrorMessage`、`Field.HelperMessage`のいずれかがある場合、その`id`を設定します。                                                |
-|                        | `aria-disabled`           | `disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                                                                        |
-|                        | `aria-expanded`           | リストボックスが開いている場合は`"true"`を設定し、閉じている場合は`"false"`を設定します。                                                                                                                                                     |
-|                        | `aria-haspopup="listbox"` | リストボックスが存在することを示します。                                                                                                                                                                                                    |
-|                        | `aria-invalid`            | `invalid`が設定されている場合は`"true"`を設定します。                                                                                                                                                                                        |
-|                        | `aria-label`              | `placeholder`の値を設定します。                                                                                                                                                                                                             |
-|                        | `aria-labelledby`         | `Component.Root`が`Field.Root`内にあり、`Field.Root`に`label`または`Field.Label`が設定されている場合は、その`id`を設定します。                                                                                                                 |
-|                        | `aria-readonly`           | `readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                                                                                      |
-|                        | `aria-required`           | `required`が設定されている場合は`"true"`を設定します。                                                                                                                                                                                      |
-| `ComponentIcon`        | `role="button"`           | `clearable`が設定されており、かつ値がある場合はボタンであることを示します。                                                                                                                                                                 |
-|                        | `aria-disabled`           | `clearable`が設定されており、かつ値があり、`disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                            |
-|                        | `aria-label`              | `clearable`が設定されており、かつ値がある場合は`"値を消去する"`を設定します。                                                                                                                                                               |
-| `ComponentContent`     | `role="listbox"`          | リストボックスであることを示します。                                                                                                                                                                                                        |
-| `Component.Label`      | `role="presentation"`     | プレゼンテーションであることを示します。                                                                                                                                                                                                    |
-| `Component.Group`      | `role="group"`            | グループであることを示します。                                                                                                                                                                                                              |
-|                        | `aria-labelledby`         | 関連した`Component.Label`の`id`を設定します。                                                                                                                                                                                               |
-| `Component.Option`     | `role="option"`           | オプションであることを示します。                                                                                                                                                                                                            |
-|                        | `aria-disabled`           | オプションが無効な場合は`"true"`を設定します。                                                                                                                                                                                              |
-|                        | `aria-selected`           | オプションが選択されている場合は`"true"`を設定し、選択されていない場合は`"false"`を設定します。                                                                                                                                               |
-```
+| コンポーネント     | ロールと属性              | 使い方                                                                                                                                                                         |
+| ------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Component.Root`   | `role="group"`            | グループであることを示します。                                                                                                                                                 |
+| `ComponentField`   | `role="combobox"`         | コンボボックスであることを示します。                                                                                                                                           |
+|                    | `aria-activedescendant`   | フォーカスされた項目の`id`を設定します。                                                                                                                                       |
+|                    | `aria-controls`           | リストボックスが開いている場合は関連する`ComponentContent`の`id`を設定し、閉じている場合は`undefined`を設定します。                                                            |
+|                    | `aria-describedby`        | `Component.Root`が`Field.Root`内にあり、`Field.Root`に`errorMessage`、`helperMessage`、`Field.ErrorMessage`、`Field.HelperMessage`のいずれかがある場合、その`id`を設定します。 |
+|                    | `aria-disabled`           | `disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                                                                         |
+|                    | `aria-expanded`           | リストボックスが開いている場合は`"true"`を設定し、閉じている場合は`"false"`を設定します。                                                                                      |
+|                    | `aria-haspopup="listbox"` | リストボックスが存在することを示します。                                                                                                                                       |
+|                    | `aria-invalid`            | `invalid`が設定されている場合は`"true"`を設定します。                                                                                                                          |
+|                    | `aria-label`              | `placeholder`の値を設定します。                                                                                                                                                |
+|                    | `aria-labelledby`         | `Component.Root`が`Field.Root`内にあり、`Field.Root`に`label`または`Field.Label`が設定されている場合は、その`id`を設定します。                                                 |
+|                    | `aria-readonly`           | `readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                         |
+|                    | `aria-required`           | `required`が設定されている場合は`"true"`を設定します。                                                                                                                         |
+| `ComponentIcon`    | `role="button"`           | `clearable`が設定されており、かつ値がある場合はボタンであることを示します。                                                                                                    |
+|                    | `aria-disabled`           | `clearable`が設定されており、かつ値があり、`disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                              |
+|                    | `aria-label`              | `clearable`が設定されており、かつ値がある場合は`"値を消去する"`を設定します。                                                                                                  |
+| `ComponentContent` | `role="listbox"`          | リストボックスであることを示します。                                                                                                                                           |
+| `Component.Label`  | `role="presentation"`     | プレゼンテーションであることを示します。                                                                                                                                       |
+| `Component.Group`  | `role="group"`            | グループであることを示します。                                                                                                                                                 |
+|                    | `aria-labelledby`         | 関連した`Component.Label`の`id`を設定します。                                                                                                                                  |
+| `Component.Option` | `role="option"`           | オプションであることを示します。                                                                                                                                               |
+|                    | `aria-disabled`           | オプションが無効な場合は`"true"`を設定します。                                                                                                                                 |
+|                    | `aria-selected`           | オプションが選択されている場合は`"true"`を設定し、選択されていない場合は`"false"`を設定します。                                                                                |
+
+````
 
 ### Translation Guidelines - Hybrid Approach (CRITICAL)
 
@@ -587,7 +592,7 @@ If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Com
 
 // ❌ INCORRECT: All English
 <Button>Submit</Button>
-```
+````
 
 ### Additional Translation Rules
 

--- a/.agents/skills/mdx-doc-generator/SKILL.md
+++ b/.agents/skills/mdx-doc-generator/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: mdx-doc-generator
 description: Generate and update component .mdx documentation files for yamada-ui with bilingual support (English/Japanese) and comprehensive accessibility sections
+metadata:
+  internal: true
 ---
 
 You are a specialized documentation generator for the yamada-ui component library. Your task is to create and maintain comprehensive component documentation files in both English and Japanese by cross-referencing implementation files, stories, tests, and i18n translations.
@@ -29,36 +31,86 @@ Generate `.mdx` documentation files for yamada-ui components that include:
 - `(charts)` - Chart components
 - `(utilities)` - Utility components
 
-### One Folder = One Documentation Rule (CRITICAL)
+### Component Documentation Grouping Rules (CRITICAL)
 
-**IMPORTANT**: In yamada-ui, multiple component files in the same folder are documented together in a single `.mdx` file.
+**IMPORTANT**: In yamada-ui, component documentation follows specific grouping patterns based on component relationships and functionality.
 
-#### Examples of Multi-Component Folders:
+#### Pattern 1: Related Component Variants → Single Documentation
+
+When components are closely related variations or helper components, they are documented together in a single `.mdx` file.
+
+**Examples:**
 
 ```
 button/
 ├── button.tsx           → Button
 ├── button-group.tsx     → ButtonGroup
-├── icon-button.tsx      → IconButton
-└── Documentation: button.mdx (includes all three)
+└── Documentation: button.mdx (includes Button + ButtonGroup)
 
 avatar/
 ├── avatar.tsx           → Avatar
 ├── avatar-group.tsx     → AvatarGroup
-└── Documentation: avatar.mdx (includes both)
+└── Documentation: avatar.mdx (includes Avatar + AvatarGroup)
 
 checkbox/
 ├── checkbox.tsx         → Checkbox
 ├── checkbox-group.tsx   → CheckboxGroup
-└── Documentation: checkbox.mdx (includes both)
+└── Documentation: checkbox.mdx (includes Checkbox + CheckboxGroup)
 
 stack/
 ├── stack.tsx            → Stack
 ├── h-stack.tsx          → HStack
 ├── v-stack.tsx          → VStack
 ├── z-stack.tsx          → ZStack
-└── Documentation: stack.mdx (includes all four)
+└── Documentation: stack.mdx (includes Stack + HStack + VStack + ZStack)
+
+input/
+├── input.tsx            → Input
+├── input-addon.tsx      → InputAddon
+├── input-element.tsx    → InputElement
+├── input-group.tsx      → InputGroup
+└── Documentation: input.mdx (includes Input + InputAddon + InputElement + InputGroup)
 ```
+
+#### Pattern 2: Independent Components → Separate Documentation
+
+When components are functionally independent or serve different purposes, they get separate `.mdx` files even if in the same folder.
+
+**Examples:**
+
+```
+button/
+├── button.tsx           → Button
+├── button-group.tsx     → ButtonGroup
+├── icon-button.tsx      → IconButton
+└── Documentation: 
+    ├── button.mdx (includes Button + ButtonGroup)
+    └── icon-button.mdx (IconButton only - separate)
+
+chart/
+├── area-chart.tsx       → AreaChart
+├── bar-chart.tsx        → BarChart
+├── line-chart.tsx       → LineChart
+├── pie-chart.tsx        → PieChart
+└── Documentation:
+    ├── area-chart.mdx (AreaChart only)
+    ├── bar-chart.mdx (BarChart only)
+    ├── line-chart.mdx (LineChart only)
+    └── pie-chart.mdx (PieChart only)
+```
+
+#### Guidelines for Determining Grouping:
+
+1. **Group together when:**
+   - Components are variations of the same concept (HStack, VStack, ZStack → Stack)
+   - Components are helper components that extend the main component (InputAddon, InputElement, InputGroup → Input)
+   - Components are commonly used together and form a logical unit (Button + ButtonGroup)
+
+2. **Separate when:**
+   - Components are functionally independent (AreaChart vs BarChart vs PieChart)
+   - Components have distinctly different use cases (Button vs IconButton)
+   - Components are complex enough to warrant separate documentation
+   - The component has a distinct identity and standalone usage
 
 #### Implementation Pattern:
 
@@ -232,21 +284,67 @@ Every component must include a comprehensive accessibility section based on the 
 
 The `ComponentName` follows the [WAI-ARIA - Pattern Name](https://www.w3.org/WAI/ARIA/apg/patterns/) for accessibility.
 
+If you are not using `Field.Root`, set `aria-label` or `aria-labelledby` to `Component.Root`.
+
+```tsx
+<Component.Root aria-label="Component label" placeholder="Component placeholder">
+  <Component.Option value="value1">Option 1</Component.Option>
+  <Component.Option value="value2">Option 2</Component.Option>
+</Component.Root>
+```
+
+```tsx
+<VStack gap="sm">
+  <Text as="h3" id="label">
+    Component Label
+  </Text>
+
+  <Component.Root aria-labelledby="label" placeholder="Component placeholder">
+    <Component.Option value="value1">Option 1</Component.Option>
+    <Component.Option value="value2">Option 2</Component.Option>
+  </Component.Root>
+</VStack>
+```
+
 ### Keyboard Navigation
 
-| Key | Description | State |
-| --- | --- | --- |
-| `Tab` | Description of what happens | `prop={value}` |
-| `Enter` | Description of what happens | `prop={value}` |
-| `Escape` | Description of what happens | `prop={value}` |
-| `Arrow keys` | Description of what happens | `prop={value}` |
+| Key         | Description                                                                                                                             | State                  |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `ArrowDown` | Focuses the next item that is not disabled. When the last item, focuses the first item that is not disabled.                            | -                      |
+| `ArrowUp`   | Focuses the previous item that is not disabled. When the first item, focuses the last item that is not disabled.                        | -                      |
+| `Enter`     | Selects the focused item and closes the listbox. When there is no focused item and the input has text, selects the first matching item. | `closeOnSelect={true}` |
+| `Home`      | When the listbox is open, focuses the first item that is not disabled.                                                                  | -                      |
+| `End`       | When the listbox is open, focuses the last item that is not disabled.                                                                   | -                      |
+| `Escape`    | Closes the listbox.                                                                                                                     | `closeOnEsc={true}`    |
+| `Backspace` | Removes the last selected value when the input is empty.                                                                                | `multiple={true}`      |
 
 ### ARIA Roles and Attributes
 
-| Component | Roles and Attributes | Usage |
-| --- | --- | --- |
-| `Component.Part` | `role="dialog"`, `aria-label="..."` | Description |
-| `Component.Trigger` | `aria-haspopup="dialog"`, `aria-expanded={...}` | Description |
+| Component           | Roles and Attributes      | Usage                                                                                                                                                               |
+| ------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Component.Root`    | `role="group"`            | Indicates that this is a group.                                                                                                                                     |
+| `ComponentField`    | `role="combobox"`         | Indicates that this is a combobox.                                                                                                                                  |
+|                     | `aria-activedescendant`   | Sets the `id` of the focused item.                                                                                                                                  |
+|                     | `aria-controls`           | If the listbox is open, sets the `id` of the related `ComponentContent`; when closed, sets `undefined`.                                                              |
+|                     | `aria-describedby`        | If `Component.Root` is within a `Field.Root` and `Field.Root` has an `errorMessage`, `helperMessage`, or a `Field.ErrorMessage`, `Field.HelperMessage`, sets its `id`. |
+|                     | `aria-disabled`           | Sets to `"true"` if `disabled` or `readOnly` is set.                                                                                                                |
+|                     | `aria-expanded`           | Sets to `"true"` when the listbox is open, `"false"` when closed.                                                                                                   |
+|                     | `aria-haspopup="listbox"` | Indicates that a listbox exists.                                                                                                                                    |
+|                     | `aria-invalid`            | Sets to `"true"` if `invalid` is set.                                                                                                                               |
+|                     | `aria-label`              | Sets the value of `placeholder`.                                                                                                                                    |
+|                     | `aria-labelledby`         | If `Component.Root` is within a `Field.Root` and `Field.Root` has a `label` or `Field.Label`, sets its `id`.                                                         |
+|                     | `aria-readonly`           | Sets to `"true"` if `readOnly` is set.                                                                                                                              |
+|                     | `aria-required`           | Sets to `"true"` if `required` is set.                                                                                                                              |
+| `ComponentIcon`     | `role="button"`           | Indicates that this is a button when `clearable` is set and a value is present.                                                                                     |
+|                     | `aria-disabled`           | Sets to `"true"` when `clearable` is set, a value is present, and `disabled` or `readOnly` is set.                                                                  |
+|                     | `aria-label`              | Sets to `"Clear value"` when `clearable` is set and a value is present.                                                                                             |
+| `ComponentContent`  | `role="listbox"`          | Indicates that this is a listbox.                                                                                                                                   |
+| `Component.Label`   | `role="presentation"`     | Indicates that this is a presentation.                                                                                                                              |
+| `Component.Group`   | `role="group"`            | Indicates that this is a group.                                                                                                                                     |
+|                     | `aria-labelledby`         | Sets the `id` of the associated `Component.Label`.                                                                                                                  |
+| `Component.Option`  | `role="option"`           | Indicates that this is an option.                                                                                                                                   |
+|                     | `aria-disabled`           | Sets to `"true"` if the option is disabled.                                                                                                                         |
+|                     | `aria-selected`           | Sets to `"true"` when the option is selected, `"false"` when not selected.                                                                                          |
 ```
 
 **Accessibility Guidelines:**
@@ -255,8 +353,11 @@ The `ComponentName` follows the [WAI-ARIA - Pattern Name](https://www.w3.org/WAI
 - Include ALL keyboard interactions found in implementation (Tab, Enter, Escape, Arrow keys, Space, etc.)
 - List ALL ARIA roles, attributes, and states actually used in the code
 - Specify prop states that enable/disable features
-- Use the component's actual subcomponent structure from implementation
+- Use the component's actual subcomponent structure from implementation (including internal components like ComponentField, ComponentIcon, ComponentContent)
 - Cross-reference test files for accessibility features
+- Format the ARIA attributes table with each component's multiple attributes grouped together in one cell
+- List role attribute first, followed by other ARIA attributes in logical order
+- Include detailed usage conditions for each attribute (when it sets values, what props affect it)
 
 ### 6. Similar Components
 
@@ -296,6 +397,76 @@ The `ComponentName` follows the [WAI-ARIA - Pattern Name](https://www.w3.org/WAI
   - "## 類似のコンポーネント" (Similar Components)
   - "## 使用しているコンポーネント・フック" (Uses Components & Hooks)
   - "## 使用されているコンポーネント・フック" (Used By Components & Hooks)
+
+**Japanese Accessibility Section Example:**
+
+```tsx
+## アクセシビリティ
+
+`ComponentName`は、アクセシビリティに関して[WAI-ARIA - Pattern Name](https://www.w3.org/WAI/ARIA/apg/patterns/)に従っています。
+
+`Field.Root`を使用しない場合は、`Component.Root`に`aria-label`または`aria-labelledby`を設定してください。
+
+```tsx
+<Component.Root aria-label="コンポーネントラベル" placeholder="コンポーネントプレースホルダー">
+  <Component.Option value="value1">オプション1</Component.Option>
+  <Component.Option value="value2">オプション2</Component.Option>
+</Component.Root>
+```
+
+```tsx
+<VStack gap="sm">
+  <Text as="h3" id="label">
+    コンポーネントラベル
+  </Text>
+
+  <Component.Root aria-labelledby="label" placeholder="コンポーネントプレースホルダー">
+    <Component.Option value="value1">オプション1</Component.Option>
+    <Component.Option value="value2">オプション2</Component.Option>
+  </Component.Root>
+</VStack>
+```
+
+### キーボード操作
+
+| キー        | 説明                                                                                                                                             | 状態                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `ArrowDown` | 無効ではない次の項目にフォーカスします。最後の項目の場合は、無効ではない最初の項目にフォーカスします。                                           | -                      |
+| `ArrowUp`   | 無効ではない前の項目にフォーカスします。最初の項目の場合は、無効ではない最後の項目にフォーカスします。                                           | -                      |
+| `Enter`     | フォーカスしている項目を選択し、リストボックスを閉じます。フォーカスしている項目がなく入力テキストがある場合は、最初に一致する項目を選択します。 | `closeOnSelect={true}` |
+| `Home`      | リストボックスが開いている場合、無効ではない最初の項目にフォーカスします。                                                                       | -                      |
+| `End`       | リストボックスが開いている場合、無効ではない最後の項目にフォーカスします。                                                                       | -                      |
+| `Escape`    | リストボックスを閉じます。                                                                                                                       | `closeOnEsc={true}`    |
+| `Backspace` | 入力が空の場合、最後に選択された値を削除します。                                                                                                 | `multiple={true}`      |
+
+### ARIAロールと属性
+
+| コンポーネント         | ロールと属性              | 使い方                                                                                                                                                                                                                                      |
+| ---------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Component.Root`       | `role="group"`            | グループであることを示します。                                                                                                                                                                                                              |
+| `ComponentField`       | `role="combobox"`         | コンボボックスであることを示します。                                                                                                                                                                                                        |
+|                        | `aria-activedescendant`   | フォーカスされた項目の`id`を設定します。                                                                                                                                                                                                    |
+|                        | `aria-controls`           | リストボックスが開いている場合は関連する`ComponentContent`の`id`を設定し、閉じている場合は`undefined`を設定します。                                                                                                                          |
+|                        | `aria-describedby`        | `Component.Root`が`Field.Root`内にあり、`Field.Root`に`errorMessage`、`helperMessage`、`Field.ErrorMessage`、`Field.HelperMessage`のいずれかがある場合、その`id`を設定します。                                                |
+|                        | `aria-disabled`           | `disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                                                                        |
+|                        | `aria-expanded`           | リストボックスが開いている場合は`"true"`を設定し、閉じている場合は`"false"`を設定します。                                                                                                                                                     |
+|                        | `aria-haspopup="listbox"` | リストボックスが存在することを示します。                                                                                                                                                                                                    |
+|                        | `aria-invalid`            | `invalid`が設定されている場合は`"true"`を設定します。                                                                                                                                                                                        |
+|                        | `aria-label`              | `placeholder`の値を設定します。                                                                                                                                                                                                             |
+|                        | `aria-labelledby`         | `Component.Root`が`Field.Root`内にあり、`Field.Root`に`label`または`Field.Label`が設定されている場合は、その`id`を設定します。                                                                                                                 |
+|                        | `aria-readonly`           | `readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                                                                                      |
+|                        | `aria-required`           | `required`が設定されている場合は`"true"`を設定します。                                                                                                                                                                                      |
+| `ComponentIcon`        | `role="button"`           | `clearable`が設定されており、かつ値がある場合はボタンであることを示します。                                                                                                                                                                 |
+|                        | `aria-disabled`           | `clearable`が設定されており、かつ値があり、`disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                                                                                            |
+|                        | `aria-label`              | `clearable`が設定されており、かつ値がある場合は`"値を消去する"`を設定します。                                                                                                                                                               |
+| `ComponentContent`     | `role="listbox"`          | リストボックスであることを示します。                                                                                                                                                                                                        |
+| `Component.Label`      | `role="presentation"`     | プレゼンテーションであることを示します。                                                                                                                                                                                                    |
+| `Component.Group`      | `role="group"`            | グループであることを示します。                                                                                                                                                                                                              |
+|                        | `aria-labelledby`         | 関連した`Component.Label`の`id`を設定します。                                                                                                                                                                                               |
+| `Component.Option`     | `role="option"`           | オプションであることを示します。                                                                                                                                                                                                            |
+|                        | `aria-disabled`           | オプションが無効な場合は`"true"`を設定します。                                                                                                                                                                                              |
+|                        | `aria-selected`           | オプションが選択されている場合は`"true"`を設定し、選択されていない場合は`"false"`を設定します。                                                                                                                                               |
+```
 
 ### Translation Guidelines - Hybrid Approach (CRITICAL)
 

--- a/.agents/skills/mdx-doc-generator/SKILL.md
+++ b/.agents/skills/mdx-doc-generator/SKILL.md
@@ -165,10 +165,65 @@ title: Component Name
 description: "Brief description of what the component does"
 tags: ["relevant-tag"]
 storybook: components-componentname--basic
-source: components/component-name
-style: components/component-name/component-name.style.ts
+source: components/actual-directory
+style: components/actual-directory/component-name.style.ts
 ---
-````
+```
+
+**CRITICAL - Resolving source and style paths:**
+
+The `source` and `style` fields MUST be resolved from the **actual implementation path** or **existing frontmatter**, NOT constructed from the component name or docs slug.
+
+**Resolution Process:**
+
+**Step 1: Check for existing frontmatter**
+- If the `.mdx` file already exists, READ its frontmatter first
+- Preserve existing `source` and `style` values if they exist
+- Only update if they are incorrect or missing
+
+**Step 2: Resolve from implementation path (if creating new or updating incorrect values)**
+1. Find the actual implementation file: `packages/react/src/components/*/component-name.tsx`
+   - Use Glob or Grep to search for the file
+   - Example: Search for `pie-chart.tsx` → found in `packages/react/src/components/chart/pie-chart.tsx`
+2. Extract the directory name where the component lives
+   - For `packages/react/src/components/chart/pie-chart.tsx` → directory is `chart`
+   - For `packages/react/src/components/button/icon-button.tsx` → directory is `button`
+3. Build the paths:
+   - `source`: `components/{actual-directory-name}`
+   - `style`: `components/{actual-directory-name}/{component-file-name}.style.ts`
+
+**Examples:**
+
+```
+pie-chart.mdx
+├── Docs slug: pie-chart
+├── ❌ WRONG: source: components/pie-chart (constructed from slug)
+├── ✅ CORRECT: 
+│   ├── Implementation: packages/react/src/components/chart/pie-chart.tsx
+│   ├── Actual directory: chart
+│   └── Frontmatter:
+│       source: components/chart
+│       style: components/chart/pie-chart.style.ts
+
+icon-button.mdx
+├── Docs slug: icon-button
+├── ❌ WRONG: source: components/icon-button (constructed from slug)
+├── ✅ CORRECT:
+│   ├── Implementation: packages/react/src/components/button/icon-button.tsx
+│   ├── Actual directory: button
+│   └── Frontmatter:
+│       source: components/button
+│       style: components/button/icon-button.style.ts
+
+button.mdx (Button + ButtonGroup)
+├── Docs slug: button
+├── ✅ CORRECT:
+│   ├── Implementation: packages/react/src/components/button/button.tsx
+│   ├── Actual directory: button
+│   └── Frontmatter:
+│       source: components/button
+│       style: components/button/button.style.ts
+```
 
 ## Cross-Reference Requirements
 
@@ -273,7 +328,32 @@ Use the `<Wrap>` pattern for displaying multiple variants:
 />
 ```
 
-Use `omit` to exclude internal component types that should not appear in the PropsTable.
+**For Split-Page Docs from Shared Folders:**
+
+When documenting a single component export from a shared folder (e.g., individual chart types from the chart/ folder), use `pick` to select only the props relevant to that specific page:
+
+```tsx
+<PropsTable
+  name="chart"
+  pick={[
+    "PieChart",
+    "PieChart.Root",
+    "PieChart.Pie",
+    "PieChart.Label",
+    "PieChart.LabelList",
+    "PieChart.Legend",
+    "PieChart.Tooltip",
+  ]}
+/>
+```
+
+**Choosing between `omit` and `pick`:**
+
+- **`omit`**: Use when documenting multiple components together from a single source. Removes internal or unnecessary types from a broader props export.
+  - Example: Documenting Button + ButtonGroup together, omitting internal component types
+- **`pick`**: Use when documenting a single export from shared props data, especially for split-page docs under shared folders.
+  - Example: PieChart page selecting only PieChart-related props from the shared chart props data
+  - **Default choice for split-page docs from shared folders**: prefer `pick`
 
 ### 5. Accessibility Section (CRITICAL)
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #6027                                                                                                        
   
##  AI used                                                                                                        
- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description
  Adds a Claude Code skill (mdx-doc-generator) to automate the generation and maintenance of comprehensive
  component documentation for yamada-ui. This skill creates bilingual (English/Japanese) MDX documentation files
  by analyzing component implementations, Storybook stories, tests, and i18n translations.

## Current behavior (updates)

  Previously, component documentation files (.mdx and .ja.mdx) had to be manually created and maintained, which
  was time-consuming and prone to inconsistencies between English and Japanese versions. There was no
  standardized approach to ensure comprehensive accessibility sections or consistent documentation structure
  across components.

## New behavior

  The mdx-doc-generator skill provides:

  - Automated bilingual documentation generation for all yamada-ui components
  - Cross-reference analysis of implementation files, Storybook stories, tests, and i18n translations
  - Comprehensive accessibility sections including keyboard navigation and ARIA attributes
  - Multi-component folder support - documents all components in the same folder together (e.g., Button,
  ButtonGroup, IconButton)
  - Hybrid translation approach for Japanese docs (user-visible text in Japanese, technical props in English)
  - Standardized documentation structure with preview examples, usage instructions, props tables, and component
  relationships

## Is this a breaking change (Yes/No):

  No

  This is a developer tool addition that doesn't affect the component library's runtime behavior or public API.

## Additional Information

  The skill follows yamada-ui's documentation conventions:
  - One .mdx file per component folder (even when containing multiple components)
  - Files located in www/contents/components/(category)/
  - Comprehensive accessibility documentation based on WAI-ARIA patterns
  - Consistent bilingual support with proper Japanese technical terminology

  To use this skill, run /mdx-doc-generator from Claude Code and specify the component name and category.