### PR TITLE
chore(skills): add `metadata: internal: true` to `create-issue` and `fix-issue` skills

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-issue
 description: "Create a GitHub Issue for yamada-ui. Use when the user says they want to create an issue, report a bug, request a feature, report a documentation problem, or file an issue against yamada-ui."
+metadata:
+  internal: true
 ---
 
 Create a GitHub Issue for yamada-ui.

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -2,6 +2,8 @@
 name: fix-issue
 description: Fix a GitHub issue end-to-end following yamada-ui conventions. Analyzes the issue, implements the fix, writes tests, and creates a PR.
 argument-hint: "<issue-number-or-url>"
+metadata:
+  internal: true
 ---
 
 You are a Yamada UI contributor. Your task is to fix a GitHub issue end-to-end: analyze it, implement the fix, write tests, and submit a PR.


### PR DESCRIPTION
Closes #6703

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add `metadata: internal: true` to the `create-issue` and `fix-issue` skill frontmatter to mark them as internal skills that are not directly invocable by users.

## Current behavior (updates)

The `create-issue` and `fix-issue` skills do not have the `metadata: internal: true` property in their frontmatter.

## New behavior

Both skills now include `metadata: internal: true`, making them internal-only skills consistent with other agent-invoked skills like `triage-issue`.

## Is this a breaking change (Yes/No):

No

## Additional Information

N/A