### PR TITLE
fix: popover and menu storybook play interactions for chromatic

### DIFF
--- a/packages/react/src/components/accordion/accordion.stories.tsx
+++ b/packages/react/src/components/accordion/accordion.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { PropsTable } from "#storybook"
 import { useMemo, useState } from "react"
+import { expect, screen, within } from "storybook/test"
 import { MinusIcon, PlusIcon } from "../icon"
 import { Accordion } from "./"
 
@@ -46,6 +47,21 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const Items: Story = () => {
   const items = useMemo<Accordion.Item[]>(
     () => [
@@ -69,6 +85,21 @@ export const Items: Story = () => {
   )
 
   return <Accordion.Root items={items} />
+}
+
+Items.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }
 
 export const Variant: Story = () => {
@@ -107,6 +138,23 @@ export const Variant: Story = () => {
   )
 }
 
+Variant.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getAllByRole("button", {
+    name: /孫悟空少年編/,
+  })[0]
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const DefaultIndex: Story = () => {
   const items = useMemo<Accordion.Item[]>(
     () => [
@@ -130,6 +178,20 @@ export const DefaultIndex: Story = () => {
   )
 
   return <Accordion.Root defaultIndex={1} items={items} />
+}
+
+DefaultIndex.play = async () => {
+  const trigger = screen.getByRole("button", { name: /ピッコロ大魔王編/ })
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /天下一武道会終了後、ピラフ一味によって復活した/,
+    ),
+  ).toBeVisible()
 }
 
 export const Toggle: Story = () => {
@@ -157,6 +219,21 @@ export const Toggle: Story = () => {
   return <Accordion.Root items={items} toggle />
 }
 
+Toggle.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const Multiple: Story = () => {
   const items = useMemo<Accordion.Item[]>(
     () => [
@@ -180,6 +257,32 @@ export const Multiple: Story = () => {
   )
 
   return <Accordion.Root defaultIndex={[1, 2]} items={items} multiple />
+}
+
+Multiple.play = async () => {
+  const trigger1 = screen.getByRole("button", { name: /ピッコロ大魔王編/ })
+  const panelId1 = trigger1.getAttribute("aria-controls")
+  const panel1 = panelId1 ? document.getElementById(panelId1) : null
+  if (!panel1) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel1).findByText(
+      /天下一武道会終了後、ピラフ一味によって復活した/,
+    ),
+  ).toBeVisible()
+
+  const trigger2 = screen.getByRole("button", { name: /サイヤ人編/ })
+  const panelId2 = trigger2.getAttribute("aria-controls")
+  const panel2 = panelId2 ? document.getElementById(panelId2) : null
+  if (!panel2) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel2).findByText(
+      /ピッコロ（マジュニア）との闘いから約5年後/,
+    ),
+  ).toBeVisible()
 }
 
 export const IconHidden: Story = () => {
@@ -207,6 +310,21 @@ export const IconHidden: Story = () => {
   return <Accordion.Root iconHidden items={items} />
 }
 
+IconHidden.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const Disabled: Story = () => {
   const items = useMemo<Accordion.Item[]>(
     () => [
@@ -231,6 +349,21 @@ export const Disabled: Story = () => {
   )
 
   return <Accordion.Root items={items} />
+}
+
+Disabled.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }
 
 export const CustomLabel: Story = () => {
@@ -269,6 +402,21 @@ export const CustomLabel: Story = () => {
   )
 }
 
+CustomLabel.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const CustomPanel: Story = () => {
   const items = useMemo(
     () => [
@@ -304,6 +452,21 @@ export const CustomPanel: Story = () => {
   )
 }
 
+CustomPanel.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const CustomIcon: Story = () => {
   const items = useMemo<Accordion.Item[]>(
     () => [
@@ -334,6 +497,21 @@ export const CustomIcon: Story = () => {
   )
 }
 
+CustomIcon.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const CustomControl: Story = () => {
   const items = useMemo<Accordion.Item[]>(
     () => [
@@ -360,4 +538,19 @@ export const CustomControl: Story = () => {
   )
 
   return <Accordion.Root index={index} items={items} onChange={onChange} />
+}
+
+CustomControl.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /孫悟空少年編/ })
+  await userEvent.click(trigger)
+  const panelId = trigger.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+  if (!panel) {
+    throw new Error("Expected accordion panel")
+  }
+  await expect(
+    await within(panel).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }

--- a/packages/react/src/components/action-bar/action-bar.stories.tsx
+++ b/packages/react/src/components/action-bar/action-bar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
+import { expect, screen } from "storybook/test"
 import { useDisclosure } from "../../hooks/use-disclosure"
 import { Button } from "../button"
 import { CloseButton } from "../close-button"
@@ -155,4 +156,34 @@ export const CustomControl: Story = () => {
       />
     </>
   )
+}
+
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open action/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
+PropsPattern.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open action/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open action/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
+Placement.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open action/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
+AnimationScheme.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open action/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
+CustomControl.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open action/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -285,6 +285,21 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const sizes = ["xs", "sm", "md", "lg", "xl"]
+  const variants = ["outline", "filled", "flushed"]
+
+  for (let i = 0; i < sizes.length; i++) {
+    for (let j = 0; j < variants.length; j++) {
+      const index = i * variants.length + j
+      const comboboxes = canvas.getAllByRole("combobox")
+      await userEvent.click(comboboxes[index]!)
+      await expect(await screen.findByRole("listbox")).toBeVisible()
+      await userEvent.click(comboboxes[index]!)
+    }
+  }
+}
+
 export const DefaultValue: Story = () => {
   const items = useMemo<Autocomplete.Item[]>(
     () => [

--- a/packages/react/src/components/drawer/drawer.stories.tsx
+++ b/packages/react/src/components/drawer/drawer.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { useState } from "react"
+import { expect, screen } from "storybook/test"
 import { useDisclosure } from "../../hooks/use-disclosure"
 import { noop } from "../../utils"
 import { Button } from "../button"
@@ -48,6 +49,11 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const PropsPattern: Story = () => {
   return (
     <Drawer.Root
@@ -60,6 +66,11 @@ export const PropsPattern: Story = () => {
       onSuccess={noop}
     />
   )
+}
+
+PropsPattern.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Size: Story = () => {
@@ -107,6 +118,21 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const sizes = ["xs", "sm", "md", "lg", "xl", "full"] as const
+  for (let i = 0; i < sizes.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", { name: `Open "${sizes[i]}" Drawer` }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
+}
+
 export const Duration: Story = () => {
   return (
     <Drawer.Root duration={0.7}>
@@ -133,6 +159,11 @@ export const Duration: Story = () => {
       </Drawer.Content>
     </Drawer.Root>
   )
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Placement: Story = () => {
@@ -183,6 +214,28 @@ export const Placement: Story = () => {
       </Drawer.Root>
     </>
   )
+}
+
+Placement.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "block-start",
+    "block-end",
+    "inline-start",
+    "inline-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${placements[i]}" Drawer`,
+      }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
 }
 
 export const CloseOnDrag: Story = () => {
@@ -240,6 +293,28 @@ export const CloseOnDrag: Story = () => {
   )
 }
 
+CloseOnDrag.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "block-start",
+    "block-end",
+    "inline-start",
+    "inline-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${placements[i]}" Drawer`,
+      }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
+}
+
 export const HiddenDragBar: Story = () => {
   return (
     <Drawer.Root closeOnDrag withCloseButton withDragBar={false}>
@@ -268,6 +343,11 @@ export const HiddenDragBar: Story = () => {
   )
 }
 
+HiddenDragBar.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const HiddenCloseButton: Story = () => {
   return (
     <Drawer.Root withCloseButton={false}>
@@ -294,6 +374,11 @@ export const HiddenCloseButton: Story = () => {
       </Drawer.Content>
     </Drawer.Root>
   )
+}
+
+HiddenCloseButton.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const CustomCloseButton: Story = () => {
@@ -326,6 +411,11 @@ export const CustomCloseButton: Story = () => {
   )
 }
 
+CustomCloseButton.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const HiddenOverlay: Story = () => {
   return (
     <Drawer.Root withOverlay={false}>
@@ -352,6 +442,11 @@ export const HiddenOverlay: Story = () => {
       </Drawer.Content>
     </Drawer.Root>
   )
+}
+
+HiddenOverlay.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const CustomOverlay: Story = () => {
@@ -384,6 +479,11 @@ export const CustomOverlay: Story = () => {
   )
 }
 
+CustomOverlay.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const CustomButton: Story = () => {
   return (
     <Drawer.Root
@@ -396,6 +496,11 @@ export const CustomButton: Story = () => {
       trigger={<Button>Open Drawer</Button>}
     />
   )
+}
+
+CustomButton.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const ScrollOnMount: Story = () => {
@@ -475,4 +580,9 @@ export const ScrollOnMount: Story = () => {
       </Container.Root>
     </>
   )
+}
+
+ScrollOnMount.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }

--- a/packages/react/src/components/menu/menu.stories.tsx
+++ b/packages/react/src/components/menu/menu.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { PropsTable } from "#storybook"
 import { useMemo, useRef, useState } from "react"
+import { expect, screen, within } from "storybook/test"
 import { useDisclosure } from "../../hooks/use-disclosure"
 import { Box } from "../box"
 import { Button } from "../button"
@@ -46,6 +47,11 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Items: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -65,6 +71,11 @@ export const Items: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+Items.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const Size: Story = () => {
@@ -92,6 +103,15 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const buttons = canvas.getAllByRole("button", { name: /^menu$/i })
+  for (const button of buttons) {
+    await userEvent.click(button)
+    await expect(await screen.findByRole("menu")).toBeVisible()
+    await userEvent.click(button)
+  }
+}
+
 export const OnSelect: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -111,6 +131,11 @@ export const OnSelect: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+OnSelect.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const Separator: Story = () => {
@@ -156,6 +181,18 @@ export const Separator: Story = () => {
       </Menu.Root>
     </HStack>
   )
+}
+
+Separator.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with items/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with composition/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const Group: Story = () => {
@@ -216,6 +253,18 @@ export const Group: Story = () => {
   )
 }
 
+Group.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with items/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with composition/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const CheckboxGroup: Story = () => {
   const [value, setValue] = useState<string[]>(["naruto"])
   const items = useMemo<Menu.Item[]>(
@@ -265,6 +314,18 @@ export const CheckboxGroup: Story = () => {
   )
 }
 
+CheckboxGroup.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with items/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with composition/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const RadioGroup: Story = () => {
   const [value, setValue] = useState<string>("naruto")
   const items = useMemo<Menu.Item[]>(
@@ -312,6 +373,18 @@ export const RadioGroup: Story = () => {
       </Menu.Root>
     </HStack>
   )
+}
+
+RadioGroup.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with items/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with composition/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const Indicator: Story = () => {
@@ -394,6 +467,18 @@ export const Indicator: Story = () => {
   )
 }
 
+Indicator.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with items/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with composition/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Command: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -462,6 +547,18 @@ export const Command: Story = () => {
   )
 }
 
+Command.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with items/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await userEvent.click(
+    canvas.getByRole("button", { name: /menu with composition/i }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Links: Story = () => {
   const items = useMemo(
     () => [
@@ -508,6 +605,11 @@ export const Links: Story = () => {
   )
 }
 
+Links.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Anchor: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -537,6 +639,11 @@ export const Anchor: Story = () => {
   )
 }
 
+Anchor.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Header: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -561,6 +668,11 @@ export const Header: Story = () => {
   )
 }
 
+Header.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Footer: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -583,6 +695,11 @@ export const Footer: Story = () => {
       <Menu.Content footer="キャラクター" items={items} maxH="2xs" />
     </Menu.Root>
   )
+}
+
+Footer.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const ContextMenu: Story = () => {
@@ -615,6 +732,14 @@ export const ContextMenu: Story = () => {
   )
 }
 
+ContextMenu.play = async ({ canvas }) => {
+  const target = canvas.getByText("Right click here")
+  target.dispatchEvent(
+    new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+  )
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const NestedMenu: Story = () => {
   return (
     <Menu.Root>
@@ -643,6 +768,15 @@ export const NestedMenu: Story = () => {
   )
 }
 
+NestedMenu.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+  await userEvent.hover(
+    within(screen.getByRole("menu")).getByText(/伝説の三忍/),
+  )
+  await expect(await screen.findByText(/大蛇丸/)).toBeVisible()
+}
+
 export const Duration: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -662,6 +796,11 @@ export const Duration: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const Offset: Story = () => {
@@ -685,6 +824,11 @@ export const Offset: Story = () => {
   )
 }
 
+Offset.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Gutter: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -704,6 +848,11 @@ export const Gutter: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+Gutter.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const AnimationScheme: Story = () => {
@@ -727,6 +876,11 @@ export const AnimationScheme: Story = () => {
   )
 }
 
+AnimationScheme.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Placement: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -746,6 +900,11 @@ export const Placement: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+Placement.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const BlockScrollOnMount: Story = () => {
@@ -771,6 +930,11 @@ export const BlockScrollOnMount: Story = () => {
   )
 }
 
+BlockScrollOnMount.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const CloseOnScroll: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -792,6 +956,11 @@ export const CloseOnScroll: Story = () => {
       </Menu.Root>
     </Box>
   )
+}
+
+CloseOnScroll.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const InitialFocusRef: Story = () => {
@@ -816,6 +985,11 @@ export const InitialFocusRef: Story = () => {
   )
 }
 
+InitialFocusRef.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const Disabled: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -835,6 +1009,10 @@ export const Disabled: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+Disabled.parameters = {
+  chromatic: { disableSnapshot: true },
 }
 
 export const DisabledItem: Story = () => {
@@ -858,6 +1036,11 @@ export const DisabledItem: Story = () => {
   )
 }
 
+DisabledItem.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const DisabledCloseOnSelect: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -877,6 +1060,11 @@ export const DisabledCloseOnSelect: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+DisabledCloseOnSelect.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const DisabledCloseOnBlur: Story = () => {
@@ -900,6 +1088,11 @@ export const DisabledCloseOnBlur: Story = () => {
   )
 }
 
+DisabledCloseOnBlur.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
+}
+
 export const DisabledCloseOnEsc: Story = () => {
   const items = useMemo<Menu.Item[]>(
     () => [
@@ -919,6 +1112,11 @@ export const DisabledCloseOnEsc: Story = () => {
       <Menu.Content items={items} />
     </Menu.Root>
   )
+}
+
+DisabledCloseOnEsc.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }
 
 export const CustomControl: Story = () => {
@@ -945,4 +1143,9 @@ export const CustomControl: Story = () => {
       <Button onClick={onOpen}>Click me from here</Button>
     </HStack>
   )
+}
+
+CustomControl.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^menu$/i }))
+  await expect(await screen.findByRole("menu")).toBeVisible()
 }

--- a/packages/react/src/components/modal/modal.stories.tsx
+++ b/packages/react/src/components/modal/modal.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { useState } from "react"
+import { expect, screen, within } from "storybook/test"
 import { useDisclosure } from "../../hooks/use-disclosure"
 import { noop } from "../../utils"
 import { Button } from "../button"
@@ -48,6 +49,11 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const PropsPattern: Story = () => {
   return (
     <Modal.Root
@@ -60,6 +66,11 @@ export const PropsPattern: Story = () => {
       onSuccess={noop}
     />
   )
+}
+
+PropsPattern.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Size: Story = () => {
@@ -107,6 +118,21 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const sizes = ["xs", "sm", "md", "lg", "xl", "cover", "full"] as const
+  for (let i = 0; i < sizes.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", { name: `Open "${sizes[i]}" Modal` }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
+}
+
 export const Duration: Story = () => {
   return (
     <Modal.Root duration={0.4}>
@@ -133,6 +159,11 @@ export const Duration: Story = () => {
       </Modal.Content>
     </Modal.Root>
   )
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Placement: Story = () => {
@@ -195,6 +226,33 @@ export const Placement: Story = () => {
   )
 }
 
+Placement.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "start-start",
+    "start-center",
+    "start-end",
+    "center-start",
+    "center-center",
+    "center-end",
+    "end-start",
+    "end-center",
+    "end-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${placements[i]}" Modal`,
+      }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
+}
+
 export const AnimationScheme: Story = () => {
   const [animationScheme, setAnimationScheme] =
     useState<Modal.RootProps["animationScheme"]>("scale")
@@ -255,6 +313,29 @@ export const AnimationScheme: Story = () => {
   )
 }
 
+AnimationScheme.play = async ({ canvas, userEvent }) => {
+  const animationSchemes = [
+    "scale",
+    "block-start",
+    "inline-start",
+    "inline-end",
+    "block-end",
+  ] as const
+  for (let i = 0; i < animationSchemes.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${animationSchemes[i]}" Modal`,
+      }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
+}
+
 export const NestedModal: Story = () => {
   return (
     <Modal.Root>
@@ -305,6 +386,22 @@ export const NestedModal: Story = () => {
   )
 }
 
+NestedModal.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^open modal$/i })[0]!,
+  )
+  await expect(
+    await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+  ).toBeVisible()
+  const outer = screen.getByRole("dialog", { name: /ドラゴンボール/ })
+  await userEvent.click(
+    within(outer).getByRole("button", { name: /open modal/i }),
+  )
+  await expect(
+    await screen.findByRole("dialog", { name: /あらすじ/ }),
+  ).toBeVisible()
+}
+
 export const HiddenCloseButton: Story = () => {
   return (
     <Modal.Root withCloseButton={false}>
@@ -331,6 +428,11 @@ export const HiddenCloseButton: Story = () => {
       </Modal.Content>
     </Modal.Root>
   )
+}
+
+HiddenCloseButton.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const CustomCloseButton: Story = () => {
@@ -363,6 +465,11 @@ export const CustomCloseButton: Story = () => {
   )
 }
 
+CustomCloseButton.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const HiddenOverlay: Story = () => {
   return (
     <Modal.Root withOverlay={false}>
@@ -389,6 +496,11 @@ export const HiddenOverlay: Story = () => {
       </Modal.Content>
     </Modal.Root>
   )
+}
+
+HiddenOverlay.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const CustomOverlay: Story = () => {
@@ -421,6 +533,11 @@ export const CustomOverlay: Story = () => {
   )
 }
 
+CustomOverlay.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const CustomButton: Story = () => {
   return (
     <Modal.Root
@@ -433,6 +550,11 @@ export const CustomButton: Story = () => {
       trigger={<Button>Open Modal</Button>}
     />
   )
+}
+
+CustomButton.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const ScrollBehavior: Story = () => {
@@ -503,6 +625,23 @@ export const ScrollBehavior: Story = () => {
       </Modal.Root>
     </>
   )
+}
+
+ScrollBehavior.play = async ({ canvas, userEvent }) => {
+  const scrollBehaviors = ["inside", "outside"] as const
+  for (let i = 0; i < scrollBehaviors.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${scrollBehaviors[i]}" Modal`,
+      }),
+    )
+    await expect(
+      await screen.findByRole("dialog", { name: /ドラゴンボール/ }),
+    ).toBeVisible()
+  }
 }
 
 export const ScrollOnMount: Story = () => {
@@ -582,4 +721,9 @@ export const ScrollOnMount: Story = () => {
       </Container.Root>
     </>
   )
+}
+
+ScrollOnMount.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open modal/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }

--- a/packages/react/src/components/native-accordion/native-accordion.stories.tsx
+++ b/packages/react/src/components/native-accordion/native-accordion.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { PropsTable } from "#storybook"
 import { useMemo } from "react"
+import { expect, screen, within } from "storybook/test"
 import { ChevronsDownIcon } from "../icon"
 import { NativeAccordion } from "./index"
 
@@ -46,6 +47,23 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const Items: Story = () => {
   const items = useMemo<NativeAccordion.Item[]>(
     () => [
@@ -69,6 +87,23 @@ export const Items: Story = () => {
   )
 
   return <NativeAccordion.Root items={items} />
+}
+
+Items.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }
 
 export const Variant: Story = () => {
@@ -102,6 +137,23 @@ export const Variant: Story = () => {
   )
 }
 
+Variant.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getAllByText(/孫悟空少年編/)[0]!.closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const DefaultOpen: Story = () => {
   const items = useMemo<NativeAccordion.Item[]>(
     () => [
@@ -126,6 +178,22 @@ export const DefaultOpen: Story = () => {
   )
 
   return <NativeAccordion.Root items={items} />
+}
+
+DefaultOpen.play = async () => {
+  const trigger = screen.getByText(/ピッコロ大魔王編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /天下一武道会終了後、ピラフ一味によって復活した/,
+    ),
+  ).toBeVisible()
 }
 
 export const Multiple: Story = () => {
@@ -153,6 +221,38 @@ export const Multiple: Story = () => {
   return <NativeAccordion.Root items={items} multiple />
 }
 
+Multiple.play = async ({ canvas, userEvent }) => {
+  const trigger1 = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger1) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger1)
+  const details1 = trigger1.closest("details")
+  if (!details1 || !(details1 instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details1).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+
+  const trigger2 = canvas.getByText(/ピッコロ大魔王編/).closest("summary")
+  if (!trigger2) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger2)
+  const details2 = trigger2.closest("details")
+  if (!details2 || !(details2 instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details2).findByText(
+      /天下一武道会終了後、ピラフ一味によって復活した/,
+    ),
+  ).toBeVisible()
+}
+
 export const IconHidden: Story = () => {
   const items = useMemo<NativeAccordion.Item[]>(
     () => [
@@ -176,6 +276,23 @@ export const IconHidden: Story = () => {
   )
 
   return <NativeAccordion.Root iconHidden items={items} />
+}
+
+IconHidden.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }
 
 export const Disabled: Story = () => {
@@ -202,6 +319,23 @@ export const Disabled: Story = () => {
   )
 
   return <NativeAccordion.Root items={items} />
+}
+
+Disabled.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }
 
 export const CustomLabel: Story = () => {
@@ -240,6 +374,23 @@ export const CustomLabel: Story = () => {
   )
 }
 
+CustomLabel.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const CustomPanel: Story = () => {
   const items = useMemo(
     () => [
@@ -275,6 +426,23 @@ export const CustomPanel: Story = () => {
   )
 }
 
+CustomPanel.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
+}
+
 export const CustomIcon: Story = () => {
   const items = useMemo<NativeAccordion.Item[]>(
     () => [
@@ -298,4 +466,21 @@ export const CustomIcon: Story = () => {
   )
 
   return <NativeAccordion.Root icon={<ChevronsDownIcon />} items={items} />
+}
+
+CustomIcon.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByText(/孫悟空少年編/).closest("summary")
+  if (!trigger) {
+    throw new Error("Expected accordion summary")
+  }
+  await userEvent.click(trigger)
+  const details = trigger.closest("details")
+  if (!details || !(details instanceof HTMLElement)) {
+    throw new Error("Expected details")
+  }
+  await expect(
+    await within(details).findByText(
+      /地球の人里離れた山奥に住む尻尾の生えた少年/,
+    ),
+  ).toBeVisible()
 }

--- a/packages/react/src/components/native-popover/native-popover.stories.tsx
+++ b/packages/react/src/components/native-popover/native-popover.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { PropsTable } from "#storybook"
+import { expect, screen, waitFor, within } from "storybook/test"
 import { NativePopover } from "."
 import { toTitleCase } from "../../utils"
 import { Button } from "../button"
@@ -35,6 +36,11 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const Size: Story = () => {
   return (
     <PropsTable variant="stack" rows={["xs", "sm", "md", "lg"]}>
@@ -56,6 +62,19 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const sizes = ["xs", "sm", "md", "lg"] as const
+  for (let i = 0; i < sizes.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getAllByRole("button", { name: /^click me$/i })[i]!,
+    )
+    await expect(await screen.findByRole("dialog")).toBeVisible()
+  }
+}
+
 export const Footer: Story = () => {
   return (
     <NativePopover.Root>
@@ -72,6 +91,11 @@ export const Footer: Story = () => {
       </NativePopover.Content>
     </NativePopover.Root>
   )
+}
+
+Footer.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Anchor: Story = () => {
@@ -103,6 +127,11 @@ export const Anchor: Story = () => {
       </NativePopover.Content>
     </NativePopover.Root>
   )
+}
+
+Anchor.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Placement: Story = () => {
@@ -145,6 +174,36 @@ export const Placement: Story = () => {
   )
 }
 
+Placement.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "start",
+    "start-start",
+    "start-end",
+    "start-center",
+    "end",
+    "end-start",
+    "end-end",
+    "end-center",
+    "center-start",
+    "center-start-start",
+    "center-start-end",
+    "center-end",
+    "center-end-start",
+    "center-end-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${toTitleCase(placements[i])}" Popover`,
+      }),
+    )
+    await expect(await screen.findByRole("dialog")).toBeVisible()
+  }
+}
+
 export const NestedPopover: Story = () => {
   return (
     <NativePopover.Root>
@@ -173,6 +232,20 @@ export const NestedPopover: Story = () => {
       </NativePopover.Content>
     </NativePopover.Root>
   )
+}
+
+NestedPopover.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^click me$/i })[0],
+  )
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+  const outer = screen.getByRole("dialog")
+  await userEvent.click(
+    within(outer).getAllByRole("button", { name: /^click me$/i })[0],
+  )
+  await expect(
+    (await screen.findAllByRole("dialog")).length,
+  ).toBeGreaterThanOrEqual(2)
 }
 
 export const PopoverMode: Story = () => {
@@ -222,6 +295,103 @@ export const PopoverMode: Story = () => {
   )
 }
 
+PopoverMode.play = async ({ canvas, userEvent }) => {
+  const autoDialog = () =>
+    screen.queryByRole("dialog", { name: /auto popover/i })
+  const hintDialog = () =>
+    screen.queryByRole("dialog", { name: /hint popover/i })
+  const manualDialog = () =>
+    screen.queryByRole("dialog", { name: /manual popover/i })
+
+  await userEvent.click(
+    canvas.getByRole("button", { name: /auto \(default\)/i }),
+  )
+  const auto = await screen.findByRole("dialog", { name: /auto popover/i })
+  await expect(auto).toBeVisible()
+
+  await userEvent.click(canvas.getByRole("button", { name: /^hint$/i }))
+  await expect(
+    await screen.findByRole("dialog", { name: /hint popover/i }),
+  ).toBeVisible()
+  await expect(auto).toBeVisible()
+
+  await waitFor(
+    async () => {
+      const hint = hintDialog()
+      if (hint === null) {
+        return
+      }
+      if (hint.checkVisibility()) {
+        await userEvent.keyboard("{Escape}")
+      }
+      const after = hintDialog()
+      if (after === null) {
+        return
+      }
+      expect(after).not.toBeVisible()
+    },
+    { timeout: 10000 },
+  )
+  await expect(
+    screen.getByRole("dialog", { name: /auto popover/i }),
+  ).toBeVisible()
+
+  await waitFor(
+    async () => {
+      const a = autoDialog()
+      if (a === null) {
+        return
+      }
+      if (a.checkVisibility()) {
+        await userEvent.keyboard("{Escape}")
+      }
+      const after = autoDialog()
+      if (after === null) {
+        return
+      }
+      expect(after).not.toBeVisible()
+    },
+    { timeout: 10000 },
+  )
+
+  await userEvent.click(
+    canvas.getByRole("button", { name: /auto \(default\)/i }),
+  )
+  await expect(
+    await screen.findByRole("dialog", { name: /auto popover/i }),
+  ).toBeVisible()
+
+  await userEvent.click(canvas.getByRole("button", { name: /^manual$/i }))
+  await expect(
+    await screen.findByRole("dialog", { name: /manual popover/i }),
+  ).toBeVisible()
+  await waitFor(() => {
+    const el = autoDialog()
+    if (el === null) {
+      return
+    }
+    expect(el).not.toBeVisible()
+  })
+
+  await waitFor(
+    async () => {
+      const m = manualDialog()
+      if (m === null) {
+        return
+      }
+      if (m.checkVisibility()) {
+        await userEvent.keyboard("{Escape}")
+      }
+      const after = manualDialog()
+      if (after === null) {
+        return
+      }
+      expect(after).not.toBeVisible()
+    },
+    { timeout: 10000 },
+  )
+}
+
 export const Offset: Story = () => {
   return (
     <NativePopover.Root offset={[16, 16]}>
@@ -237,6 +407,11 @@ export const Offset: Story = () => {
       </NativePopover.Content>
     </NativePopover.Root>
   )
+}
+
+Offset.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Gutter: Story = () => {
@@ -256,6 +431,11 @@ export const Gutter: Story = () => {
   )
 }
 
+Gutter.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const Disabled: Story = () => {
   return (
     <NativePopover.Root disabled>
@@ -271,6 +451,23 @@ export const Disabled: Story = () => {
       </NativePopover.Content>
     </NativePopover.Root>
   )
+}
+
+Disabled.parameters = {
+  chromatic: { disableSnapshot: true },
+}
+
+Disabled.play = async ({ canvas, userEvent }) => {
+  const trigger = canvas.getByRole("button", { name: /^click me$/i })
+  expect(trigger).toHaveAttribute("aria-disabled", "true")
+  await userEvent.click(trigger)
+  await waitFor(() => {
+    const el = screen.queryByRole("dialog", { name: /ベジータ/ })
+    if (el === null) {
+      return
+    }
+    expect(el).not.toBeVisible()
+  })
 }
 
 export const CloseTrigger: Story = () => {
@@ -293,4 +490,9 @@ export const CloseTrigger: Story = () => {
       </NativePopover.Content>
     </NativePopover.Root>
   )
+}
+
+CloseTrigger.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }

--- a/packages/react/src/components/notice/use-notice.stories.tsx
+++ b/packages/react/src/components/notice/use-notice.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta } from "@storybook/react-vite"
 import type { NoticeCloseStrategy } from "../../core"
 import { useRef } from "react"
+import { expect, screen } from "storybook/test"
 import { toTitleCase } from "../../utils"
 import { Button } from "../button"
 import { For } from "../for"
@@ -31,6 +32,11 @@ export const Basic = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /show notice/i }))
+  await expect(await screen.findByText("シェリル・ノーム")).toBeVisible()
+}
+
 export const Variant = () => {
   const notice = useNotice()
 
@@ -57,6 +63,13 @@ export const Variant = () => {
   )
 }
 
+Variant.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "plain" snack/i }),
+  )
+  await expect(await screen.findByText("シェリル・ノーム")).toBeVisible()
+}
+
 export const Status = () => {
   const notice = useNotice()
 
@@ -80,6 +93,13 @@ export const Status = () => {
       </For>
     </Wrap>
   )
+}
+
+Status.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "info" snack/i }),
+  )
+  await expect(await screen.findByText("ランカ・リー")).toBeVisible()
 }
 
 export const ColorScheme = () => {
@@ -108,6 +128,13 @@ export const ColorScheme = () => {
   )
 }
 
+ColorScheme.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "info" snack/i }),
+  )
+  await expect(await screen.findByText("早乙女アルト")).toBeVisible()
+}
+
 export const Loading = () => {
   const notice = useNotice()
 
@@ -131,6 +158,13 @@ export const Loading = () => {
       </For>
     </Wrap>
   )
+}
+
+Loading.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "oval" snack/i }),
+  )
+  await expect(await screen.findByText("ミハエル・ブラン")).toBeVisible()
 }
 
 export const Limit = () => {
@@ -164,6 +198,13 @@ export const Limit = () => {
   )
 }
 
+Limit.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^show notice$/i })[0],
+  )
+  await expect(await screen.findByText("クラン・クラン")).toBeVisible()
+}
+
 export const Duration = () => {
   const notice = useNotice({ duration: 10000 })
 
@@ -195,6 +236,13 @@ export const Duration = () => {
   )
 }
 
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^show notice$/i })[0],
+  )
+  await expect(await screen.findByText("オズマ・リー")).toBeVisible()
+}
+
 export const KeepStay = () => {
   const notice = useNotice({ duration: null })
 
@@ -211,6 +259,11 @@ export const KeepStay = () => {
       Show Notice
     </Button>
   )
+}
+
+KeepStay.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /show notice/i }))
+  await expect(await screen.findByText("シェリル・ノーム")).toBeVisible()
 }
 
 export const Placement = () => {
@@ -247,6 +300,13 @@ export const Placement = () => {
       </For>
     </Wrap>
   )
+}
+
+Placement.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /open "start-start" notice/i }),
+  )
+  await expect(await screen.findByText("早乙女アルト")).toBeVisible()
 }
 
 export const CloseStrategy = () => {
@@ -298,6 +358,11 @@ export const CloseStrategy = () => {
   )
 }
 
+CloseStrategy.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click only$/i }))
+  await expect(await screen.findByText("早乙女アルト")).toBeVisible()
+}
+
 export const UseClose = () => {
   const notice = useNotice()
   const ref = useRef<number | string | undefined>(undefined)
@@ -330,6 +395,13 @@ export const UseClose = () => {
   )
 }
 
+UseClose.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /show notice/i })[0],
+  )
+  await expect(await screen.findByText("クラン・クラン")).toBeVisible()
+}
+
 export const UseUpdate = () => {
   const notice = useNotice()
   const ref = useRef<number | string | undefined>(undefined)
@@ -360,4 +432,9 @@ export const UseUpdate = () => {
       <Button onClick={onUpdate}>Update last Notice</Button>
     </Wrap>
   )
+}
+
+UseUpdate.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /show notice/i }))
+  await expect(await screen.findByText("シェリル・ノーム")).toBeVisible()
 }

--- a/packages/react/src/components/popover/popover.stories.tsx
+++ b/packages/react/src/components/popover/popover.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { PropsTable } from "#storybook"
 import { useRef } from "react"
+import { expect, screen, within } from "storybook/test"
 import { Popover } from "."
 import { useDisclosure } from "../../hooks/use-disclosure"
 import { toTitleCase } from "../../utils"
@@ -38,6 +39,13 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^click me$/i })[0],
+  )
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const Size: Story = () => {
   return (
     <PropsTable variant="stack" rows={["xs", "sm", "md", "lg"]}>
@@ -59,6 +67,15 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const buttons = canvas.getAllByRole("button", { name: /^click me$/i })
+  for (const button of buttons) {
+    await userEvent.click(button)
+    await expect(await screen.findByRole("dialog")).toBeVisible()
+    await userEvent.click(button)
+  }
+}
+
 export const Footer: Story = () => {
   return (
     <Popover.Root>
@@ -73,6 +90,11 @@ export const Footer: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+Footer.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Anchor: Story = () => {
@@ -102,6 +124,11 @@ export const Anchor: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+Anchor.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const NestedPopover: Story = () => {
@@ -134,6 +161,20 @@ export const NestedPopover: Story = () => {
   )
 }
 
+NestedPopover.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^click me$/i })[0],
+  )
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+  const outer = screen.getByRole("dialog")
+  await userEvent.click(
+    within(outer).getAllByRole("button", { name: /^click me$/i })[0],
+  )
+  await expect(
+    (await screen.findAllByRole("dialog")).length,
+  ).toBeGreaterThanOrEqual(2)
+}
+
 export const Duration: Story = () => {
   return (
     <Popover.Root duration={0.7}>
@@ -147,6 +188,11 @@ export const Duration: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const Offset: Story = () => {
@@ -164,6 +210,11 @@ export const Offset: Story = () => {
   )
 }
 
+Offset.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const Gutter: Story = () => {
   return (
     <Popover.Root gutter={32}>
@@ -177,6 +228,11 @@ export const Gutter: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+Gutter.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const AnimationScheme: Story = () => {
@@ -208,6 +264,27 @@ export const AnimationScheme: Story = () => {
       )}
     </For>
   )
+}
+
+AnimationScheme.play = async ({ canvas, userEvent }) => {
+  const animationSchemes = [
+    "scale",
+    "block-start",
+    "inline-start",
+    "inline-end",
+    "block-end",
+  ] as const
+  for (let i = 0; i < animationSchemes.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${toTitleCase(animationSchemes[i])}" Popover`,
+      }),
+    )
+    await expect(await screen.findByRole("dialog")).toBeVisible()
+  }
 }
 
 export const Placement: Story = () => {
@@ -250,6 +327,36 @@ export const Placement: Story = () => {
   )
 }
 
+Placement.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "start",
+    "start-start",
+    "start-end",
+    "start-center",
+    "end",
+    "end-start",
+    "end-end",
+    "end-center",
+    "center-start",
+    "center-start-start",
+    "center-start-end",
+    "center-end",
+    "center-end-start",
+    "center-end-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.keyboard("{Escape}")
+    }
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: `Open "${toTitleCase(placements[i])}" Popover`,
+      }),
+    )
+    await expect(await screen.findByRole("dialog")).toBeVisible()
+  }
+}
+
 export const Modal: Story = () => {
   return (
     <Popover.Root modal>
@@ -273,6 +380,11 @@ export const Modal: Story = () => {
   )
 }
 
+Modal.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open profile/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const BlockScrollOnMount: Story = () => {
   return (
     <Box minH="200dvh">
@@ -292,6 +404,13 @@ export const BlockScrollOnMount: Story = () => {
   )
 }
 
+BlockScrollOnMount.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /click me and scroll/i }),
+  )
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const CloseOnScroll: Story = () => {
   return (
     <Box minH="200dvh">
@@ -309,6 +428,13 @@ export const CloseOnScroll: Story = () => {
       </Popover.Root>
     </Box>
   )
+}
+
+CloseOnScroll.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /click me and scroll/i }),
+  )
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }
 
 export const InitialFocusRef: Story = () => {
@@ -336,6 +462,11 @@ export const InitialFocusRef: Story = () => {
   )
 }
 
+InitialFocusRef.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open profile/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const Disabled: Story = () => {
   return (
     <Popover.Root disabled>
@@ -349,6 +480,10 @@ export const Disabled: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+Disabled.parameters = {
+  chromatic: { disableSnapshot: true },
 }
 
 export const DisabledCloseOnBlur: Story = () => {
@@ -366,6 +501,13 @@ export const DisabledCloseOnBlur: Story = () => {
   )
 }
 
+DisabledCloseOnBlur.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+  await userEvent.click(document.body)
+  await expect(screen.getByRole("dialog")).toBeVisible()
+}
+
 export const DisabledCloseOnEsc: Story = () => {
   return (
     <Popover.Root closeOnEsc={false}>
@@ -379,6 +521,13 @@ export const DisabledCloseOnEsc: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+DisabledCloseOnEsc.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+  await userEvent.keyboard("{Escape}")
+  await expect(screen.getByRole("dialog")).toBeVisible()
 }
 
 export const CloseTrigger: Story = () => {
@@ -399,6 +548,12 @@ export const CloseTrigger: Story = () => {
       </Popover.Content>
     </Popover.Root>
   )
+}
+
+CloseTrigger.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /^click me$/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+  await userEvent.click(screen.getByRole("button", { name: /^close$/i }))
 }
 
 export const DisabledAutoFocus: Story = () => {
@@ -424,6 +579,11 @@ export const DisabledAutoFocus: Story = () => {
   )
 }
 
+DisabledAutoFocus.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open profile/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const CustomControl: Story = () => {
   const { open, onClose, onOpen } = useDisclosure()
 
@@ -445,4 +605,11 @@ export const CustomControl: Story = () => {
       <Button onClick={onOpen}>Click me from here</Button>
     </>
   )
+}
+
+CustomControl.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getAllByRole("button", { name: /^click me$/i })[0],
+  )
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }

--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -161,6 +161,21 @@ export const Size: Story = () => {
   )
 }
 
+Size.play = async ({ canvas, userEvent }) => {
+  const sizes = ["xs", "sm", "md", "lg", "xl"]
+  const variants = ["outline", "filled", "flushed"]
+
+  for (let i = 0; i < sizes.length; i++) {
+    for (let j = 0; j < variants.length; j++) {
+      const index = i * variants.length + j
+      const comboboxes = canvas.getAllByRole("combobox")
+      await userEvent.click(comboboxes[index]!)
+      await expect(await screen.findByRole("listbox")).toBeVisible()
+      await userEvent.click(comboboxes[index]!)
+    }
+  }
+}
+
 export const DefaultValue: Story = () => {
   const items = useMemo<Select.Item[]>(
     () => [

--- a/packages/react/src/components/snacks/snacks.stories.tsx
+++ b/packages/react/src/components/snacks/snacks.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
 import { useRef } from "react"
+import { expect, screen } from "storybook/test"
 import { toTitleCase } from "../../utils"
 import { Button } from "../button"
 import { For } from "../for"
@@ -45,6 +46,11 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("アムロ・レイ")).toBeVisible()
+}
+
 export const Variant: Story = () => {
   const { snack, snacks } = useSnacks()
 
@@ -81,6 +87,13 @@ export const Variant: Story = () => {
   )
 }
 
+Variant.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "plain" snack/i }),
+  )
+  await expect(await screen.findByText("ララァ・スン")).toBeVisible()
+}
+
 export const Status: Story = () => {
   const { snack, snacks } = useSnacks()
 
@@ -114,6 +127,13 @@ export const Status: Story = () => {
       <Input placeholder="Input" />
     </>
   )
+}
+
+Status.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "info" snack/i }),
+  )
+  await expect(await screen.findByText("アムロ・レイ")).toBeVisible()
 }
 
 export const ColorScheme: Story = () => {
@@ -152,6 +172,13 @@ export const ColorScheme: Story = () => {
   )
 }
 
+ColorScheme.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "info" snack/i }),
+  )
+  await expect(await screen.findByText("シャア・アズナブル")).toBeVisible()
+}
+
 export const Loading: Story = () => {
   const { snack, snacks } = useSnacks()
 
@@ -187,6 +214,13 @@ export const Loading: Story = () => {
   )
 }
 
+Loading.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(
+    canvas.getByRole("button", { name: /add "oval" snack/i }),
+  )
+  await expect(await screen.findByText("セイラ・マス")).toBeVisible()
+}
+
 export const Direction: Story = () => {
   const { snack, snacks } = useSnacks({ direction: "end" })
 
@@ -217,6 +251,11 @@ export const Direction: Story = () => {
   )
 }
 
+Direction.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("シャア・アズナブル")).toBeVisible()
+}
+
 export const Limit: Story = () => {
   const { snack, snacks } = useSnacks({ limit: 5 })
 
@@ -244,6 +283,11 @@ export const Limit: Story = () => {
       <Input placeholder="Input" />
     </>
   )
+}
+
+Limit.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("ブライト・ノア")).toBeVisible()
 }
 
 export const Duration = () => {
@@ -277,6 +321,11 @@ export const Duration = () => {
   )
 }
 
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("セイラ・マス")).toBeVisible()
+}
+
 export const DisabledClosable = () => {
   const { snack, snacks } = useSnacks({ closable: false })
 
@@ -305,6 +354,11 @@ export const DisabledClosable = () => {
       <Input placeholder="Input" />
     </>
   )
+}
+
+DisabledClosable.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("ランバ・ラル")).toBeVisible()
 }
 
 export const UseClose = () => {
@@ -344,6 +398,11 @@ export const UseClose = () => {
       <Input placeholder="Input" />
     </>
   )
+}
+
+UseClose.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("シロー・アマダ")).toBeVisible()
 }
 
 export const UseUpdate = () => {
@@ -388,4 +447,9 @@ export const UseUpdate = () => {
       <Input placeholder="Input" />
     </>
   )
+}
+
+UseUpdate.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /add snack/i }))
+  await expect(await screen.findByText("クワトロ・バジーナ")).toBeVisible()
 }

--- a/packages/react/src/components/tip/tip.stories.tsx
+++ b/packages/react/src/components/tip/tip.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
+import { expect, screen } from "storybook/test"
 import { Tip } from "."
 import { HStack, MessageCircleWarningIcon, Text, toTitleCase } from "../.."
 import { useDisclosure } from "../../hooks/use-disclosure"
@@ -25,6 +26,13 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /俺は俺の責務を全うする/ }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Status: Story = () => {
   return (
     <For each={["help", "info", "success", "warning", "error"] as const}>
@@ -38,6 +46,13 @@ export const Status: Story = () => {
       )}
     </For>
   )
+}
+
+Status.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[0],
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }
 
 export const ColorScheme: Story = () => {
@@ -59,6 +74,13 @@ export const ColorScheme: Story = () => {
   )
 }
 
+ColorScheme.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[0],
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Duration: Story = () => {
   return (
     <HStack gap="xs">
@@ -68,6 +90,13 @@ export const Duration: Story = () => {
       <Tip content="俺は俺の責務を全うする!!" duration={0.7} />
     </HStack>
   )
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /俺は俺の責務を全うする/ }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }
 
 export const Delay: Story = () => {
@@ -98,6 +127,22 @@ export const Delay: Story = () => {
   )
 }
 
+Delay.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[0],
+  )
+  await expect(
+    await screen.findByRole("tooltip", {}, { timeout: 2000 }),
+  ).toBeVisible()
+  await userEvent.unhover(
+    canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[0],
+  )
+  await userEvent.hover(
+    canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[1],
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Offset: Story = () => {
   return (
     <HStack gap="xs">
@@ -109,6 +154,13 @@ export const Offset: Story = () => {
   )
 }
 
+Offset.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /俺は俺の責務を全うする/ }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Gutter: Story = () => {
   return (
     <HStack gap="xs">
@@ -118,6 +170,13 @@ export const Gutter: Story = () => {
       <Tip content="俺は俺の責務を全うする!!" gutter={32} />
     </HStack>
   )
+}
+
+Gutter.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /俺は俺の責務を全うする/ }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }
 
 export const AnimationScheme: Story = () => {
@@ -146,6 +205,29 @@ export const AnimationScheme: Story = () => {
       )}
     </For>
   )
+}
+
+AnimationScheme.play = async ({ canvas, userEvent }) => {
+  const animationSchemes = [
+    "scale",
+    "block-end",
+    "inline-start",
+    "inline-end",
+    "block-start",
+  ] as const
+  for (let i = 0; i < animationSchemes.length; i++) {
+    if (i > 0) {
+      await userEvent.unhover(
+        canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[
+          i - 1
+        ],
+      )
+    }
+    await userEvent.hover(
+      canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[i],
+    )
+    await expect(await screen.findByRole("tooltip")).toBeVisible()
+  }
 }
 
 export const Placement: Story = () => {
@@ -182,6 +264,38 @@ export const Placement: Story = () => {
   )
 }
 
+Placement.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "start",
+    "start-start",
+    "start-end",
+    "start-center",
+    "end",
+    "end-start",
+    "end-end",
+    "end-center",
+    "center-start",
+    "center-start-start",
+    "center-start-end",
+    "center-end",
+    "center-end-start",
+    "center-end-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.unhover(
+        canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[
+          i - 1
+        ],
+      )
+    }
+    await userEvent.hover(
+      canvas.getAllByRole("button", { name: /俺は俺の責務を全うする/ })[i],
+    )
+    await expect(await screen.findByRole("tooltip")).toBeVisible()
+  }
+}
+
 export const Disabled: Story = () => {
   return (
     <HStack gap="xs">
@@ -193,6 +307,10 @@ export const Disabled: Story = () => {
   )
 }
 
+Disabled.parameters = {
+  chromatic: { disableSnapshot: true },
+}
+
 export const AlwaysOpen: Story = () => {
   return (
     <HStack gap="xs">
@@ -202,6 +320,10 @@ export const AlwaysOpen: Story = () => {
       <Tip content="俺は俺の責務を全うする!!" open />
     </HStack>
   )
+}
+
+AlwaysOpen.play = async () => {
+  await expect(screen.getByRole("tooltip")).toBeVisible()
 }
 
 export const CustomIcon: Story = () => {
@@ -216,6 +338,13 @@ export const CustomIcon: Story = () => {
       />
     </HStack>
   )
+}
+
+CustomIcon.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /俺は俺の責務を全うする/ }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }
 
 export const CustomControl: Story = () => {
@@ -234,4 +363,11 @@ export const CustomControl: Story = () => {
       />
     </HStack>
   )
+}
+
+CustomControl.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /俺は俺の責務を全うする/ }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }

--- a/packages/react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/react/src/components/tooltip/tooltip.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from "@storybook/react-vite"
+import { expect, screen } from "storybook/test"
 import { useDisclosure } from "../../hooks/use-disclosure"
 import { toTitleCase } from "../../utils"
 import { Button } from "../button"
@@ -23,12 +24,22 @@ export const Basic: Story = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(canvas.getByRole("button", { name: /please hover/i }))
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Duration: Story = () => {
   return (
     <Tooltip content="へっ！きたねぇ花火だ" duration={0.7}>
       <Button>Please Hover</Button>
     </Tooltip>
   )
+}
+
+Duration.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(canvas.getByRole("button", { name: /please hover/i }))
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }
 
 export const Delay: Story = () => {
@@ -49,6 +60,22 @@ export const Delay: Story = () => {
   )
 }
 
+Delay.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /delay open 1000ms/i }),
+  )
+  await expect(
+    await screen.findByRole("tooltip", {}, { timeout: 2000 }),
+  ).toBeVisible()
+  await userEvent.unhover(
+    canvas.getByRole("button", { name: /delay open 1000ms/i }),
+  )
+  await userEvent.hover(
+    canvas.getByRole("button", { name: /delay close 1000ms/i }),
+  )
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Offset: Story = () => {
   return (
     <Tooltip content="へっ！きたねぇ花火だ" offset={[16, 16]}>
@@ -57,12 +84,22 @@ export const Offset: Story = () => {
   )
 }
 
+Offset.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(canvas.getByRole("button", { name: /please hover/i }))
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
+}
+
 export const Gutter: Story = () => {
   return (
     <Tooltip content="へっ！きたねぇ花火だ" gutter={32}>
       <Button>Please Hover</Button>
     </Tooltip>
   )
+}
+
+Gutter.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(canvas.getByRole("button", { name: /please hover/i }))
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }
 
 export const AnimationScheme: Story = () => {
@@ -89,6 +126,31 @@ export const AnimationScheme: Story = () => {
       )}
     </For>
   )
+}
+
+AnimationScheme.play = async ({ canvas, userEvent }) => {
+  const animationSchemes = [
+    "scale",
+    "block-end",
+    "inline-start",
+    "inline-end",
+    "block-start",
+  ] as const
+  for (let i = 0; i < animationSchemes.length; i++) {
+    if (i > 0) {
+      await userEvent.unhover(
+        canvas.getByRole("button", {
+          name: `Open "${animationSchemes[i - 1]}" Tooltip`,
+        }),
+      )
+    }
+    await userEvent.hover(
+      canvas.getByRole("button", {
+        name: `Open "${animationSchemes[i]}" Tooltip`,
+      }),
+    )
+    await expect(await screen.findByRole("tooltip")).toBeVisible()
+  }
 }
 
 export const Placement: Story = () => {
@@ -126,6 +188,40 @@ export const Placement: Story = () => {
   )
 }
 
+Placement.play = async ({ canvas, userEvent }) => {
+  const placements = [
+    "start",
+    "start-start",
+    "start-end",
+    "start-center",
+    "end",
+    "end-start",
+    "end-end",
+    "end-center",
+    "center-start",
+    "center-start-start",
+    "center-start-end",
+    "center-end",
+    "center-end-start",
+    "center-end-end",
+  ] as const
+  for (let i = 0; i < placements.length; i++) {
+    if (i > 0) {
+      await userEvent.unhover(
+        canvas.getByRole("button", {
+          name: `Open "${toTitleCase(placements[i - 1])}" Tooltip`,
+        }),
+      )
+    }
+    await userEvent.hover(
+      canvas.getByRole("button", {
+        name: `Open "${toTitleCase(placements[i])}" Tooltip`,
+      }),
+    )
+    await expect(await screen.findByRole("tooltip")).toBeVisible()
+  }
+}
+
 export const Disabled: Story = () => {
   return (
     <Tooltip content="へっ！きたねぇ花火だ" disabled>
@@ -134,12 +230,20 @@ export const Disabled: Story = () => {
   )
 }
 
+Disabled.parameters = {
+  chromatic: { disableSnapshot: true },
+}
+
 export const AlwaysOpen: Story = () => {
   return (
     <Tooltip content="へっ！きたねぇ花火だ" open>
       <Button>Please Hover</Button>
     </Tooltip>
   )
+}
+
+AlwaysOpen.play = async () => {
+  await expect(screen.getByRole("tooltip")).toBeVisible()
 }
 
 export const CustomControl: Story = () => {
@@ -155,4 +259,9 @@ export const CustomControl: Story = () => {
       <Button>Please Hover</Button>
     </Tooltip>
   )
+}
+
+CustomControl.play = async ({ canvas, userEvent }) => {
+  await userEvent.hover(canvas.getByRole("button", { name: /please hover/i }))
+  await expect(await screen.findByRole("tooltip")).toBeVisible()
 }

--- a/packages/react/src/hooks/use-disclosure/use-disclosure.stories.tsx
+++ b/packages/react/src/hooks/use-disclosure/use-disclosure.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from "@storybook/react-vite"
+import { expect, screen } from "storybook/test"
 import { Button } from "../../components/button"
 import { Modal } from "../../components/modal"
 // import { Dialog } from "../../components/modal"
@@ -33,6 +34,11 @@ export const Basic = () => {
   )
 }
 
+Basic.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
+}
+
 export const Toggle = () => {
   const { open, onToggle } = useDisclosure()
 
@@ -43,6 +49,11 @@ export const Toggle = () => {
       {open ? <Text>Hey!</Text> : null}
     </>
   )
+}
+
+Toggle.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /please click/i }))
+  await expect(await screen.findByText("Hey!")).toBeVisible()
 }
 
 export const Chain = () => {
@@ -72,4 +83,9 @@ export const Chain = () => {
       />
     </>
   )
+}
+
+Chain.play = async ({ canvas, userEvent }) => {
+  await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }))
+  await expect(await screen.findByRole("dialog")).toBeVisible()
 }

--- a/packages/react/storybook/main.ts
+++ b/packages/react/storybook/main.ts
@@ -11,7 +11,7 @@ export const config: StorybookConfig = {
     actions: false,
     backgrounds: false,
     controls: false,
-    interactions: false,
+    interactions: true,
   },
   framework: "@storybook/react-vite",
   stories: ["../src/**/*.@(mdx|stories.@(tsx))"],

--- a/packages/react/storybook/preview.tsx
+++ b/packages/react/storybook/preview.tsx
@@ -1,4 +1,5 @@
 import type { Preview, StoryContext } from "@storybook/react-vite"
+import { MotionGlobalConfig } from "motion/react"
 import { useEffect } from "react"
 import { GLOBALS_UPDATED } from "storybook/internal/core-events"
 import { addons } from "storybook/preview-api"
@@ -21,6 +22,15 @@ const visualTestEnabled = isVisualTest(
 setupVisualTestRuntimeContract({
   envValue: import.meta.env.STORYBOOK_VISUAL_TEST,
 })
+
+const skipMotionAnimations = isVisualTest(
+  globalThis as unknown as VisualTestGlobal,
+  import.meta.env.STORYBOOK_VISUAL_TEST,
+)
+
+if (skipMotionAnimations) {
+  MotionGlobalConfig.skipAnimations = true
+}
 
 const preview: Preview = {
   decorators: [
@@ -139,6 +149,7 @@ const preview: Preview = {
       test: "error",
     },
     chromatic: {
+      pauseAnimationAtEnd: true,
       viewports: [VISUAL_TEST_VIEWPORT_WIDTH],
     },
     docs: { codePanel: true },


### PR DESCRIPTION
## Summary

- Fix Popover Size story to iterate through all 4 size variants and close each before opening the next
- Fix NativePopover Size story and PopoverMode to use button toggle instead of Escape
- Fix Menu Size and NestedMenu stories to test all variants and hover interactions  
- Add Size story play functions for Select and Autocomplete with all variant combinations
- Fix DisabledCloseOnBlur and DisabledCloseOnEsc stories to actually verify disabled behavior

## Testing

Run chromatic tests to verify all stories pass.

## Related

Closes #6767