### PR TITLE
Security: Catch-all fallback re-executes module code with `node-eval`

### DIFF
--- a/packages/cli/src/utils/module.ts
+++ b/packages/cli/src/utils/module.ts
@@ -1,6 +1,5 @@
 import { isObject } from "@yamada-ui/utils"
 import { build } from "esbuild"
-import nodeEval from "node-eval"
 import { realpathSync } from "node:fs"
 import { Script } from "node:vm"
 
@@ -22,22 +21,16 @@ export async function getModule(file: string, cwd: string) {
     ? Object.keys(result.metafile.inputs)
     : []
 
-  try {
-    const realFileName = realpathSync.native(file)
+  const realFileName = realpathSync.native(file)
 
-    if (!code) throw new Error("code is undefined")
+  if (!code) throw new Error("code is undefined")
 
-    const script = new Script(code, { filename: realFileName })
-    const mod = { exports: {} }
-    const require = (id: string): any =>
-      id === realFileName ? mod.exports : require(id)
+  const script = new Script(code, { filename: realFileName })
+  const mod = { exports: {} }
+  const require = (id: string): any =>
+    id === realFileName ? mod.exports : require(id)
 
-    script.runInThisContext()(mod.exports, require, mod)
+  script.runInThisContext()(mod.exports, require, mod)
 
-    return { code, dependencies, mod }
-  } catch {
-    const mod = nodeEval(code)
-
-    return { code, dependencies, mod }
-  }
+  return { code, dependencies, mod }
 }


### PR DESCRIPTION
## Summary

Security: Catch-all fallback re-executes module code with `node-eval`

## Problem

**Severity**: `Medium` | **File**: `packages/cli/src/utils/module.ts:L22`

Any error during the `vm` execution path triggers a catch block that re-evaluates the same code using `node-eval`. This means malicious or faulty code can execute once in the VM path and then execute again in the fallback path, amplifying side effects and making exploit behavior more reliable.

## Solution

Do not re-evaluate on generic errors. Only fallback for narrowly scoped, validated error types (if absolutely necessary), and never execute the same code twice. Prefer failing closed with explicit error reporting.

## Changes

- `packages/cli/src/utils/module.ts` (modified)