### PR TITLE
ci(test): remove playwright with-deps installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Browser
         if: steps.check-modified.outputs.any_changed == 'true'
-        run: pnpm react exec playwright install chromium --with-deps --only-shell
+        run: pnpm react exec playwright install chromium --only-shell
 
       - name: Run chromium coverage shard
         if: steps.check-modified.outputs.any_changed == 'true'
@@ -99,7 +99,7 @@ jobs:
 
       - name: Setup Browser
         if: steps.check-modified.outputs.any_changed == 'true'
-        run: pnpm react exec playwright install ${{ matrix.id }} --with-deps
+        run: pnpm react exec playwright install ${{ matrix.id }}
 
       - name: Run Browser Test on ${{ matrix.id }}
         if: steps.check-modified.outputs.any_changed == 'true'


### PR DESCRIPTION
Closes #6795

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Remove `--with-deps` from the remaining Playwright install commands in the test workflow so browser setup stays leaner and can complete faster on GitHub-hosted runners.

## Current behavior (updates)

The Chromium, Firefox, and WebKit setup steps still invoke Playwright install with `--with-deps`, which adds extra dependency installation during browser setup.

## New behavior

The workflow now installs Chromium with `--only-shell` only and installs Firefox/WebKit without `--with-deps`, reducing extra setup work in those browser setup steps.

## Is this a breaking change (Yes/No):

No

## Additional Information

Related #6631
