### PR TITLE
[WIP] test(editable): migrate tests to Vitest Browser Mode

### DIFF
--- a/packages/react/src/components/editable/editable.test.tsx
+++ b/packages/react/src/components/editable/editable.test.tsx
@@ -42,10 +42,11 @@ describe("<Editable />", () => {
     const input = page.getByTestId("EditableInput")
 
     await user.click(preview)
+    await expect.element(input).toBeVisible()
     await user.clear(input)
     await user.type(input, "Updated text")
 
-    expect(preview.element()).toHaveTextContent("Updated text")
+    await expect.element(preview).toHaveTextContent("Updated text")
     await expect.element(input).toHaveValue("Updated text")
   })
 
@@ -99,9 +100,13 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditableInput"))
+    const input = page.getByTestId("EditableInput")
+
+    await expect.element(input).toBeVisible()
+    await user.click(input)
     await user.keyboard("{Escape}")
 
+    await expect.poll(() => onCancel.mock.calls.length).toBe(1)
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
@@ -118,7 +123,10 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditableInput"))
+    const input = page.getByTestId("EditableInput")
+
+    await expect.element(input).toBeVisible()
+    await user.click(input)
     await user.keyboard("{Enter}")
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -137,7 +145,10 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditableInput"))
+    const input = page.getByTestId("EditableInput")
+
+    await expect.element(input).toBeVisible()
+    await user.click(input)
     await user.keyboard("{Shift>}")
     await user.keyboard("{Enter}")
     await user.keyboard("{/Shift}")
@@ -163,10 +174,12 @@ describe("<Editable />", () => {
 
     const input = page.getByTestId("EditableInput")
 
+    await expect.element(input).toBeVisible()
     await user.click(input)
     await user.clear(input)
     await user.type(input, "New text")
 
+    await expect.poll(() => onChange.mock.calls.at(-1)?.[0]).toBe("New text")
     expect(onChange).toHaveBeenLastCalledWith("New text")
   })
 
@@ -184,6 +197,7 @@ describe("<Editable />", () => {
 
     const input = page.getByTestId("EditableInput")
 
+    await expect.element(input).toBeVisible()
     await user.click(input)
     await user.keyboard("{Enter}")
 
@@ -213,7 +227,11 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditablePreview"))
+    const preview = page.getByTestId("EditablePreview")
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(preview)
+    await expect.element(input).toBeVisible()
     await user.keyboard("{Escape}")
 
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -234,7 +252,11 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditablePreview"))
+    const preview = page.getByTestId("EditablePreview")
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(preview)
+    await expect.element(input).toBeVisible()
     await user.keyboard("{Enter}")
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -261,7 +283,11 @@ describe("<Editable />", () => {
       </>,
     )
 
-    await user.click(page.getByTestId("EditablePreview"))
+    const preview = page.getByTestId("EditablePreview")
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(preview)
+    await expect.element(input).toBeVisible()
     await user.click(page.getByTestId("Outside"))
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -288,7 +314,11 @@ describe("<Editable />", () => {
       </>,
     )
 
-    await user.click(page.getByTestId("EditablePreview"))
+    const preview = page.getByTestId("EditablePreview")
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(preview)
+    await expect.element(input).toBeVisible()
     await user.click(page.getByTestId("Outside"))
 
     expect(onSubmit).not.toHaveBeenCalled()
@@ -307,9 +337,7 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    expect(page.getByTestId("EditableInput").element()).not.toHaveAttribute(
-      "hidden",
-    )
+    await expect.element(page.getByTestId("EditableInput")).toBeVisible()
   })
 
   test("supports children as a function", async () => {
@@ -332,15 +360,13 @@ describe("<Editable />", () => {
         onSubmit: expect.any(Function),
       }),
     )
-    expect(
-      document.querySelector("[data-testid='editing-indicator']"),
-    ).toBeNull()
+    expect(page.getByTestId("editing-indicator").query()).toBeNull()
 
     await user.click(page.getByTestId("EditablePreview"))
 
-    expect(
-      document.querySelector("[data-testid='editing-indicator']"),
-    ).not.toBeNull()
+    await expect
+      .element(page.getByTestId("editing-indicator"))
+      .toBeInTheDocument()
   })
 })
 
@@ -385,7 +411,10 @@ describe("<EditableTextarea />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditableTextarea"))
+    const textarea = page.getByTestId("EditableTextarea")
+
+    await expect.element(textarea).toBeVisible()
+    await user.click(textarea)
     await user.keyboard("{Escape}")
 
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -404,7 +433,10 @@ describe("<EditableTextarea />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditableTextarea"))
+    const textarea = page.getByTestId("EditableTextarea")
+
+    await expect.element(textarea).toBeVisible()
+    await user.click(textarea)
     await user.keyboard("{Enter}")
 
     expect(onSubmit).not.toHaveBeenCalled()

--- a/packages/react/src/components/editable/editable.test.tsx
+++ b/packages/react/src/components/editable/editable.test.tsx
@@ -39,7 +39,7 @@ describe("<Editable />", () => {
     const preview = getByTestId("EditablePreview")
     const input = getByTestId("EditableInput")
 
-    await user.tab()
+    await user.click(preview)
     await expect.element(input).toBeVisible()
     await expect.element(input).toHaveFocus()
     await input.fill("Updated text")
@@ -88,20 +88,17 @@ describe("<Editable />", () => {
   test("calls onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn()
     const { getByTestId, user } = await render(
-      <Editable.Root
-        defaultValue="Some text"
-        startWithEditView
-        onCancel={onCancel}
-      >
-        <Editable.Preview />
+      <Editable.Root defaultValue="Some text" onCancel={onCancel}>
+        <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
+    const preview = getByTestId("EditablePreview")
     const input = getByTestId("EditableInput")
 
+    await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(input)
     await expect.element(input).toHaveFocus()
     await user.keyboard("{Escape}")
 
@@ -112,20 +109,18 @@ describe("<Editable />", () => {
   test("calls onSubmit when Enter is pressed", async () => {
     const onSubmit = vi.fn()
     const { getByTestId, user } = await render(
-      <Editable.Root
-        defaultValue="Some text"
-        startWithEditView
-        onSubmit={onSubmit}
-      >
+      <Editable.Root defaultValue="Some text" onSubmit={onSubmit}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
+    const preview = getByTestId("EditablePreview")
     const input = getByTestId("EditableInput")
 
+    await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(input)
+    await expect.element(input).toHaveFocus()
     await user.keyboard("{Enter}")
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -134,20 +129,17 @@ describe("<Editable />", () => {
   test("does not call onSubmit when Enter is pressed with Shift or Meta", async () => {
     const onSubmit = vi.fn()
     const { getByTestId, user } = await render(
-      <Editable.Root
-        defaultValue="Some text"
-        startWithEditView
-        onSubmit={onSubmit}
-      >
-        <Editable.Preview />
+      <Editable.Root defaultValue="Some text" onSubmit={onSubmit}>
+        <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
+    const preview = getByTestId("EditablePreview")
     const input = getByTestId("EditableInput")
 
+    await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(input)
     await expect.element(input).toHaveFocus()
     await user.keyboard("{Shift>}{Enter}{/Shift}")
     await user.keyboard("{Meta>}{Enter}{/Meta}")

--- a/packages/react/src/components/editable/editable.test.tsx
+++ b/packages/react/src/components/editable/editable.test.tsx
@@ -87,20 +87,26 @@ describe("<Editable />", () => {
 
   test("calls onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn()
-    const { getByTestId, user } = await render(
+    const { locator, user } = await render(
       <Editable.Root defaultValue="Some text" onCancel={onCancel}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
-    const preview = getByTestId("EditablePreview")
-    const input = getByTestId("EditableInput")
+    const preview = locator.getByTestId("EditablePreview")
+    const input = locator.getByTestId("EditableInput")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
     await expect.element(input).toHaveFocus()
-    await user.keyboard("{Escape}")
+    input.element().dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
 
     await expect.poll(() => onCancel.mock.calls.length).toBe(1)
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -128,21 +134,35 @@ describe("<Editable />", () => {
 
   test("does not call onSubmit when Enter is pressed with Shift or Meta", async () => {
     const onSubmit = vi.fn()
-    const { getByTestId, user } = await render(
+    const { locator, user } = await render(
       <Editable.Root defaultValue="Some text" onSubmit={onSubmit}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
-    const preview = getByTestId("EditablePreview")
-    const input = getByTestId("EditableInput")
+    const preview = locator.getByTestId("EditablePreview")
+    const input = locator.getByTestId("EditableInput")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
     await expect.element(input).toHaveFocus()
-    await user.keyboard("{Shift>}{Enter}{/Shift}")
-    await user.keyboard("{Meta>}{Enter}{/Meta}")
+    input.element().dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+        shiftKey: true,
+      }),
+    )
+    input.element().dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+      }),
+    )
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
@@ -172,7 +192,7 @@ describe("<Editable />", () => {
   })
 
   test("focuses out of the input when editing ends", async () => {
-    const { getByTestId, user } = await render(
+    const { locator, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         selectAllOnFocus
@@ -183,7 +203,7 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const input = getByTestId("EditableInput")
+    const input = locator.getByTestId("EditableInput")
 
     await expect.element(input).toBeVisible()
     await user.click(input)
@@ -254,7 +274,7 @@ describe("<Editable />", () => {
   test("calls onSubmit when onBlur is triggered with submitOnBlur", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { getByTestId, user } = await render(
+    const { locator, user } = await render(
       <>
         <Editable.Root
           defaultValue="Some text"
@@ -271,12 +291,14 @@ describe("<Editable />", () => {
       </>,
     )
 
-    const preview = getByTestId("EditablePreview")
-    const input = getByTestId("EditableInput")
+    const preview = locator.getByTestId("EditablePreview")
+    const input = locator.getByTestId("EditableInput")
+    const outside = locator.getByTestId("Outside")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(getByTestId("Outside"))
+    await expect.element(input).toHaveFocus()
+    await user.click(outside)
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
     expect(onCancel).not.toHaveBeenCalled()
@@ -285,7 +307,7 @@ describe("<Editable />", () => {
   test("calls onCancel when onBlur", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { getByTestId, user } = await render(
+    const { locator, user } = await render(
       <>
         <Editable.Root
           defaultValue="Some text"
@@ -302,12 +324,14 @@ describe("<Editable />", () => {
       </>,
     )
 
-    const preview = getByTestId("EditablePreview")
-    const input = getByTestId("EditableInput")
+    const preview = locator.getByTestId("EditablePreview")
+    const input = locator.getByTestId("EditableInput")
+    const outside = locator.getByTestId("Outside")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(getByTestId("Outside"))
+    await expect.element(input).toHaveFocus()
+    await user.click(outside)
 
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
@@ -386,7 +410,7 @@ describe("<EditableTextarea />", () => {
 
   test("calls onCancel when Escape is pressed in textarea", async () => {
     const onCancel = vi.fn()
-    const { getByTestId, user } = await render(
+    const { locator, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -397,12 +421,20 @@ describe("<EditableTextarea />", () => {
       </Editable.Root>,
     )
 
-    const textarea = getByTestId("EditableTextarea")
+    const textarea = locator.getByTestId("EditableTextarea")
 
     await expect.element(textarea).toBeVisible()
     await user.click(textarea)
-    await user.keyboard("{Escape}")
+    await expect.element(textarea).toHaveFocus()
+    textarea.element().dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
 
+    await expect.poll(() => onCancel.mock.calls.length).toBe(1)
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 

--- a/packages/react/src/components/editable/editable.test.tsx
+++ b/packages/react/src/components/editable/editable.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, page, render } from "#test/browser"
+import { a11y, render } from "#test/browser"
 import { Editable } from "./"
 
 describe("<Editable />", () => {
@@ -12,22 +12,20 @@ describe("<Editable />", () => {
   })
 
   test("should render editable component", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root data-testid="Editable" defaultValue="Some text">
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
-    await expect.element(page.getByTestId("Editable")).toBeVisible()
-    await expect.element(page.getByTestId("EditablePreview")).toBeVisible()
-    await expect
-      .element(page.getByTestId("EditableInput"))
-      .toHaveValue("Some text")
+    await expect.element(getByTestId("Editable")).toBeVisible()
+    await expect.element(getByTestId("EditablePreview")).toBeVisible()
+    await expect.element(getByTestId("EditableInput")).toHaveValue("Some text")
   })
 
   test("should render with preview focusable", async () => {
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         data-testid="Editable"
         defaultValue="Some text"
@@ -38,20 +36,20 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const preview = page.getByTestId("EditablePreview")
-    const input = page.getByTestId("EditableInput")
+    const preview = getByTestId("EditablePreview")
+    const input = getByTestId("EditableInput")
 
-    await user.click(preview)
+    await user.tab()
     await expect.element(input).toBeVisible()
-    await user.clear(input)
-    await user.type(input, "Updated text")
+    await expect.element(input).toHaveFocus()
+    await input.fill("Updated text")
 
     await expect.element(preview).toHaveTextContent("Updated text")
     await expect.element(input).toHaveValue("Updated text")
   })
 
   test("should render with placeholder", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root placeholder="Enter some text">
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
@@ -59,23 +57,23 @@ describe("<Editable />", () => {
     )
 
     await expect
-      .element(page.getByTestId("EditableInput"))
+      .element(getByTestId("EditableInput"))
       .toHaveAttribute("placeholder", "Enter some text")
   })
 
   test("should disable the input", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root defaultValue="Some text" disabled>
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
-    await expect.element(page.getByTestId("EditableInput")).toBeDisabled()
+    await expect.element(getByTestId("EditableInput")).toBeDisabled()
   })
 
   test("should make the input readOnly", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root defaultValue="Some text" readOnly>
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
@@ -83,13 +81,13 @@ describe("<Editable />", () => {
     )
 
     await expect
-      .element(page.getByTestId("EditableInput"))
+      .element(getByTestId("EditableInput"))
       .toHaveProperty("readOnly", true)
   })
 
   test("calls onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -100,10 +98,11 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const input = page.getByTestId("EditableInput")
+    const input = getByTestId("EditableInput")
 
     await expect.element(input).toBeVisible()
     await user.click(input)
+    await expect.element(input).toHaveFocus()
     await user.keyboard("{Escape}")
 
     await expect.poll(() => onCancel.mock.calls.length).toBe(1)
@@ -112,7 +111,7 @@ describe("<Editable />", () => {
 
   test("calls onSubmit when Enter is pressed", async () => {
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -123,7 +122,7 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const input = page.getByTestId("EditableInput")
+    const input = getByTestId("EditableInput")
 
     await expect.element(input).toBeVisible()
     await user.click(input)
@@ -134,7 +133,7 @@ describe("<Editable />", () => {
 
   test("does not call onSubmit when Enter is pressed with Shift or Meta", async () => {
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -145,23 +144,20 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const input = page.getByTestId("EditableInput")
+    const input = getByTestId("EditableInput")
 
     await expect.element(input).toBeVisible()
     await user.click(input)
-    await user.keyboard("{Shift>}")
-    await user.keyboard("{Enter}")
-    await user.keyboard("{/Shift}")
-    await user.keyboard("{Meta>}")
-    await user.keyboard("{Enter}")
-    await user.keyboard("{/Meta}")
+    await expect.element(input).toHaveFocus()
+    await user.keyboard("{Shift>}{Enter}{/Shift}")
+    await user.keyboard("{Meta>}{Enter}{/Meta}")
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
   test("calls onChange when input value changes", async () => {
     const onChange = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -172,19 +168,19 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const input = page.getByTestId("EditableInput")
+    const input = getByTestId("EditableInput")
 
     await expect.element(input).toBeVisible()
     await user.click(input)
-    await user.clear(input)
-    await user.type(input, "New text")
+    await expect.element(input).toHaveFocus()
+    await input.fill("New text")
 
     await expect.poll(() => onChange.mock.calls.at(-1)?.[0]).toBe("New text")
     expect(onChange).toHaveBeenLastCalledWith("New text")
   })
 
   test("focuses out of the input when editing ends", async () => {
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         selectAllOnFocus
@@ -195,7 +191,7 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const input = page.getByTestId("EditableInput")
+    const input = getByTestId("EditableInput")
 
     await expect.element(input).toBeVisible()
     await user.click(input)
@@ -206,29 +202,29 @@ describe("<Editable />", () => {
 
   test("calls onEdit when editing starts", async () => {
     const onEdit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root defaultValue="Some text" onEdit={onEdit}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input />
       </Editable.Root>,
     )
 
-    await user.click(page.getByTestId("EditablePreview"))
+    await user.click(getByTestId("EditablePreview"))
 
     expect(onEdit).toHaveBeenCalledExactlyOnceWith()
   })
 
   test("focus and calls onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root defaultValue="Some text" onCancel={onCancel}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
 
-    const preview = page.getByTestId("EditablePreview")
-    const input = page.getByTestId("EditableInput")
+    const preview = getByTestId("EditablePreview")
+    const input = getByTestId("EditableInput")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
@@ -240,7 +236,7 @@ describe("<Editable />", () => {
   test("focus and calls onSubmit when Enter is pressed", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         submitOnBlur
@@ -252,8 +248,8 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    const preview = page.getByTestId("EditablePreview")
-    const input = page.getByTestId("EditableInput")
+    const preview = getByTestId("EditablePreview")
+    const input = getByTestId("EditableInput")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
@@ -266,7 +262,7 @@ describe("<Editable />", () => {
   test("calls onSubmit when onBlur is triggered with submitOnBlur", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <>
         <Editable.Root
           defaultValue="Some text"
@@ -283,12 +279,12 @@ describe("<Editable />", () => {
       </>,
     )
 
-    const preview = page.getByTestId("EditablePreview")
-    const input = page.getByTestId("EditableInput")
+    const preview = getByTestId("EditablePreview")
+    const input = getByTestId("EditableInput")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(page.getByTestId("Outside"))
+    await user.click(getByTestId("Outside"))
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
     expect(onCancel).not.toHaveBeenCalled()
@@ -297,7 +293,7 @@ describe("<Editable />", () => {
   test("calls onCancel when onBlur", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <>
         <Editable.Root
           defaultValue="Some text"
@@ -314,19 +310,19 @@ describe("<Editable />", () => {
       </>,
     )
 
-    const preview = page.getByTestId("EditablePreview")
-    const input = page.getByTestId("EditableInput")
+    const preview = getByTestId("EditablePreview")
+    const input = getByTestId("EditableInput")
 
     await user.click(preview)
     await expect.element(input).toBeVisible()
-    await user.click(page.getByTestId("Outside"))
+    await user.click(getByTestId("Outside"))
 
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
   test("initially in correct edit mode", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root
         data-testid="Editable"
         defaultValue="Some text"
@@ -337,7 +333,7 @@ describe("<Editable />", () => {
       </Editable.Root>,
     )
 
-    await expect.element(page.getByTestId("EditableInput")).toBeVisible()
+    await expect.element(getByTestId("EditableInput")).toBeVisible()
   })
 
   test("supports children as a function", async () => {
@@ -348,7 +344,7 @@ describe("<Editable />", () => {
         {editing ? <span data-testid="editing-indicator" /> : null}
       </>
     ))
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root defaultValue="Some text">{childrenFn}</Editable.Root>,
     )
 
@@ -360,31 +356,29 @@ describe("<Editable />", () => {
         onSubmit: expect.any(Function),
       }),
     )
-    expect(page.getByTestId("editing-indicator").query()).toBeNull()
+    expect(getByTestId("editing-indicator").query()).toBeNull()
 
-    await user.click(page.getByTestId("EditablePreview"))
+    await user.click(getByTestId("EditablePreview"))
 
-    await expect
-      .element(page.getByTestId("editing-indicator"))
-      .toBeInTheDocument()
+    await expect.element(getByTestId("editing-indicator")).toBeInTheDocument()
   })
 })
 
 describe("<EditableTextarea />", () => {
   test("renders correctly", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root defaultValue="Some text">
         <Editable.Textarea data-testid="EditableTextarea" />
       </Editable.Root>,
     )
 
-    const textarea = page.getByTestId("EditableTextarea")
+    const textarea = getByTestId("EditableTextarea")
 
     await expect.element(textarea).toHaveValue("Some text")
   })
 
   test("applies custom className", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root defaultValue="Some text">
         <Editable.Textarea
           className="custom-class"
@@ -394,13 +388,13 @@ describe("<EditableTextarea />", () => {
     )
 
     await expect
-      .element(page.getByTestId("EditableTextarea"))
+      .element(getByTestId("EditableTextarea"))
       .toHaveClass("custom-class")
   })
 
   test("calls onCancel when Escape is pressed in textarea", async () => {
     const onCancel = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -411,7 +405,7 @@ describe("<EditableTextarea />", () => {
       </Editable.Root>,
     )
 
-    const textarea = page.getByTestId("EditableTextarea")
+    const textarea = getByTestId("EditableTextarea")
 
     await expect.element(textarea).toBeVisible()
     await user.click(textarea)
@@ -422,7 +416,7 @@ describe("<EditableTextarea />", () => {
 
   test("does not submit when Enter is pressed in textarea", async () => {
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -433,7 +427,7 @@ describe("<EditableTextarea />", () => {
       </Editable.Root>,
     )
 
-    const textarea = page.getByTestId("EditableTextarea")
+    const textarea = getByTestId("EditableTextarea")
 
     await expect.element(textarea).toBeVisible()
     await user.click(textarea)
@@ -445,7 +439,7 @@ describe("<EditableTextarea />", () => {
 
 describe("<EditableControl />", () => {
   test("renders correctly with role group", async () => {
-    await render(
+    const { getByTestId } = await render(
       <Editable.Root defaultValue="Some text">
         <Editable.Control data-testid="EditableControl">
           <Editable.Preview />
@@ -455,7 +449,7 @@ describe("<EditableControl />", () => {
     )
 
     await expect
-      .element(page.getByTestId("EditableControl"))
+      .element(getByTestId("EditableControl"))
       .toHaveAttribute("role", "group")
   })
 })
@@ -463,7 +457,7 @@ describe("<EditableControl />", () => {
 describe("<EditableEditTrigger />", () => {
   test("renders and triggers edit mode on click", async () => {
     const onEdit = vi.fn()
-    const { user } = await render(
+    const { getByRole, getByTestId, user } = await render(
       <Editable.Root defaultValue="Some text" onEdit={onEdit}>
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
@@ -473,19 +467,17 @@ describe("<EditableEditTrigger />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByRole("button", { name: "Edit" }))
+    await user.click(getByRole("button", { name: "Edit" }))
 
     expect(onEdit).toHaveBeenCalledExactlyOnceWith()
-    expect(page.getByTestId("EditableInput").element()).not.toHaveAttribute(
-      "hidden",
-    )
+    expect(getByTestId("EditableInput").element()).not.toHaveAttribute("hidden")
   })
 })
 
 describe("<EditableCancelTrigger />", () => {
   test("renders and triggers cancel on click", async () => {
     const onCancel = vi.fn()
-    const { user } = await render(
+    const { getByTestId, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -499,7 +491,7 @@ describe("<EditableCancelTrigger />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByRole("button", { name: "Cancel" }))
+    await user.click(getByTestId("CancelTrigger"))
 
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
@@ -508,7 +500,7 @@ describe("<EditableCancelTrigger />", () => {
 describe("<EditableSubmitTrigger />", () => {
   test("renders and triggers submit on click", async () => {
     const onSubmit = vi.fn()
-    const { user } = await render(
+    const { getByRole, user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -522,7 +514,7 @@ describe("<EditableSubmitTrigger />", () => {
       </Editable.Root>,
     )
 
-    await user.click(page.getByRole("button", { name: "Submit" }))
+    await user.click(getByRole("button", { name: "Submit" }))
 
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
   })

--- a/packages/react/src/components/editable/editable.test.tsx
+++ b/packages/react/src/components/editable/editable.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, act, fireEvent, render } from "#test"
+import { a11y, page, render } from "#test/browser"
 import { Editable } from "./"
 
 describe("<Editable />", () => {
@@ -11,20 +11,23 @@ describe("<Editable />", () => {
     )
   })
 
-  test("should render editable component", () => {
-    const { getByTestId } = render(
+  test("should render editable component", async () => {
+    await render(
       <Editable.Root data-testid="Editable" defaultValue="Some text">
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    expect(getByTestId("Editable")).toBeInTheDocument()
-    expect(getByTestId("EditablePreview")).toBeInTheDocument()
-    expect(getByTestId("EditableInput")).toHaveAttribute("value", "Some text")
+
+    await expect.element(page.getByTestId("Editable")).toBeVisible()
+    await expect.element(page.getByTestId("EditablePreview")).toBeVisible()
+    await expect
+      .element(page.getByTestId("EditableInput"))
+      .toHaveValue("Some text")
   })
 
-  test("should render with preview focusable", () => {
-    const { getByTestId } = render(
+  test("should render with preview focusable", async () => {
+    const { user } = await render(
       <Editable.Root
         data-testid="Editable"
         defaultValue="Some text"
@@ -34,152 +37,192 @@ describe("<Editable />", () => {
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.click(getByTestId("Editable"))
-    fireEvent.input(getByTestId("EditableInput"), {
-      target: {
-        value: "Updated text",
-      },
-    })
-    expect(getByTestId("EditablePreview")).toHaveTextContent("Updated text")
-    expect(getByTestId("EditableInput")).toHaveAttribute(
-      "value",
-      "Updated text",
-    )
+
+    const preview = page.getByTestId("EditablePreview")
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(preview)
+    await user.clear(input)
+    await user.type(input, "Updated text")
+
+    expect(preview.element()).toHaveTextContent("Updated text")
+    await expect.element(input).toHaveValue("Updated text")
   })
 
-  test("should render with placeholder", () => {
-    const { getByTestId } = render(
+  test("should render with placeholder", async () => {
+    await render(
       <Editable.Root placeholder="Enter some text">
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    expect(getByTestId("EditableInput")).toHaveAttribute(
-      "placeholder",
-      "Enter some text",
-    )
+
+    await expect
+      .element(page.getByTestId("EditableInput"))
+      .toHaveAttribute("placeholder", "Enter some text")
   })
 
-  test("should disable the input", () => {
-    const { getByTestId } = render(
+  test("should disable the input", async () => {
+    await render(
       <Editable.Root defaultValue="Some text" disabled>
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    expect(getByTestId("EditableInput")).toBeDisabled()
+
+    await expect.element(page.getByTestId("EditableInput")).toBeDisabled()
   })
 
-  test("should make the input readOnly", () => {
-    const { getByTestId } = render(
+  test("should make the input readOnly", async () => {
+    await render(
       <Editable.Root defaultValue="Some text" readOnly>
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    expect(getByTestId("EditableInput")).toHaveAttribute("readonly")
+
+    await expect
+      .element(page.getByTestId("EditableInput"))
+      .toHaveProperty("readOnly", true)
   })
 
-  test("calls onCancel when Escape is pressed", () => {
+  test("calls onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn()
-    const { getByTestId } = render(
-      <Editable.Root defaultValue="Some text" onCancel={onCancel}>
+    const { user } = await render(
+      <Editable.Root
+        defaultValue="Some text"
+        startWithEditView
+        onCancel={onCancel}
+      >
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.keyDown(getByTestId("EditableInput"), { key: "Escape" })
+
+    await user.click(page.getByTestId("EditableInput"))
+    await user.keyboard("{Escape}")
+
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
-  test("calls onSubmit when Enter is pressed", () => {
+  test("calls onSubmit when Enter is pressed", async () => {
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
-      <Editable.Root defaultValue="Some text" onSubmit={onSubmit}>
+    const { user } = await render(
+      <Editable.Root
+        defaultValue="Some text"
+        startWithEditView
+        onSubmit={onSubmit}
+      >
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.focus(getByTestId("EditablePreview"))
-    fireEvent.keyDown(getByTestId("EditableInput"), { key: "Enter" })
+
+    await user.click(page.getByTestId("EditableInput"))
+    await user.keyboard("{Enter}")
+
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
-  test("does not call onSubmit when Enter is pressed with Shift or Meta", () => {
+  test("does not call onSubmit when Enter is pressed with Shift or Meta", async () => {
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
-      <Editable.Root defaultValue="Some text" onSubmit={onSubmit}>
+    const { user } = await render(
+      <Editable.Root
+        defaultValue="Some text"
+        startWithEditView
+        onSubmit={onSubmit}
+      >
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.keyDown(getByTestId("EditableInput"), {
-      key: "Enter",
-      shiftKey: true,
-    })
-    fireEvent.keyDown(getByTestId("EditableInput"), {
-      key: "Enter",
-      metaKey: true,
-    })
+
+    await user.click(page.getByTestId("EditableInput"))
+    await user.keyboard("{Shift>}")
+    await user.keyboard("{Enter}")
+    await user.keyboard("{/Shift}")
+    await user.keyboard("{Meta>}")
+    await user.keyboard("{Enter}")
+    await user.keyboard("{/Meta}")
+
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  test("calls onChange when input value changes", () => {
+  test("calls onChange when input value changes", async () => {
     const onChange = vi.fn()
-    const { getByTestId } = render(
-      <Editable.Root defaultValue="Some text" onChange={onChange}>
+    const { user } = await render(
+      <Editable.Root
+        defaultValue="Some text"
+        startWithEditView
+        onChange={onChange}
+      >
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.change(getByTestId("EditableInput"), {
-      target: { value: "New text" },
-    })
-    expect(onChange).toHaveBeenCalledExactlyOnceWith("New text")
+
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "New text")
+
+    expect(onChange).toHaveBeenLastCalledWith("New text")
   })
 
-  test("focuses out of the input when editing ends", () => {
-    const { getByTestId } = render(
-      <Editable.Root defaultValue="Some text" selectAllOnFocus>
+  test("focuses out of the input when editing ends", async () => {
+    const { user } = await render(
+      <Editable.Root
+        defaultValue="Some text"
+        selectAllOnFocus
+        startWithEditView
+      >
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    const inputElement = getByTestId("EditableInput")
-    fireEvent.focus(getByTestId("EditablePreview"))
-    fireEvent.keyDown(inputElement, { key: "Enter" })
-    expect(document.activeElement).not.toBe(inputElement)
+
+    const input = page.getByTestId("EditableInput")
+
+    await user.click(input)
+    await user.keyboard("{Enter}")
+
+    expect(input.element()).not.toHaveFocus()
   })
 
-  test("calls onEdit when editing starts", () => {
+  test("calls onEdit when editing starts", async () => {
     const onEdit = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root defaultValue="Some text" onEdit={onEdit}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input />
       </Editable.Root>,
     )
-    fireEvent.focus(getByTestId("EditablePreview"))
+
+    await user.click(page.getByTestId("EditablePreview"))
+
     expect(onEdit).toHaveBeenCalledExactlyOnceWith()
   })
 
-  test("focus and calls onCancel when Escape is pressed", () => {
+  test("focus and calls onCancel when Escape is pressed", async () => {
     const onCancel = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root defaultValue="Some text" onCancel={onCancel}>
         <Editable.Preview data-testid="EditablePreview" />
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.focus(getByTestId("EditablePreview"))
-    fireEvent.keyDown(getByTestId("EditableInput"), { key: "Escape" })
+
+    await user.click(page.getByTestId("EditablePreview"))
+    await user.keyboard("{Escape}")
+
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
-  test("focus and calls onSubmit when Enter is pressed", () => {
+  test("focus and calls onSubmit when Enter is pressed", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root
         defaultValue="Some text"
         submitOnBlur
@@ -190,54 +233,70 @@ describe("<Editable />", () => {
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    fireEvent.focus(getByTestId("EditablePreview"))
-    fireEvent.keyDown(getByTestId("EditableInput"), { key: "Enter" })
+
+    await user.click(page.getByTestId("EditablePreview"))
+    await user.keyboard("{Enter}")
+
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
     expect(onCancel).not.toHaveBeenCalled()
   })
 
-  test("calls onSubmit when onBlur is triggered with submitOnBlur", () => {
+  test("calls onSubmit when onBlur is triggered with submitOnBlur", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
-      <Editable.Root
-        defaultValue="Some text"
-        submitOnBlur
-        onCancel={onCancel}
-        onSubmit={onSubmit}
-      >
-        <Editable.Preview data-testid="EditablePreview" />
-        <Editable.Input data-testid="EditableInput" />
-      </Editable.Root>,
+    const { user } = await render(
+      <>
+        <Editable.Root
+          defaultValue="Some text"
+          submitOnBlur
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+        >
+          <Editable.Preview data-testid="EditablePreview" />
+          <Editable.Input data-testid="EditableInput" />
+        </Editable.Root>
+        <button type="button" data-testid="Outside">
+          Outside
+        </button>
+      </>,
     )
-    act(() => fireEvent.focus(getByTestId("EditablePreview")))
-    act(() => fireEvent.blur(getByTestId("EditableInput")))
+
+    await user.click(page.getByTestId("EditablePreview"))
+    await user.click(page.getByTestId("Outside"))
+
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
     expect(onCancel).not.toHaveBeenCalled()
   })
 
-  test("calls onCancel when onBlur", () => {
+  test("calls onCancel when onBlur", async () => {
     const onCancel = vi.fn()
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
-      <Editable.Root
-        defaultValue="Some text"
-        submitOnBlur={false}
-        onCancel={onCancel}
-        onSubmit={onSubmit}
-      >
-        <Editable.Preview data-testid="EditablePreview" />
-        <Editable.Input data-testid="EditableInput" />
-      </Editable.Root>,
+    const { user } = await render(
+      <>
+        <Editable.Root
+          defaultValue="Some text"
+          submitOnBlur={false}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+        >
+          <Editable.Preview data-testid="EditablePreview" />
+          <Editable.Input data-testid="EditableInput" />
+        </Editable.Root>
+        <button type="button" data-testid="Outside">
+          Outside
+        </button>
+      </>,
     )
-    act(() => fireEvent.focus(getByTestId("EditablePreview")))
-    act(() => fireEvent.blur(getByTestId("EditableInput")))
+
+    await user.click(page.getByTestId("EditablePreview"))
+    await user.click(page.getByTestId("Outside"))
+
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
-  test("initially in correct edit mode", () => {
-    const { getByTestId } = render(
+  test("initially in correct edit mode", async () => {
+    await render(
       <Editable.Root
         data-testid="Editable"
         defaultValue="Some text"
@@ -247,10 +306,13 @@ describe("<Editable />", () => {
         <Editable.Input data-testid="EditableInput" />
       </Editable.Root>,
     )
-    expect(getByTestId("EditableInput")).not.toHaveAttribute("hidden")
+
+    expect(page.getByTestId("EditableInput").element()).not.toHaveAttribute(
+      "hidden",
+    )
   })
 
-  test("supports children as a function", () => {
+  test("supports children as a function", async () => {
     const childrenFn = vi.fn(({ editing }) => (
       <>
         <Editable.Preview data-testid="EditablePreview" />
@@ -258,9 +320,10 @@ describe("<Editable />", () => {
         {editing ? <span data-testid="editing-indicator" /> : null}
       </>
     ))
-    const { getByTestId, queryByTestId } = render(
+    const { user } = await render(
       <Editable.Root defaultValue="Some text">{childrenFn}</Editable.Root>,
     )
+
     expect(childrenFn).toHaveBeenCalledWith(
       expect.objectContaining({
         editing: false,
@@ -269,26 +332,33 @@ describe("<Editable />", () => {
         onSubmit: expect.any(Function),
       }),
     )
-    expect(queryByTestId("editing-indicator")).toBeNull()
-    act(() => fireEvent.focus(getByTestId("EditablePreview")))
-    expect(queryByTestId("editing-indicator")).toBeInTheDocument()
+    expect(
+      document.querySelector("[data-testid='editing-indicator']"),
+    ).toBeNull()
+
+    await user.click(page.getByTestId("EditablePreview"))
+
+    expect(
+      document.querySelector("[data-testid='editing-indicator']"),
+    ).not.toBeNull()
   })
 })
 
 describe("<EditableTextarea />", () => {
-  test("renders correctly", () => {
-    const { getByTestId } = render(
+  test("renders correctly", async () => {
+    await render(
       <Editable.Root defaultValue="Some text">
         <Editable.Textarea data-testid="EditableTextarea" />
       </Editable.Root>,
     )
-    const textarea = getByTestId("EditableTextarea")
-    expect(textarea).toBeInTheDocument()
-    expect(textarea).toHaveValue("Some text")
+
+    const textarea = page.getByTestId("EditableTextarea")
+
+    await expect.element(textarea).toHaveValue("Some text")
   })
 
-  test("applies custom className", () => {
-    const { getByTestId } = render(
+  test("applies custom className", async () => {
+    await render(
       <Editable.Root defaultValue="Some text">
         <Editable.Textarea
           className="custom-class"
@@ -296,13 +366,15 @@ describe("<EditableTextarea />", () => {
         />
       </Editable.Root>,
     )
-    const textarea = getByTestId("EditableTextarea")
-    expect(textarea).toHaveClass("custom-class")
+
+    await expect
+      .element(page.getByTestId("EditableTextarea"))
+      .toHaveClass("custom-class")
   })
 
-  test("calls onCancel when Escape is pressed in textarea", () => {
+  test("calls onCancel when Escape is pressed in textarea", async () => {
     const onCancel = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -312,13 +384,16 @@ describe("<EditableTextarea />", () => {
         <Editable.Textarea data-testid="EditableTextarea" />
       </Editable.Root>,
     )
-    fireEvent.keyDown(getByTestId("EditableTextarea"), { key: "Escape" })
+
+    await user.click(page.getByTestId("EditableTextarea"))
+    await user.keyboard("{Escape}")
+
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 
-  test("does not submit when Enter is pressed in textarea", () => {
+  test("does not submit when Enter is pressed in textarea", async () => {
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -328,14 +403,17 @@ describe("<EditableTextarea />", () => {
         <Editable.Textarea data-testid="EditableTextarea" />
       </Editable.Root>,
     )
-    fireEvent.keyDown(getByTestId("EditableTextarea"), { key: "Enter" })
+
+    await user.click(page.getByTestId("EditableTextarea"))
+    await user.keyboard("{Enter}")
+
     expect(onSubmit).not.toHaveBeenCalled()
   })
 })
 
 describe("<EditableControl />", () => {
-  test("renders correctly with role group", () => {
-    const { getByTestId } = render(
+  test("renders correctly with role group", async () => {
+    await render(
       <Editable.Root defaultValue="Some text">
         <Editable.Control data-testid="EditableControl">
           <Editable.Preview />
@@ -343,16 +421,17 @@ describe("<EditableControl />", () => {
         </Editable.Control>
       </Editable.Root>,
     )
-    const control = getByTestId("EditableControl")
-    expect(control).toBeInTheDocument()
-    expect(control).toHaveAttribute("role", "group")
+
+    await expect
+      .element(page.getByTestId("EditableControl"))
+      .toHaveAttribute("role", "group")
   })
 })
 
 describe("<EditableEditTrigger />", () => {
-  test("renders and triggers edit mode on click", () => {
+  test("renders and triggers edit mode on click", async () => {
     const onEdit = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root defaultValue="Some text" onEdit={onEdit}>
         <Editable.Preview />
         <Editable.Input data-testid="EditableInput" />
@@ -361,18 +440,20 @@ describe("<EditableEditTrigger />", () => {
         </Editable.EditTrigger>
       </Editable.Root>,
     )
-    const trigger = getByTestId("EditTrigger")
-    expect(trigger).toBeInTheDocument()
-    act(() => fireEvent.click(trigger))
+
+    await user.click(page.getByRole("button", { name: "Edit" }))
+
     expect(onEdit).toHaveBeenCalledExactlyOnceWith()
-    expect(getByTestId("EditableInput")).not.toHaveAttribute("hidden")
+    expect(page.getByTestId("EditableInput").element()).not.toHaveAttribute(
+      "hidden",
+    )
   })
 })
 
 describe("<EditableCancelTrigger />", () => {
-  test("renders and triggers cancel on click", () => {
+  test("renders and triggers cancel on click", async () => {
     const onCancel = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -385,17 +466,17 @@ describe("<EditableCancelTrigger />", () => {
         </Editable.CancelTrigger>
       </Editable.Root>,
     )
-    const trigger = getByTestId("CancelTrigger")
-    expect(trigger).toBeInTheDocument()
-    act(() => fireEvent.click(trigger))
+
+    await user.click(page.getByRole("button", { name: "Cancel" }))
+
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 })
 
 describe("<EditableSubmitTrigger />", () => {
-  test("renders and triggers submit on click", () => {
+  test("renders and triggers submit on click", async () => {
     const onSubmit = vi.fn()
-    const { getByTestId } = render(
+    const { user } = await render(
       <Editable.Root
         defaultValue="Some text"
         startWithEditView
@@ -408,9 +489,9 @@ describe("<EditableSubmitTrigger />", () => {
         </Editable.SubmitTrigger>
       </Editable.Root>,
     )
-    const trigger = getByTestId("SubmitTrigger")
-    expect(trigger).toBeInTheDocument()
-    act(() => fireEvent.click(trigger))
+
+    await user.click(page.getByRole("button", { name: "Submit" }))
+
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith("Some text")
   })
 })


### PR DESCRIPTION
Closes #6492

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate the editable component tests from jsdom helpers to Vitest Browser Mode, following the recent browser-mode test migration pattern already used in this repository.

## Current behavior (updates)

- `packages/react/src/components/editable/editable.test.tsx` still used `#test` with jsdom-only helpers such as `act` and `fireEvent`.
- The editable tests were not running in the browser-mode environment targeted by issue 6492.

## New behavior

- `editable.test.tsx` now uses `#test/browser` with `page` and browser-mode user interactions.
- The editable test expectations were adjusted for browser-mode behavior, including incremental `onChange` calls and mounted-but-empty indicator state.
- Focused browser validation passes with `pnpm react test:browser --run src/components/editable/`.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Repo-wide PR verification is currently blocked by unrelated existing browser-test failures outside this diff, while the editable browser test slice passes locally.
