### PR TITLE
[WIP] test(date-picker): migrate to Vitest Browser Mode

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -637,7 +637,9 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    expect(page.getByText(/;/).element()).toBeInTheDocument()
+    expect(
+      (page.getByRole("combobox").elements()[0] as HTMLElement).textContent,
+    ).toContain(";")
   })
 
   test("handles max for multiple mode", async () => {
@@ -1368,7 +1370,9 @@ describe("<DatePicker />", () => {
     )
 
     // Range uses separator between inputs
-    expect(page.getByText("~").element()).toBeInTheDocument()
+    expect(
+      (page.getByRole("combobox").elements()[0] as HTMLElement).textContent,
+    ).toContain("~")
   })
 
   test("handles Enter key on range end input with existing start value", async () => {

--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -1,5 +1,6 @@
 import type { DatePickerProps } from "."
-import { a11y, fireEvent, render, screen, waitFor } from "#test"
+import { a11y, page, render } from "#test/browser"
+import { fireEvent } from "@testing-library/react"
 import { useState } from "react"
 import { vi } from "vitest"
 import { DatePicker } from "."
@@ -20,8 +21,8 @@ describe("<DatePicker />", () => {
     expect(DatePicker.displayName).toBe("DatePickerRoot")
   })
 
-  test("sets `className` correctly", () => {
-    render(
+  test("sets `className` correctly", async () => {
+    await render(
       <DatePicker
         defaultOpen
         placeholder="Choose a option"
@@ -30,18 +31,22 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    expect(screen.getByTestId("root")).toHaveClass("ui-date-picker__root")
-    expect(screen.getByTestId("icon")).toHaveClass("ui-date-picker__icon")
-    expect(screen.getAllByRole("combobox")[0]!).toHaveClass(
+    expect(page.getByTestId("root").element()).toHaveClass(
+      "ui-date-picker__root",
+    )
+    expect(page.getByTestId("icon").element()).toHaveClass(
+      "ui-date-picker__icon",
+    )
+    expect(page.getByRole("combobox").elements()[0] as HTMLElement).toHaveClass(
       "ui-date-picker__field",
     )
   })
 
-  test("merges root props without overwriting user props", () => {
+  test("merges root props without overwriting user props", async () => {
     const onRootClick = vi.fn()
     const onUserClick = vi.fn()
 
-    render(
+    await render(
       <DatePicker
         className="from-root"
         defaultOpen
@@ -58,8 +63,8 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const el = screen.getByTestId("root")
-    fireEvent.click(screen.getAllByRole("combobox")[0]!)
+    const el = page.getByTestId("root").element()
+    fireEvent.click(page.getByRole("combobox").elements()[0] as HTMLElement)
 
     expect(el).toHaveClass("from-root", "from-user")
     expect(el).toHaveStyle({ color: "rgb(255, 0, 0)" })
@@ -68,11 +73,11 @@ describe("<DatePicker />", () => {
     expect(onUserClick).toHaveBeenCalledTimes(1)
   })
 
-  test("merges input context props without overwriting user props", () => {
+  test("merges input context props without overwriting user props", async () => {
     const onRootClick = vi.fn()
     const onUserClick = vi.fn()
 
-    render(
+    await render(
       <InputPropsContext
         value={{
           className: "from-root",
@@ -90,8 +95,8 @@ describe("<DatePicker />", () => {
       </InputPropsContext>,
     )
 
-    const root = screen.getByTestId("root")
-    const el = screen.getAllByRole("combobox")[0]!
+    const root = page.getByTestId("root").element()
+    const el = page.getByRole("combobox").elements()[0] as HTMLElement
 
     fireEvent.click(el)
 
@@ -102,8 +107,8 @@ describe("<DatePicker />", () => {
     expect(onUserClick).toHaveBeenCalledTimes(1)
   })
 
-  test("renders HTML tag correctly", () => {
-    render(
+  test("renders HTML tag correctly", async () => {
+    await render(
       <DatePicker
         defaultOpen
         placeholder="Choose a option"
@@ -112,72 +117,74 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    expect(screen.getByTestId("root").tagName).toBe("DIV")
-    expect(screen.getByTestId("icon").tagName).toBe("DIV")
-    expect(screen.getAllByRole("combobox")[0]?.tagName).toBe("DIV")
+    expect(page.getByTestId("root").element().tagName).toBe("DIV")
+    expect(page.getByTestId("icon").element().tagName).toBe("DIV")
+    expect(
+      (page.getByRole("combobox").elements()[0] as HTMLElement).tagName,
+    ).toBe("DIV")
   })
 
-  test("renders with defaultValue", () => {
-    render(<DatePicker defaultValue={new Date(2024, 0, 15)} />)
+  test("renders with defaultValue", async () => {
+    await render(<DatePicker defaultValue={new Date(2024, 0, 15)} />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("January 15, 2024")
   })
 
-  test("renders with range mode", () => {
-    render(<DatePicker range rootProps={{ "data-testid": "root" }} />)
+  test("renders with range mode", async () => {
+    await render(<DatePicker range rootProps={{ "data-testid": "root" }} />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs).toHaveLength(2)
   })
 
-  test("renders with multiple mode", () => {
-    render(<DatePicker multiple placeholder="Select dates" />)
+  test("renders with multiple mode", async () => {
+    await render(<DatePicker multiple placeholder="Select dates" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toBeInTheDocument()
   })
 
-  test("shows clear icon when value exists", () => {
-    render(
+  test("shows clear icon when value exists", async () => {
+    await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     expect(icon).toHaveAttribute("role", "button")
   })
 
-  test("shows calendar icon when no value exists", () => {
-    render(<DatePicker clearable iconProps={{ "data-testid": "icon" }} />)
+  test("shows calendar icon when no value exists", async () => {
+    await render(<DatePicker clearable iconProps={{ "data-testid": "icon" }} />)
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     expect(icon).not.toHaveAttribute("role", "button")
   })
 
   test("clears value when clear icon is clicked", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("January 15, 2024")
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.click(icon)
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("")
     })
   })
 
   test("clears range value when clear icon is clicked", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -188,21 +195,21 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveValue("January 15, 2024")
     expect(inputs[1]).toHaveValue("January 20, 2024")
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.click(icon)
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[0]).toHaveValue("")
       expect(inputs[1]).toHaveValue("")
     })
   })
 
-  test("shows clear icon for range value with start only", () => {
-    render(
+  test("shows clear icon for range value with start only", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: undefined,
@@ -213,12 +220,12 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     expect(icon).toHaveAttribute("role", "button")
   })
 
-  test("shows clear icon for range value with end only", () => {
-    render(
+  test("shows clear icon for range value with end only", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -229,12 +236,12 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     expect(icon).toHaveAttribute("role", "button")
   })
 
-  test("renders with clearable=false", () => {
-    render(
+  test("renders with clearable=false", async () => {
+    await render(
       <DatePicker
         clearable={false}
         defaultValue={new Date(2024, 0, 15)}
@@ -242,55 +249,59 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     expect(icon).not.toHaveAttribute("role", "button")
   })
 
   test("opens on click", async () => {
-    render(<DatePicker placeholder="Select date" />)
+    await render(<DatePicker placeholder="Select date" />)
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.click(field)
 
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('[role="dialog"]') as HTMLElement,
+      ).toBeInTheDocument()
     })
   })
 
   test("opens on input focus when openOnFocus is true", async () => {
-    render(<DatePicker placeholder="Select date" />)
+    await render(<DatePicker placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
 
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('[role="dialog"]') as HTMLElement,
+      ).toBeInTheDocument()
     })
   })
 
-  test("does not open on input focus when openOnFocus is false", () => {
-    render(<DatePicker openOnFocus={false} placeholder="Select date" />)
+  test("does not open on input focus when openOnFocus is false", async () => {
+    await render(<DatePicker openOnFocus={false} placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
 
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument()
   })
 
-  test("handles input change for single date", () => {
-    render(<DatePicker placeholder="Select date" />)
+  test("handles input change for single date", async () => {
+    await render(<DatePicker placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-15" } })
 
     expect(input).toHaveValue("2024-01-15")
   })
 
-  test("handles input change for range date", () => {
-    render(<DatePicker placeholder="Select date" range />)
+  test("handles input change for range date", async () => {
+    await render(<DatePicker placeholder="Select date" range />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[0]!)
     fireEvent.change(inputs[0]!, { target: { value: "2024-01-15" } })
 
@@ -298,33 +309,33 @@ describe("<DatePicker />", () => {
   })
 
   test("handles Enter key on single date input", async () => {
-    render(<DatePicker defaultOpen placeholder="Select date" />)
+    await render(<DatePicker defaultOpen placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-15" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("January 15, 2024")
     })
   })
 
   test("handles Enter key on range date start input", async () => {
-    render(<DatePicker defaultOpen placeholder="Select date" range />)
+    await render(<DatePicker defaultOpen placeholder="Select date" range />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[0]!)
     fireEvent.change(inputs[0]!, { target: { value: "2024-01-15" } })
     fireEvent.keyDown(inputs[0]!, { key: "Enter" })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[0]).toHaveValue("January 15, 2024")
     })
   })
 
   test("handles Enter key on range date end input", async () => {
-    render(
+    await render(
       <DatePicker
         defaultOpen
         defaultValue={{
@@ -336,18 +347,18 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[1]!)
     fireEvent.change(inputs[1]!, { target: { value: "2024-01-20" } })
     fireEvent.keyDown(inputs[1]!, { key: "Enter" })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[1]).toHaveValue("January 20, 2024")
     })
   })
 
   test("handles Backspace key on multiple date input", async () => {
-    render(
+    await render(
       <DatePicker
         defaultOpen
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
@@ -356,18 +367,18 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.keyDown(input, { key: "Backspace" })
 
-    await waitFor(() => {
-      const tags = screen.getAllByText(/January 1[56], 2024/)
+    await vi.waitFor(() => {
+      const tags = page.getByText(/January 1[56], 2024/).elements()
       expect(tags).toHaveLength(1)
     })
   })
 
   test("handles Backspace key on range date end input", async () => {
-    render(
+    await render(
       <DatePicker
         defaultOpen
         defaultValue={{
@@ -379,7 +390,7 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[1]!)
 
     // Clear the end input value first
@@ -387,28 +398,28 @@ describe("<DatePicker />", () => {
     fireEvent.keyDown(inputs[1]!, { key: "Backspace" })
 
     // After backspace on empty end input, should clear both and focus start
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[0]).toHaveValue("")
       expect(inputs[1]).toHaveValue("")
     })
   })
 
   test("handles blur on single date", async () => {
-    render(<DatePicker placeholder="Select date" />)
+    await render(<DatePicker placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "invalid" } })
     fireEvent.blur(input, { relatedTarget: null })
 
     // On blur with invalid value, input should be cleared
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("")
     })
   })
 
   test("handles blur on range date resets input value", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -419,7 +430,7 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[0]!)
 
     // Type a valid date string within range as input
@@ -429,13 +440,13 @@ describe("<DatePicker />", () => {
     fireEvent.blur(inputs[0]!, { relatedTarget: null })
 
     // On blur, range input should show the formatted date value (clamped within range)
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[0]).toHaveValue("January 18, 2024")
     })
   })
 
   test("handles blur on multiple date input", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15)]}
         multiple
@@ -443,61 +454,63 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "something" } })
     fireEvent.blur(input, { relatedTarget: null })
 
     // On blur with multiple, input value should be cleared
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("")
     })
   })
 
-  test("handles input with pattern", () => {
-    render(<DatePicker pattern={/[^0-9-]/g} placeholder="Select date" />)
+  test("handles input with pattern", async () => {
+    await render(<DatePicker pattern={/[^0-9-]/g} placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "abc2024-01-15xyz" } })
 
     expect(input).toHaveValue("2024-01-15")
   })
 
-  test("does not allow input when allowInput is false", () => {
-    render(<DatePicker allowInput={false} placeholder="Select date" />)
+  test("does not allow input when allowInput is false", async () => {
+    await render(<DatePicker allowInput={false} placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.change(input, { target: { value: "2024-01-15" } })
 
     expect(input).toHaveValue("")
   })
 
-  test("handles disabled state", () => {
-    render(<DatePicker disabled placeholder="Select date" />)
+  test("handles disabled state", async () => {
+    await render(<DatePicker disabled placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toBeDisabled()
   })
 
-  test("handles readOnly state", () => {
-    render(<DatePicker placeholder="Select date" readOnly />)
+  test("handles readOnly state", async () => {
+    await render(<DatePicker placeholder="Select date" readOnly />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveAttribute("readOnly")
   })
 
   test("handles onChange callback", async () => {
     const onChange = vi.fn()
 
-    render(<DatePicker defaultOpen placeholder="Select" onChange={onChange} />)
+    await render(
+      <DatePicker defaultOpen placeholder="Select" onChange={onChange} />,
+    )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-15" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(expect.any(Date))
     })
   })
@@ -505,30 +518,34 @@ describe("<DatePicker />", () => {
   test("handles onInputChange callback", async () => {
     const onInputChange = vi.fn()
 
-    render(<DatePicker placeholder="Select" onInputChange={onInputChange} />)
+    await render(
+      <DatePicker placeholder="Select" onInputChange={onInputChange} />,
+    )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-15" } })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(onInputChange).toHaveBeenCalledWith("2024-01-15")
     })
   })
 
   test("handles closeOnChange", async () => {
-    render(<DatePicker closeOnChange defaultOpen placeholder="Select date" />)
+    await render(
+      <DatePicker closeOnChange defaultOpen placeholder="Select date" />,
+    )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.change(input, { target: { value: "2024-01-15" } })
 
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument()
     })
   })
 
   test("handles closeOnChange as function", async () => {
-    render(
+    await render(
       <DatePicker
         closeOnChange={(ev) => ev.target.value.length > 5}
         defaultOpen
@@ -537,16 +554,16 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.change(input, { target: { value: "2024-01-15" } })
 
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument()
     })
   })
 
   test("handles openOnChange as function", async () => {
-    render(
+    await render(
       <DatePicker
         openOnChange={(ev) => ev.target.value.length > 1}
         openOnFocus={false}
@@ -554,63 +571,65 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.change(input, { target: { value: "20" } })
 
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('[role="dialog"]') as HTMLElement,
+      ).toBeInTheDocument()
     })
   })
 
-  test("handles defaultInputValue", () => {
-    render(<DatePicker defaultInputValue="2024-01-15" />)
+  test("handles defaultInputValue", async () => {
+    await render(<DatePicker defaultInputValue="2024-01-15" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("January 15, 2024")
   })
 
-  test("handles defaultInputValue for range", () => {
-    render(
+  test("handles defaultInputValue for range", async () => {
+    await render(
       <DatePicker
         defaultInputValue={{ end: "2024-01-20", start: "2024-01-15" }}
         range
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveValue("January 15, 2024")
     expect(inputs[1]).toHaveValue("January 20, 2024")
   })
 
-  test("handles defaultInputValue with invalid date string for range", () => {
-    render(
+  test("handles defaultInputValue with invalid date string for range", async () => {
+    await render(
       <DatePicker
         defaultInputValue={{ end: "invalid", start: "invalid" }}
         range
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveValue("invalid")
     expect(inputs[1]).toHaveValue("invalid")
   })
 
-  test("handles defaultInputValue with invalid date string for single", () => {
-    render(<DatePicker defaultInputValue="invalid-date" />)
+  test("handles defaultInputValue with invalid date string for single", async () => {
+    await render(<DatePicker defaultInputValue="invalid-date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("invalid-date")
   })
 
-  test("handles format with null input", () => {
-    render(<DatePicker format={{ input: null }} />)
+  test("handles format with null input", async () => {
+    await render(<DatePicker format={{ input: null }} />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toBeInTheDocument()
   })
 
-  test("handles custom separator", () => {
-    render(
+  test("handles custom separator", async () => {
+    await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
         multiple
@@ -618,11 +637,11 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    expect(screen.getByText(/;/)).toBeInTheDocument()
+    expect(page.getByText(/;/).element()).toBeInTheDocument()
   })
 
-  test("handles max for multiple mode", () => {
-    render(
+  test("handles max for multiple mode", async () => {
+    await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
         max={2}
@@ -631,15 +650,15 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.change(input, { target: { value: "2024-01-17" } })
 
     // Should not add more when max is reached
     expect(input).toHaveValue("")
   })
 
-  test("handles excludeDate", () => {
-    render(
+  test("handles excludeDate", async () => {
+    await render(
       <DatePicker
         defaultOpen
         excludeDate={(date) => date.getDay() === 0}
@@ -647,7 +666,7 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
 
     // Try to type a Sunday
@@ -661,7 +680,7 @@ describe("<DatePicker />", () => {
   test("handles allowInputBeyond=false with minDate", async () => {
     const minDate = new Date(2024, 0, 10)
 
-    render(
+    await render(
       <DatePicker
         allowInputBeyond={false}
         defaultOpen
@@ -670,13 +689,13 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-05" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
     // Should clamp to minDate
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("January 10, 2024")
     })
   })
@@ -684,7 +703,7 @@ describe("<DatePicker />", () => {
   test("handles allowInputBeyond=false with maxDate", async () => {
     const maxDate = new Date(2024, 0, 20)
 
-    render(
+    await render(
       <DatePicker
         allowInputBeyond={false}
         defaultOpen
@@ -693,19 +712,19 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-25" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
     // Should clamp to maxDate
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("January 20, 2024")
     })
   })
 
   test("handles allowInputBeyond=true", async () => {
-    render(
+    await render(
       <DatePicker
         allowInputBeyond
         defaultOpen
@@ -715,19 +734,19 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-05" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
     // Should allow dates beyond bounds
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("January 5, 2024")
     })
   })
 
   test("handles Enter key on multiple date input", async () => {
-    render(
+    await render(
       <DatePicker
         defaultOpen
         defaultValue={[new Date(2024, 0, 15)]}
@@ -736,19 +755,19 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-01-16" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
     // Input should be cleared after adding
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("")
     })
   })
 
   test("handles onClear with multiple value", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15)]}
         multiple
@@ -756,17 +775,19 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.click(icon)
 
     // After clear, no tags should remain
-    await waitFor(() => {
-      expect(screen.queryByText(/January 15, 2024/)).not.toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(
+        page.getByText(/January 15, 2024/).elements()[0],
+      ).not.toBeInTheDocument()
     })
   })
 
   test("handles focusOnClear=false", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         focusOnClear={false}
@@ -774,17 +795,17 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.click(icon)
 
-    await waitFor(() => {
-      const input = screen.getByRole("textbox")
+    await vi.waitFor(() => {
+      const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
       expect(input).toHaveValue("")
     })
   })
 
   test("handles focusOnClear with allowInput=false", async () => {
-    render(
+    await render(
       <DatePicker
         allowInput={false}
         defaultValue={new Date(2024, 0, 15)}
@@ -793,20 +814,20 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.click(icon)
 
-    await waitFor(() => {
-      const input = screen.getByRole("textbox")
+    await vi.waitFor(() => {
+      const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
       expect(input).toHaveValue("")
     })
   })
 
   test("handles closeOnSelect for single date via calendar click", async () => {
-    render(<DatePicker defaultOpen placeholder="Select date" />)
+    await render(<DatePicker defaultOpen placeholder="Select date" />)
 
     // Find a day cell in the calendar and click it
-    const dialog = screen.getByRole("dialog")
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement
     const dayCells = dialog.querySelectorAll("td")
     const validDay = Array.from(dayCells).find(
       (td) =>
@@ -816,13 +837,13 @@ describe("<DatePicker />", () => {
     fireEvent.click(validDay)
 
     // closeOnSelect defaults to true for single, so dialog should close
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument()
     })
   })
 
-  test("handles closeOnSelect=false keeps dialog open after calendar click", () => {
-    render(
+  test("handles closeOnSelect=false keeps dialog open after calendar click", async () => {
+    await render(
       <DatePicker
         closeOnSelect={false}
         defaultOpen
@@ -831,7 +852,7 @@ describe("<DatePicker />", () => {
     )
 
     // Find a day cell in the calendar and click it
-    const dialog = screen.getByRole("dialog")
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement
     const dayCells = dialog.querySelectorAll("td")
     const validDay = Array.from(dayCells).find(
       (td) =>
@@ -841,11 +862,13 @@ describe("<DatePicker />", () => {
     fireEvent.click(validDay)
 
     // closeOnSelect is false, so dialog should remain open
-    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(
+      document.querySelector('[role="dialog"]') as HTMLElement,
+    ).toBeInTheDocument()
   })
 
-  test("handles openOnClick=false", () => {
-    render(
+  test("handles openOnClick=false", async () => {
+    await render(
       <DatePicker
         openOnClick={false}
         openOnFocus={false}
@@ -853,29 +876,31 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.click(field)
 
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument()
   })
 
   test("handles onFieldFocus when allowInput is false and openOnFocus is true", async () => {
-    render(
+    await render(
       <DatePicker allowInput={false} openOnFocus placeholder="Select date" />,
     )
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.focus(field)
 
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('[role="dialog"]') as HTMLElement,
+      ).toBeInTheDocument()
     })
   })
 
-  test("handles onMouseDown when openOnFocus is true", () => {
-    render(<DatePicker placeholder="Select date" />)
+  test("handles onMouseDown when openOnFocus is true", async () => {
+    await render(<DatePicker placeholder="Select date" />)
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.mouseDown(field)
 
     // mouseDown should be prevented and stopped
@@ -883,18 +908,18 @@ describe("<DatePicker />", () => {
   })
 
   test("handles clear icon keyboard events", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.keyDown(icon, { key: "Enter" })
 
-    await waitFor(() => {
-      const input = screen.getByRole("textbox")
+    await vi.waitFor(() => {
+      const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
       expect(input).toHaveValue("")
     })
   })
@@ -902,7 +927,7 @@ describe("<DatePicker />", () => {
   test("handles clear icon Space key", async () => {
     const onChange = vi.fn()
 
-    render(
+    await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
@@ -910,19 +935,19 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const icon = screen.getByTestId("icon")
+    const icon = page.getByTestId("icon").element()
     fireEvent.keyDown(icon, { key: " ", code: "Space" })
 
     // The onClear should have been triggered via Space key
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(undefined)
     })
   })
 
-  test("handles controlled value update", () => {
-    render(<ControlledDatePicker placeholder="Select date" />)
+  test("handles controlled value update", async () => {
+    await render(<ControlledDatePicker placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("")
   })
 
@@ -951,14 +976,14 @@ describe("<DatePicker />", () => {
       )
     }
 
-    render(<RangeControlled />)
+    await render(<RangeControlled />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveValue("")
 
-    fireEvent.click(screen.getByTestId("set-value"))
+    fireEvent.click(page.getByTestId("set-value").element())
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[0]).toHaveValue("January 15, 2024")
       expect(inputs[1]).toHaveValue("January 20, 2024")
     })
@@ -981,20 +1006,20 @@ describe("<DatePicker />", () => {
       )
     }
 
-    render(<SingleControlled />)
+    await render(<SingleControlled />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("")
 
-    fireEvent.click(screen.getByTestId("set-value"))
+    fireEvent.click(page.getByTestId("set-value").element())
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(input).toHaveValue("January 15, 2024")
     })
   })
 
-  test("handles input change for range with existing start value", () => {
-    render(
+  test("handles input change for range with existing start value", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: undefined,
@@ -1005,15 +1030,15 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[1]!)
     fireEvent.change(inputs[1]!, { target: { value: "2024-01-20" } })
 
     expect(inputs[1]).toHaveValue("2024-01-20")
   })
 
-  test("handles input change for range with existing end value", () => {
-    render(
+  test("handles input change for range with existing end value", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -1024,26 +1049,26 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[0]!)
     fireEvent.change(inputs[0]!, { target: { value: "2024-01-15" } })
 
     expect(inputs[0]).toHaveValue("2024-01-15")
   })
 
-  test("handles click on range field focuses start input when both empty", () => {
-    render(<DatePicker placeholder="Select date" range />)
+  test("handles click on range field focuses start input when both empty", async () => {
+    await render(<DatePicker placeholder="Select date" range />)
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.click(field)
 
     // Start input should be focused
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveFocus()
   })
 
-  test("handles click on range field focuses end input when only start is set", () => {
-    render(
+  test("handles click on range field focuses end input when only start is set", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: undefined,
@@ -1054,16 +1079,16 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.click(field)
 
     // End input should be focused since start has value
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[1]).toHaveFocus()
   })
 
-  test("handles click on range field focuses start input when end is set", () => {
-    render(
+  test("handles click on range field focuses start input when end is set", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -1074,16 +1099,16 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const field = screen.getAllByRole("combobox")[0]!
+    const field = page.getByRole("combobox").elements()[0] as HTMLElement
     fireEvent.click(field)
 
     // Start input should be focused when end is already set
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveFocus()
   })
 
-  test("handles custom render for multiple mode", () => {
-    render(
+  test("handles custom render for multiple mode", async () => {
+    await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15)]}
         multiple
@@ -1095,14 +1120,14 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    expect(screen.getByTestId("custom-tag")).toBeInTheDocument()
-    expect(screen.getByTestId("custom-tag")).toHaveTextContent(
+    expect(page.getByTestId("custom-tag").element()).toBeInTheDocument()
+    expect(page.getByTestId("custom-tag").element()).toHaveTextContent(
       "January 15, 2024",
     )
   })
 
   test("handles custom render onClear removes item", async () => {
-    render(
+    await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
         multiple
@@ -1114,14 +1139,16 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const tag = screen.getByTestId("tag-January 15, 2024")
+    const tag = page.getByTestId("tag-January 15, 2024").element()
     fireEvent.click(tag)
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(
-        screen.queryByTestId("tag-January 15, 2024"),
+        page.getByTestId("tag-January 15, 2024").elements()[0],
       ).not.toBeInTheDocument()
-      expect(screen.getByTestId("tag-January 16, 2024")).toBeInTheDocument()
+      expect(
+        page.getByTestId("tag-January 16, 2024").element(),
+      ).toBeInTheDocument()
     })
   })
 
@@ -1138,7 +1165,7 @@ describe("<DatePicker />", () => {
       return undefined
     })
 
-    render(
+    await render(
       <DatePicker
         defaultOpen
         parseDate={parseDate}
@@ -1146,19 +1173,19 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024/1/15" } })
     fireEvent.keyDown(input, { key: "Enter" })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(parseDate).toHaveBeenCalledWith("2024/1/15")
     })
   })
 
-  test("handles minDate after maxDate correction", () => {
+  test("handles minDate after maxDate correction", async () => {
     // When minDate > maxDate, maxDate should be set to minDate
-    render(
+    await render(
       <DatePicker
         maxDate={new Date(2024, 0, 1)}
         minDate={new Date(2024, 5, 1)}
@@ -1166,12 +1193,12 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toBeInTheDocument()
   })
 
-  test("handles defaultValue for range with inputValue", () => {
-    render(
+  test("handles defaultValue for range with inputValue", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -1181,22 +1208,22 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveValue("January 15, 2024")
     expect(inputs[1]).toHaveValue("January 20, 2024")
   })
 
-  test("handles input id and name for range mode", () => {
-    render(<DatePicker id="test-id" name="test-name" range />)
+  test("handles input id and name for range mode", async () => {
+    await render(<DatePicker id="test-id" name="test-name" range />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     // When start is empty, start input gets id/name
     expect(inputs[0]).toHaveAttribute("id", "test-id")
     expect(inputs[0]).toHaveAttribute("name", "test-name")
   })
 
-  test("handles input id and name for range mode with start value", () => {
-    render(
+  test("handles input id and name for range mode with start value", async () => {
+    await render(
       <DatePicker
         id="test-id"
         name="test-name"
@@ -1208,30 +1235,30 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     // When start has value, end input gets id/name
     expect(inputs[1]).toHaveAttribute("id", "test-id")
     expect(inputs[1]).toHaveAttribute("name", "test-name")
   })
 
   test("handles Enter key on range start input moves focus to end input", async () => {
-    render(<DatePicker defaultOpen placeholder="Select date" range />)
+    await render(<DatePicker defaultOpen placeholder="Select date" range />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     fireEvent.focus(inputs[0]!)
     fireEvent.change(inputs[0]!, { target: { value: "2024-01-15" } })
     fireEvent.keyDown(inputs[0]!, { key: "Enter" })
 
     // After entering start date, focus should move to end input
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[1]).toHaveFocus()
     })
   })
 
-  test("handles Enter key with invalid date does nothing", () => {
-    render(<DatePicker defaultOpen placeholder="Select date" />)
+  test("handles Enter key with invalid date does nothing", async () => {
+    await render(<DatePicker defaultOpen placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "invalid" } })
     fireEvent.keyDown(input, { key: "Enter" })
@@ -1240,33 +1267,33 @@ describe("<DatePicker />", () => {
     expect(input).toHaveValue("invalid")
   })
 
-  test("handles Enter key with empty value does nothing", () => {
-    render(<DatePicker defaultOpen placeholder="Select date" />)
+  test("handles Enter key with empty value does nothing", async () => {
+    await render(<DatePicker defaultOpen placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.keyDown(input, { key: "Enter" })
 
     expect(input).toHaveValue("")
   })
 
-  test("handles custom placeholder", () => {
-    render(<DatePicker placeholder="Custom placeholder" />)
+  test("handles custom placeholder", async () => {
+    await render(<DatePicker placeholder="Custom placeholder" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveAttribute("placeholder", "Custom placeholder")
   })
 
-  test("handles custom placeholder for range", () => {
-    render(<DatePicker placeholder="Custom" range />)
+  test("handles custom placeholder for range", async () => {
+    await render(<DatePicker placeholder="Custom" range />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
     expect(inputs[0]).toHaveAttribute("placeholder", "Custom")
     expect(inputs[1]).toHaveAttribute("placeholder", "Custom")
   })
 
-  test("handles Backspace on single date input does nothing", () => {
-    render(
+  test("handles Backspace on single date input does nothing", async () => {
+    await render(
       <DatePicker
         defaultOpen
         defaultValue={new Date(2024, 0, 15)}
@@ -1274,7 +1301,7 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.keyDown(input, { key: "Backspace" })
 
@@ -1282,43 +1309,45 @@ describe("<DatePicker />", () => {
     expect(input).toHaveValue("January 15, 2024")
   })
 
-  test("handles defaultMonth with minDate", () => {
+  test("handles defaultMonth with minDate", async () => {
     const minDate = new Date(2025, 5, 1)
 
-    render(<DatePicker defaultMonth={new Date(2024, 0, 1)} minDate={minDate} />)
+    await render(
+      <DatePicker defaultMonth={new Date(2024, 0, 1)} minDate={minDate} />,
+    )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toBeInTheDocument()
   })
 
-  test("handles defaultMonth with valueProp", () => {
-    render(
+  test("handles defaultMonth with valueProp", async () => {
+    await render(
       <DatePicker
         defaultMonth={new Date(2024, 0, 1)}
         value={new Date(2024, 5, 15)}
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("June 15, 2024")
   })
 
-  test("handles defaultMonth with defaultValue", () => {
-    render(
+  test("handles defaultMonth with defaultValue", async () => {
+    await render(
       <DatePicker
         defaultMonth={new Date(2024, 0, 1)}
         defaultValue={new Date(2024, 5, 15)}
       />,
     )
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toHaveValue("June 15, 2024")
   })
 
-  test("handles input change for multiple with valid date updates month", () => {
-    render(<DatePicker defaultOpen multiple placeholder="Select dates" />)
+  test("handles input change for multiple with valid date updates month", async () => {
+    await render(<DatePicker defaultOpen multiple placeholder="Select dates" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: "2024-06-15" } })
 
@@ -1326,8 +1355,8 @@ describe("<DatePicker />", () => {
     expect(input).toHaveValue("2024-06-15")
   })
 
-  test("handles range separator", () => {
-    render(
+  test("handles range separator", async () => {
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -1339,11 +1368,11 @@ describe("<DatePicker />", () => {
     )
 
     // Range uses separator between inputs
-    expect(screen.getByText("~")).toBeInTheDocument()
+    expect(page.getByText("~").element()).toBeInTheDocument()
   })
 
   test("handles Enter key on range end input with existing start value", async () => {
-    render(
+    await render(
       <DatePicker
         defaultOpen
         defaultValue={{
@@ -1355,22 +1384,22 @@ describe("<DatePicker />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = page.getByRole("textbox").elements() as HTMLInputElement[]
 
     // Focus on start and update with minDate constraint from end value
     fireEvent.focus(inputs[0]!)
     fireEvent.change(inputs[0]!, { target: { value: "2024-01-10" } })
     fireEvent.keyDown(inputs[0]!, { key: "Enter" })
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(inputs[0]).toHaveValue("January 10, 2024")
     })
   })
 
-  test("handles input with composing state (IME)", () => {
-    render(<DatePicker defaultOpen placeholder="Select date" />)
+  test("handles input with composing state (IME)", async () => {
+    await render(<DatePicker defaultOpen placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.focus(input)
 
     // Simulate composition
@@ -1381,65 +1410,73 @@ describe("<DatePicker />", () => {
     expect(input).toHaveValue("")
   })
 
-  test("handles disabled state prevents keyboard actions", () => {
-    render(<DatePicker defaultOpen disabled placeholder="Select date" />)
+  test("handles disabled state prevents keyboard actions", async () => {
+    await render(<DatePicker defaultOpen disabled placeholder="Select date" />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     fireEvent.keyDown(input, { key: "Enter" })
 
     expect(input).toHaveValue("")
   })
 
-  test("handles contentProps", () => {
-    render(
+  test("handles contentProps", async () => {
+    await render(
       <DatePicker
         defaultOpen
         contentProps={{ "data-testid": "content" } as any}
       />,
     )
 
-    expect(screen.getByTestId("content")).toBeInTheDocument()
+    expect(page.getByTestId("content").element()).toBeInTheDocument()
   })
 
-  test("handles custom icon", () => {
-    render(<DatePicker icon={<span data-testid="custom-icon">icon</span>} />)
+  test("handles custom icon", async () => {
+    await render(
+      <DatePicker icon={<span data-testid="custom-icon">icon</span>} />,
+    )
 
-    expect(screen.getByTestId("custom-icon")).toBeInTheDocument()
+    expect(page.getByTestId("custom-icon").element()).toBeInTheDocument()
   })
 
-  test("handles animationScheme prop", () => {
-    render(<DatePicker animationScheme="inline-start" defaultOpen />)
+  test("handles animationScheme prop", async () => {
+    await render(<DatePicker animationScheme="inline-start" defaultOpen />)
 
-    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(
+      document.querySelector('[role="dialog"]') as HTMLElement,
+    ).toBeInTheDocument()
   })
 
-  test("handles calendarProps", () => {
-    render(
+  test("handles calendarProps", async () => {
+    await render(
       <DatePicker
         defaultOpen
         calendarProps={{ "data-testid": "calendar" } as any}
       />,
     )
 
-    expect(screen.getByTestId("calendar")).toBeInTheDocument()
+    expect(page.getByTestId("calendar").element()).toBeInTheDocument()
   })
 
-  test("handles duration prop", () => {
-    render(<DatePicker defaultOpen duration={0} />)
+  test("handles duration prop", async () => {
+    await render(<DatePicker defaultOpen duration={0} />)
 
-    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(
+      document.querySelector('[role="dialog"]') as HTMLElement,
+    ).toBeInTheDocument()
   })
 
-  test("handles elementProps", () => {
-    render(<DatePicker elementProps={{ "data-testid": "element" } as any} />)
+  test("handles elementProps", async () => {
+    await render(
+      <DatePicker elementProps={{ "data-testid": "element" } as any} />,
+    )
 
-    expect(screen.getByTestId("element")).toBeInTheDocument()
+    expect(page.getByTestId("element").element()).toBeInTheDocument()
   })
 
-  test("handles required prop", () => {
-    render(<DatePicker placeholder="Select date" required />)
+  test("handles required prop", async () => {
+    await render(<DatePicker placeholder="Select date" required />)
 
-    const input = screen.getByRole("textbox")
+    const input = page.getByRole("textbox").elements()[0] as HTMLInputElement
     expect(input).toBeRequired()
   })
 })


### PR DESCRIPTION
Closes #6489

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `date-picker.test.tsx` to Vitest Browser Mode using the same `#test/browser` patterns used in Hirotomo Yamada's recent component test migrations.

## Current behavior (updates)

`packages/react/src/components/date-picker/date-picker.test.tsx` ran under jsdom via `#test` helpers.

## New behavior

The `date-picker` component tests now run in Vitest Browser Mode with `#test/browser`, `page`, and Browser Mode-friendly DOM assertions while preserving the existing scenarios covered by the test file.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Focused validation: `pnpm react test:browser --run src/components/date-picker/`
- The repo-wide `packages/react` browser suite is currently blocked by unrelated existing failures in components such as `action-bar`, `accordion`, `carousel`, `number-input`, and `stack`.
