### PR TITLE
docs(autocomplete): update custom query examples

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "words": [
     "activedescendant",
     "Adebayo",
+    "agumon",
     "Adlm",
     "Anytown",
     "arrowdown",

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -196,7 +196,7 @@ export const ItemsWithQuery: Story = () => {
             <HeartIcon fontSize="lg" />
           </>
         ),
-        query: "アグモン",
+        query: "agumon アグモン",
         value: "アグモン",
       },
       { label: "ガブモン", value: "ガブモン" },

--- a/www/contents/components/(components)/autocomplete.ja.mdx
+++ b/www/contents/components/(components)/autocomplete.ja.mdx
@@ -195,7 +195,7 @@ const items = useMemo<Autocomplete.Item[]>(
           <HeartIcon fontSize="lg" />
         </>
       ),
-      query: "アグモン",
+      query: "agumon アグモン",
       value: "アグモン",
     },
     { label: "ガブモン", value: "ガブモン" },

--- a/www/contents/components/(components)/autocomplete.mdx
+++ b/www/contents/components/(components)/autocomplete.mdx
@@ -195,7 +195,7 @@ const items = useMemo<Autocomplete.Item[]>(
           <HeartIcon fontSize="lg" />
         </>
       ),
-      query: "アグモン",
+      query: "agumon アグモン",
       value: "アグモン",
     },
     { label: "ガブモン", value: "ガブモン" },


### PR DESCRIPTION
Closes #6846

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the `Autocomplete` `Use Query` examples so they demonstrate a query value that differs from the visible label.

## Current behavior (updates)

The docs and Storybook `Use Query` examples used the same value, `"アグモン"`, for both the visible label and `query`, which made the purpose of `query` unclear.

## New behavior

The examples now use `"agumon アグモン"` for `query` while keeping the visible label unchanged, making the custom-query behavior explicit. This PR also adds `agumon` to `cspell.json`.

## Is this a breaking change (Yes/No):

No

## Additional Information
