### PR TITLE
docs(review-anti-patterns): add "Anti-pattern misapplication" entry so reviewers verify each site before invoking a known pattern

### DIFF
--- a/.agents/references/review-anti-patterns/anti-pattern-misapplication.md
+++ b/.agents/references/review-anti-patterns/anti-pattern-misapplication.md
@@ -1,0 +1,21 @@
+# Anti-pattern misapplication
+
+**Example**: [PR #6581](https://github.com/yamada-ui/yamada-ui/pull/6581) — "fix(calendar): merge user props with context props via mergeProps"
+
+**Diff** (reviewers rejected this site as "Utility over-application", but `mergeProps` is actually required here):
+
+```tsx
+// Before
+...getNavigationProps({ ...navigationProps, ...rest }),
+// After
+...getNavigationProps(mergeProps(navigationProps, rest)()),
+```
+
+**What was missed**: Reviewers flagged the entire PR as matching [Utility over-application](utility-over-application.md) and rejected every site wholesale. In reality, `navigationProps` / `controlProps` / `buttonProps` / `prevButtonProps` / `monthProps` are prop bags the user passes through `Calendar.Root`, and `rest` is the user's props on the child component. Both sides are user-supplied, so `className` / `style` / `onClick` can collide — `mergeProps` is required. The getter's internal `handlerAll` / `mergeRefs` merges user↔internal, not user↔user, so it does not cover this case. Only the `Select` sub-component sites were genuine over-application; mixing them in a blanket rejection missed the legitimate fixes.
+
+**Rule of thumb**: Before invoking an existing anti-pattern on a PR, ask:
+
+1. Did I verify **each site individually** against the pattern's criteria, instead of labeling the whole PR from one matching site?
+2. For `mergeProps` specifically, are the inputs two user-supplied prop bags (merge required) or a user prop + getter/internal output (merge likely redundant)?
+
+Known anti-patterns and genuine usage often coexist in the same PR. Blanket rejection based on one matching site is itself a misapplication of the anti-pattern.

--- a/.agents/references/review-anti-patterns/index.md
+++ b/.agents/references/review-anti-patterns/index.md
@@ -4,6 +4,7 @@ Case library of past PRs where both bots approved something the maintainer rejec
 
 - [Utility over-application](utility-over-application.md): a utility (e.g. `mergeProps`, `useMergeRefs`) applied mechanically to many sites in one PR.
 - [Prop fan-out to elements without dynamic content](suppress-hydration-warning.md): `suppressHydrationWarning` forwarded or added to multiple elements.
+- [Anti-pattern misapplication](anti-pattern-misapplication.md): a known anti-pattern invoked on a whole PR when only some sites actually match, rejecting legitimate fixes.
 
 ## Adding a new entry
 


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a new review anti-pattern entry, **Anti-pattern misapplication**, capturing the miss where AI reviewers rejected [PR #6581](https://github.com/yamada-ui/yamada-ui/pull/6581) wholesale by invoking [Utility over-application](../.agents/references/review-anti-patterns/utility-over-application.md) on every `mergeProps` site, when in fact only the `Calendar` `Select` sub-components were over-application — the `Navigation` / `Control` / `PrevButton` / `NextButton` / `Month` sites legitimately needed `mergeProps` because both sides (`*Props` from `Calendar.Root` and child `rest`) are user-supplied and can collide on `className` / `style` / event handlers.

## Current behavior (updates)

The review knowledge base has no guidance against applying a known anti-pattern wholesale to a PR. A single matching site can cause reviewers to reject legitimate fixes elsewhere in the same diff.

## New behavior

Adds `.agents/references/review-anti-patterns/anti-pattern-misapplication.md` and links it from the index. Future reviewers must verify each site individually before invoking an existing anti-pattern on the whole PR, and for `mergeProps` specifically must distinguish user↔user prop-bag merges (required) from user↔getter/internal merges (likely redundant).

## Is this a breaking change (Yes/No):

No

## Additional Information