### PR TITLE
chore(ci): avoid setup-node Node 20 deprecation

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: ".nvmrc"
         registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Closes #6903

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the shared install composite action to the latest pinnable
`actions/setup-node` release.

## Current behavior (updates)

The repo pins `actions/setup-node@v4.4.0` in
`.github/composite-actions/install/action.yml`, so workflow runs emit a
Node.js 20 deprecation warning.

## New behavior

The composite action now pins `actions/setup-node@v6.4.0`, which uses
Node.js 24 and aligns with GitHub Actions runner migration.

## Is this a breaking change (Yes/No):

No

## Additional Information

- The issue body referenced `v6.3.0`, but `v6.4.0` is the latest
  pinnable release at PR creation time.
- Verified the composite action YAML parses successfully.
- Verified upstream `actions/setup-node@v6.4.0` metadata declares
  `using: 'node24'`.
