### PR TITLE
chore(ci): avoid pnpm action Node 20 deprecation

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup PNPM
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      uses: pnpm/action-setup@8b2eead6074fefa43a68bf4c9e0f03ea4126b5ba # v6.0.3
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
Closes #6907

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the shared install composite action to the latest pinnable
`pnpm/action-setup` release.

## Current behavior (updates)

The repo pins `pnpm/action-setup@v4.2.0` in
`.github/composite-actions/install/action.yml`, so workflow runs still
emit a Node.js 20 deprecation warning from that action.

## New behavior

The composite action now pins `pnpm/action-setup@v6.0.3`, which uses
Node.js 24 and removes the remaining deprecated JavaScript action in the
shared install path.

## Is this a breaking change (Yes/No):

No

## Additional Information

- This follows the earlier `actions/setup-node` update from #6903.
- Verified the composite action YAML parses successfully.
- Verified upstream `pnpm/action-setup@v6.0.3` metadata declares
  `using: node24`.
