### PR TITLE
chore(ci): avoid checkout Node 20 deprecation in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         shard_index: [1, 2, 3, 4]
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Check modified files
         id: check-modified


### PR DESCRIPTION
Closes #6909

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update the remaining old `actions/checkout` pin in `test.yml` to the
repo's newer Node.js 24-capable checkout release.

## Current behavior (updates)

The Chromium shard job in `.github/workflows/test.yml` still uses
`actions/checkout@v4.3.1`, so the `Test / Chromium 1/4` through
`Test / Chromium 4/4` jobs emit a Node.js 20 deprecation warning.

## New behavior

The Chromium shard job now uses `actions/checkout@v6.0.1`, matching the
newer checkout pin already used elsewhere in the repo.

## Is this a breaking change (Yes/No):

No

## Additional Information

- This follows the earlier GitHub Actions runtime cleanup in #6903 and
  #6907.
- Verified `.github/workflows/test.yml` parses successfully after the
  pin update.
