### PR TITLE
fix(breadcrumb): merge list props safely

### DIFF
--- a/.changeset/breadcrumb-list-merge-props.md
+++ b/.changeset/breadcrumb-list-merge-props.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed Breadcrumb list props merging so root gap values are preserved when list props contain undefined values.

--- a/packages/react/src/components/breadcrumb/breadcrumb.test.tsx
+++ b/packages/react/src/components/breadcrumb/breadcrumb.test.tsx
@@ -50,6 +50,22 @@ describe("<Breadcrumb />", () => {
     expect(screen.getByTestId("ellipsis").tagName).toBe("svg")
   })
 
+  test("preserves root `gap` when `listProps` has an undefined `gap`", () => {
+    render(
+      <Breadcrumb.Root
+        gap="10px"
+        listProps={{ "data-testid": "list", gap: undefined }}
+      >
+        <Breadcrumb.Link href="/">Link 1</Breadcrumb.Link>
+        <Breadcrumb.Link href="/" currentPage>
+          Link 2
+        </Breadcrumb.Link>
+      </Breadcrumb.Root>,
+    )
+
+    expect(screen.getByTestId("list")).toHaveStyle({ gap: "10px" })
+  })
+
   test("separator property is being passed accurately", () => {
     render(
       <Breadcrumb.Root separator="-">

--- a/packages/react/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/breadcrumb.tsx
@@ -5,7 +5,7 @@ import type { HTMLStyledProps, PropGetter, ThemeProps } from "../../core"
 import type { BreadcrumbStyle } from "./breadcrumb.style"
 import type { UseBreadcrumbProps } from "./use-breadcrumb"
 import { Fragment, useMemo } from "react"
-import { createSlotComponent, styled } from "../../core"
+import { createSlotComponent, mergeProps, styled } from "../../core"
 import { ChevronRightIcon, EllipsisIcon } from "../icon"
 import { breadcrumbStyle } from "./breadcrumb.style"
 import { useBreadcrumb } from "./use-breadcrumb"
@@ -104,7 +104,7 @@ export const BreadcrumbRoot = withProvider<"nav", BreadcrumbRootProps>(
     return (
       <ComponentContext value={context}>
         <styled.nav {...getRootProps()}>
-          <BreadcrumbList {...getListProps({ gap, ...listProps })}>
+          <BreadcrumbList {...getListProps(mergeProps({ gap }, listProps)())}>
             {children.map((child, index) => {
               const last = index === children.length - 1
 


### PR DESCRIPTION
Closes #6459

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Merges `Breadcrumb` list props with root-provided gap props through `mergeProps` so undefined list props do not overwrite context/default values.

## Current behavior (updates)

`Breadcrumb.Root` called `getListProps({ gap, ...listProps })`, so an undefined `listProps.gap` could replace the root `gap` before the getter received props.

## New behavior

`Breadcrumb.Root` now calls `getListProps(mergeProps({ gap }, listProps)())` and includes a focused regression test for preserving the root gap.

## Is this a breaking change (Yes/No):

No

## Additional Information

Targeted test passed with Node's localStorage workaround:

```bash
NODE_OPTIONS=--no-experimental-webstorage pnpm react test:jsdom --run src/components/breadcrumb/
```