### PR TITLE
docs(action-bar): align accessibility dialog docs

### DIFF
--- a/www/contents/components/(components)/action-bar.ja.mdx
+++ b/www/contents/components/(components)/action-bar.ja.mdx
@@ -191,7 +191,7 @@ return (
 
 ## アクセシビリティ
 
-`ActionBar`は、アクセシビリティに関して[WAI-ARIA - Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)に従います。
+`ActionBar`は、コンテンツを非モーダルのダイアログとして公開し、以下のダイアログ関連のARIA属性を設定します。`aria-modal`やアクセシブルネームはデフォルトでは設定されないため、ラベルが必要な場合は`aria-label`または`aria-labelledby`を`ActionBar.Content`に渡してください。
 
 ### キーボード操作
 
@@ -203,7 +203,7 @@ return (
 
 | コンポーネント           | ロールと属性             | 使い方                                                                                    |
 | ------------------------ | ------------------------ | ----------------------------------------------------------------------------------------- |
-| `ActionBar.Content`      | `role="dialog"`          | ダイアログであることを示します。                                                          |
+| `ActionBar.Content`      | `role="dialog"`          | ダイアログであることを示します。`aria-modal`とアクセシブルネームはデフォルトでは設定されません。 |
 | `ActionBar.OpenTrigger`  | `aria-haspopup="dialog"` | ダイアログが存在することを示します。                                                      |
 |                          | `aria-expanded`          | アクションバーが開いている場合は`"true"`を設定し、閉じている場合は`"false"`を設定します。 |
 |                          | `aria-controls`          | アクションバーが開いている場合は、`ActionBar.Content`の`id`を設定します。                 |

--- a/www/contents/components/(components)/action-bar.mdx
+++ b/www/contents/components/(components)/action-bar.mdx
@@ -191,7 +191,7 @@ return (
 
 ## Accessibility
 
-The `ActionBar` follows the [WAI-ARIA - Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) for accessibility.
+The `ActionBar` exposes its content as a non-modal dialog and sets the dialog-related ARIA attributes listed below. It does not set `aria-modal` or an accessible name by default, so pass `aria-label` or `aria-labelledby` to `ActionBar.Content` when a label is needed.
 
 ### Keyboard Navigation
 
@@ -203,7 +203,7 @@ The `ActionBar` follows the [WAI-ARIA - Dialog (Modal) Pattern](https://www.w3.o
 
 | Component                | Roles and Attributes     | Usage                                                                      |
 | ------------------------ | ------------------------ | -------------------------------------------------------------------------- |
-| `ActionBar.Content`      | `role="dialog"`          | Indicates that this is a dialog.                                           |
+| `ActionBar.Content`      | `role="dialog"`          | Indicates that this is a dialog. `aria-modal` and an accessible name are not set by default. |
 | `ActionBar.OpenTrigger`  | `aria-haspopup="dialog"` | Indicates that a dialog exists.                                            |
 |                          | `aria-expanded`          | Sets to `"true"` if the action bar is open, and `"false"` if it is closed. |
 |                          | `aria-controls`          | If the action bar is open, sets to the `id` of `ActionBar.Content`.        |


### PR DESCRIPTION
Closes: N/A

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates the ActionBar accessibility docs in English and Japanese so they describe the current source behavior instead of claiming conformance with the WAI-ARIA Dialog (Modal) Pattern.

## Current behavior (updates)

The docs say `ActionBar` follows the WAI-ARIA Dialog (Modal) Pattern, but the source only sets dialog-related attributes such as `role="dialog"` and trigger attributes. It does not set modal dialog defaults like `aria-modal` or an accessible name.

## New behavior

The docs now describe `ActionBar.Content` as a non-modal dialog, document that `aria-modal` and an accessible name are not set by default, and tell users to pass `aria-label` or `aria-labelledby` when a label is needed.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation: Not run. This is a docs-only copy change.