### PR TITLE
docs(color-selector): document keyboard activation

### DIFF
--- a/www/contents/components/(components)/color-selector.ja.mdx
+++ b/www/contents/components/(components)/color-selector.ja.mdx
@@ -183,6 +183,7 @@ return <ColorSelector.Root maxW="md" value={value} onChange={setValue} />
 | `End`                    | 色相スライダーまたは透明スライダー内である場合は`max`の値を設定します。                    | -    |
 | `PageUp`                 | 色相スライダーまたは透明スライダー内である場合は`min`と`max`の値に基づいて値を増加します。 | -    |
 | `PageDown`               | 色相スライダーまたは透明スライダー内である場合は`min`と`max`の値に基づいて値を減少します。 | -    |
+| `Enter`, `Space`         | スポイトボタンを起動するか、フォーカスされた色候補を選択します。                         | -    |
 
 ### ARIAロールと属性
 
@@ -191,7 +192,6 @@ return <ColorSelector.Root maxW="md" value={value} onChange={setValue} />
 | `ColorSelector.EyeDropper`               | `role="button"`        | ボタンであることを示します。                                                                                                                                                   |
 |                                          | `aria-disabled`        | `disabled`または`readOnly`が設定されている場合は`"true"`を設定します。                                                                                                         |
 |                                          | `aria-label`           | `"色を選択する"`を設定します。                                                                                                                                                 |
-|                                          | `aria-disabled`        | `disabled`が設定されている場合は`"true"`を設定します。                                                                                                                         |
 | `ColorSelector.SaturationSlider > input` | `aria-hidden`          | 要素をアクセシビリティツリーから除外します。                                                                                                                                   |
 |                                          | `aria-describedby`     | `Field.Root`内にあり、`Field.Root`に`errorMessage`または`helperMessage`、もしくは`Field.ErrorMessage`または`Field.HelperMessage`が設定されている場合は、その`id`を設定します。 |
 | `ColorSelector.SaturationSlider > div`   | `role="slider"`        | スライダーであることを示します。                                                                                                                                               |

--- a/www/contents/components/(components)/color-selector.mdx
+++ b/www/contents/components/(components)/color-selector.mdx
@@ -183,6 +183,7 @@ return <ColorSelector.Root maxW="md" value={value} onChange={setValue} />
 | `End`                    | If within hue slider or alpha slider, sets the value to `max`.                      | -     |
 | `PageUp`                 | If within hue slider or alpha slider, increases the value based on `min` and `max`. | -     |
 | `PageDown`               | If within hue slider or alpha slider, decreases the value based on `min` and `max`. | -     |
+| `Enter`, `Space`         | Activates the eyedropper button or selects the focused color swatch item.           | -     |
 
 ### ARIA Roles and Attributes
 
@@ -191,7 +192,6 @@ return <ColorSelector.Root maxW="md" value={value} onChange={setValue} />
 | `ColorSelector.EyeDropper`               | `role="button"`        | Indicates that this is a button.                                                                                                                           |
 |                                          | `aria-disabled`        | Sets to `"true"` if `disabled` or `readOnly` is set.                                                                                                       |
 |                                          | `aria-label`           | Sets to `"Pick a color"`.                                                                                                                                  |
-|                                          | `aria-disabled`        | Set to `"true"` if `disabled` is set.                                                                                                                      |
 | `ColorSelector.SaturationSlider > input` | `aria-hidden`          | Excludes the element from the accessibility tree.                                                                                                          |
 |                                          | `aria-describedby`     | If this is within a `Field.Root` and `Field.Root` has an `errorMessage`, `helperMessage`, or a `Field.ErrorMessage`, `Field.HelperMessage`, sets its `id`. |
 | `ColorSelector.SaturationSlider > div`   | `role="slider"`        | Indicates that this is a slider.                                                                                                                           |


### PR DESCRIPTION
Closes: N/A

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates the ColorSelector accessibility docs to align the keyboard navigation and ARIA attribute descriptions with the implementation.

## Current behavior (updates)

The accessibility docs omitted Enter and Space activation for interactive color selector controls, and duplicated the EyeDropper `aria-disabled` row with conflicting descriptions.

## New behavior

The English and Japanese docs now document Enter and Space activation consistently and remove the conflicting duplicate `aria-disabled` description.

## Is this a breaking change (Yes/No):

No

## Additional Information

Docs-only change. Tests, format, lint, and typecheck were not run.