### PR TITLE
docs(table): align accessibility pattern reference

### DIFF
--- a/www/contents/components/(components)/table.ja.mdx
+++ b/www/contents/components/(components)/table.ja.mdx
@@ -979,7 +979,7 @@ return (
 
 ## アクセシビリティ
 
-`Table`は、アクセシビリティに関して[WAI-ARIA - Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/)に従います。
+`Table`は、`role="grid"`を使用し、アクセシビリティに関して[WAI-ARIA - Grid Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)に従います。
 
 `tableProps`に`aria-label`を設定すると、スクリーンリーダーによって読み上げられます。
 

--- a/www/contents/components/(components)/table.mdx
+++ b/www/contents/components/(components)/table.mdx
@@ -979,7 +979,7 @@ return (
 
 ## Accessibility
 
-The `Table` follows the [WAI-ARIA - Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/) for accessibility.
+The `Table` uses `role="grid"` and follows the [WAI-ARIA - Grid Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) for accessibility.
 
 Setting an `aria-label` on the `tableProps` allows it to be read by screen readers.
 


### PR DESCRIPTION
Closes: N/A

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Align the Table accessibility docs with the rendered ARIA role and documented keyboard behavior.

## Current behavior (updates)

The accessibility prose referenced the WAI-ARIA Table Pattern even though the docs list `role="grid"` and grid-style arrow-key navigation.

## New behavior

The English and Japanese Table docs now reference the WAI-ARIA Grid Pattern and explicitly note that `Table` uses `role="grid"`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Validation: docs-only change; no format, lint, typecheck, or tests were run manually. Commit hooks ran during commit and passed after the worktree was linked to the existing local dependency tree.