### PR TITLE
docs(progress): align accessibility pattern reference

### DIFF
--- a/www/contents/components/(components)/progress.ja.mdx
+++ b/www/contents/components/(components)/progress.ja.mdx
@@ -151,7 +151,7 @@ import { Progress } from "@workspaces/ui"
 
 ## アクセシビリティ
 
-`Progress`は、アクセシビリティに関して[WAI-ARIA - Meter Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/meter/)に従います。
+`Progress`は、アクセシビリティに関して[WAI-ARIA - Progressbar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/progressbar/)に従います。
 
 `Progress`に`aria-label`または`aria-labelledby`を設定すると、スクリーンリーダーによって読み上げられます。
 

--- a/www/contents/components/(components)/progress.mdx
+++ b/www/contents/components/(components)/progress.mdx
@@ -151,7 +151,7 @@ To use animation, set `value` to `null`.
 
 ## Accessibility
 
-The `Progress` follows the [WAI-ARIA - Meter Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/meter/) for accessibility.
+The `Progress` follows the [WAI-ARIA - Progressbar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/progressbar/) for accessibility.
 
 Setting `aria-label` or `aria-labelledby` on `Progress` will make it readable by screen readers.
 


### PR DESCRIPTION
Closes: N/A

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Aligns the Progress accessibility documentation with the documented and implemented `role="progressbar"` behavior.

## Current behavior (updates)

The English and Japanese Accessibility prose links to the WAI-ARIA Meter Pattern, while the ARIA table and source behavior use `role="progressbar"`.

## New behavior

The Accessibility prose now references the WAI-ARIA Progressbar Pattern in both English and Japanese docs.

## Is this a breaking change (Yes/No):

No

## Additional Information

Docs-only change. Format, lint, typecheck, and tests were not run per task instructions.