### PR TITLE
fix(docs): avoid CSS columns in examples layout

### DIFF
--- a/www/components/examples/appearance.tsx
+++ b/www/components/examples/appearance.tsx
@@ -23,7 +23,6 @@ export function Appearance() {
       layerStyle="card"
       bg="bg.panel"
       gap="md"
-      mb="{space}"
       p="{space}"
       separator={<Separator />}
     >

--- a/www/components/examples/bookmark.tsx
+++ b/www/components/examples/bookmark.tsx
@@ -17,7 +17,6 @@ export function Bookmark() {
       alignItems="center"
       bg="bg.panel"
       gap="md"
-      mb="{space}"
       p="{space}"
     >
       <HStack w="full">

--- a/www/components/examples/calendar.tsx
+++ b/www/components/examples/calendar.tsx
@@ -2,14 +2,7 @@ import { Center, Calendar as OriginalCalendar } from "@yamada-ui/react"
 
 export function Calendar() {
   return (
-    <Center
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      gap="md"
-      mb="{space}"
-      p="{space}"
-    >
+    <Center as="section" layerStyle="card" bg="bg.panel" gap="md" p="{space}">
       <OriginalCalendar.Root
         colorScheme="primary"
         size="lg"

--- a/www/components/examples/create-account.tsx
+++ b/www/components/examples/create-account.tsx
@@ -18,7 +18,6 @@ export function CreateAccount() {
       alignItems="stretch"
       bg="bg.panel"
       gap="md"
-      mb="{space}"
       p="{space}"
     >
       <VStack gap="xs">

--- a/www/components/examples/index.tsx
+++ b/www/components/examples/index.tsx
@@ -1,4 +1,7 @@
-import { Box } from "@yamada-ui/react"
+"use client"
+
+import type { ComponentType } from "react"
+import { For, Grid, useBreakpointValue, VStack } from "@yamada-ui/react"
 import { Appearance } from "./appearance"
 import { Bookmark } from "./bookmark"
 import { Calendar } from "./calendar"
@@ -11,25 +14,59 @@ import { Roadmap } from "./roadmap"
 import { Role } from "./role"
 import { SocialMedia } from "./social-media"
 
+const THREE_COLUMN_GROUPS = [
+  [PaymentMethod, CreateAccount, Role],
+  [SocialMedia, Appearance, Bookmark, Calendar],
+  [Processing, Notifications, Roadmap, QAndA],
+] as const satisfies readonly (readonly ComponentType[])[]
+
+const TWO_COLUMN_GROUPS = [
+  [PaymentMethod, Role, Appearance, Calendar, Notifications],
+  [CreateAccount, SocialMedia, Bookmark, Processing, Roadmap, QAndA],
+] as const satisfies readonly (readonly ComponentType[])[]
+
+const SINGLE_COLUMN_GROUPS = [
+  [
+    PaymentMethod,
+    CreateAccount,
+    Role,
+    SocialMedia,
+    Appearance,
+    Bookmark,
+    Calendar,
+    Processing,
+    Notifications,
+    Roadmap,
+    QAndA,
+  ],
+] as const satisfies readonly (readonly ComponentType[])[]
+
 export function Examples() {
+  const columns = useBreakpointValue<readonly (readonly ComponentType[])[]>({
+    base: THREE_COLUMN_GROUPS,
+    md: SINGLE_COLUMN_GROUPS,
+    xl: TWO_COLUMN_GROUPS,
+  })
+
   return (
-    <Box
+    <Grid
       as="section"
-      columnCount="auto"
-      columnWidth="calc(sm + {space} * 2)"
       gap="{space}"
+      templateColumns={{
+        base: "repeat(3, minmax(0, 1fr))",
+        md: "1fr",
+        xl: "repeat(2, minmax(0, 1fr))",
+      }}
     >
-      <PaymentMethod />
-      <CreateAccount />
-      <Role />
-      <SocialMedia />
-      <Appearance />
-      <Bookmark />
-      <Calendar />
-      <Processing />
-      <Notifications />
-      <Roadmap />
-      <QAndA />
-    </Box>
+      <For each={columns}>
+        {(column, index) => (
+          <VStack key={index} alignItems="stretch" gap="{space}">
+            <For each={column}>
+              {(Component, index) => <Component key={index} />}
+            </For>
+          </VStack>
+        )}
+      </For>
+    </Grid>
   )
 }

--- a/www/components/examples/notifications.tsx
+++ b/www/components/examples/notifications.tsx
@@ -2,14 +2,7 @@ import { Heading, RadioCardGroup, Text, VStack } from "@yamada-ui/react"
 
 export function Notifications() {
   return (
-    <VStack
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      gap="md"
-      mb="{space}"
-      p="{space}"
-    >
+    <VStack as="section" layerStyle="card" bg="bg.panel" gap="md" p="{space}">
       <VStack gap="xs">
         <Heading as="h2" size="xl">
           Notifications

--- a/www/components/examples/payment-method.tsx
+++ b/www/components/examples/payment-method.tsx
@@ -14,13 +14,7 @@ import {
 
 export function PaymentMethod() {
   return (
-    <VStack
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      mb="{space}"
-      p="{space}"
-    >
+    <VStack as="section" layerStyle="card" bg="bg.panel" p="{space}">
       <VStack gap="xs">
         <Heading as="h2" size="xl">
           Payment Method

--- a/www/components/examples/processing.tsx
+++ b/www/components/examples/processing.tsx
@@ -15,7 +15,6 @@ export function Processing() {
       alignItems="center"
       bg="bg.panel"
       gap="md"
-      mb="{space}"
       p="{space}"
     >
       <Center py="{space}">

--- a/www/components/examples/q-and-a.tsx
+++ b/www/components/examples/q-and-a.tsx
@@ -2,14 +2,7 @@ import { Accordion, Heading, VStack } from "@yamada-ui/react"
 
 export function QAndA() {
   return (
-    <VStack
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      gap="md"
-      mb="{space}"
-      p="{space}"
-    >
+    <VStack as="section" layerStyle="card" bg="bg.panel" gap="md" p="{space}">
       <Heading as="h2" size="xl">
         Q&A
       </Heading>

--- a/www/components/examples/roadmap.tsx
+++ b/www/components/examples/roadmap.tsx
@@ -2,14 +2,7 @@ import { Heading, Timeline, VStack } from "@yamada-ui/react"
 
 export function Roadmap() {
   return (
-    <VStack
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      gap="md"
-      mb="{space}"
-      p="{space}"
-    >
+    <VStack as="section" layerStyle="card" bg="bg.panel" gap="md" p="{space}">
       <Heading as="h2" size="xl">
         Roadmap
       </Heading>

--- a/www/components/examples/role.tsx
+++ b/www/components/examples/role.tsx
@@ -2,14 +2,7 @@ import { Avatar, Heading, HStack, Select, Text, VStack } from "@yamada-ui/react"
 
 export function Role() {
   return (
-    <VStack
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      gap="md"
-      mb="{space}"
-      p="{space}"
-    >
+    <VStack as="section" layerStyle="card" bg="bg.panel" gap="md" p="{space}">
       <VStack gap="xs">
         <Heading as="h2" size="xl">
           Role

--- a/www/components/examples/social-media.tsx
+++ b/www/components/examples/social-media.tsx
@@ -2,14 +2,7 @@ import { Avatar, Button, Heading, HStack, Text, VStack } from "@yamada-ui/react"
 
 export function SocialMedia() {
   return (
-    <VStack
-      as="section"
-      layerStyle="card"
-      bg="bg.panel"
-      gap="md"
-      mb="{space}"
-      p="{space}"
-    >
+    <VStack as="section" layerStyle="card" bg="bg.panel" gap="md" p="{space}">
       <HStack>
         <HStack flex="1" gap="sm">
           <Avatar src="https://avatars.githubusercontent.com/u/84060430?v=4" />


### PR DESCRIPTION
Closes #6227

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Replaces the documentation examples masonry layout with explicit Yamada UI `Grid` and `VStack` column groups instead of CSS multi-column layout.

## Current behavior (updates)

The docs landing/examples layout uses CSS columns for stacked cards. Safari can render the page with a large empty bottom area.

## New behavior

The examples layout now renders explicit responsive stacked columns:

- 3 columns at the default layout
- 2 columns at the `xl` breakpoint
- 1 column at the `md` breakpoint

Card spacing is handled by the parent stack gap instead of per-card bottom margins.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified with docs package quality checks and a production Next.js build.
