### PR TITLE
test(tooltip): stabilize flaky openDelay and closeDelay test

### DIFF
--- a/packages/react/src/components/tooltip/tooltip.test.tsx
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx
@@ -1,5 +1,5 @@
-import { a11y, page, render } from "#test/browser"
 import { vi } from "vitest"
+import { a11y, page, render } from "#test/browser"
 import { Tooltip } from "."
 import { Text } from "../text"
 
@@ -319,7 +319,7 @@ describe("<Tooltip />", () => {
 
   test("handles openDelay and closeDelay", async () => {
     const { user } = await render(
-      <Tooltip closeDelay={100} content="Tooltip Hovered" openDelay={100}>
+      <Tooltip closeDelay={500} content="Tooltip Hovered" openDelay={500}>
         <Text as="span">Trigger</Text>
       </Tooltip>,
     )
@@ -329,7 +329,7 @@ describe("<Tooltip />", () => {
     await user.hover(trigger)
 
     await expect
-      .element(page.getByRole("tooltip").query())
+      .element(page.getByRole("tooltip").query(), { timeout: 50 })
       .not.toBeInTheDocument()
 
     await vi.waitFor(async () => {
@@ -337,6 +337,10 @@ describe("<Tooltip />", () => {
     })
 
     await user.unhover(trigger)
+
+    await expect
+      .element(page.getByRole("tooltip"), { timeout: 50 })
+      .toBeInTheDocument()
 
     await vi.waitFor(async () => {
       await expect


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes a flaky test (`<Tooltip /> > handles openDelay and closeDelay`) in [packages/react/src/components/tooltip/tooltip.test.tsx](packages/react/src/components/tooltip/tooltip.test.tsx) that has been failing in the Codecov workflow on `main` for the last 8+ runs (each timing out after ~10s with `Matcher did not succeed in time`).

## Current behavior (updates)

The test verified that hovering does not show the tooltip immediately when `openDelay` is set:

```ts
await user.hover(trigger)

await expect
  .element(page.getByRole("tooltip").query())
  .not.toBeInTheDocument()
```

`expect.element(locator).not.toBeInTheDocument()` is a sugar for `expect.poll(...)` and **auto-retries until the configured polling timeout** (~10s by default). With `openDelay = 100ms`, the tooltip becomes visible during the polling window, so the `.not.` assertion can never converge and the matcher times out.

CI logs across recent runs (`24959751893`, `24958863417`, `24957009435`, `24956776155`, `24955687273`, `24955131508`, `24954017552`, `24950216559`) all show the same `handles openDelay and closeDelay` test failing at exactly this assertion with ~10s polling timeout.

## New behavior

- Increased `openDelay` and `closeDelay` from `100` to `500` so the delay is reliably larger than `user.hover()` / `user.unhover()` processing time on slow CI runners.
- Added `{ timeout: 50 }` to the absolute "not yet visible / still visible immediately after the gesture" assertions so they fall through quickly when the expected state is observed on the first poll, instead of racing with the delay.
- The `vi.waitFor` calls verifying the eventual transition keep their default 1000ms timeout, which comfortably accommodates the 500ms delay.

Verified locally with 5 consecutive `pnpm react test:browser --run src/components/tooltip/tooltip.test.tsx` runs across chromium / webkit / firefox — all 54 tests pass each time.

## Is this a breaking change (Yes/No):

No. Test-only change.

## Additional Information

Test file change only — no changeset required per [.agents/rules/changesets.md](.agents/rules/changesets.md).