### PR TITLE
test(tree): stabilize getRootProps merge test across browsers

### DIFF
--- a/packages/react/src/components/tree/tree.test.tsx
+++ b/packages/react/src/components/tree/tree.test.tsx
@@ -535,7 +535,9 @@ describe("<Tree />", () => {
             style: { fontSize: "16px" },
             onClick: onClickFromGetter,
           })}
-        />
+        >
+          <li role="treeitem">Item</li>
+        </ul>
       )
     }
 
@@ -554,7 +556,7 @@ describe("<Tree />", () => {
       fontSize: "16px",
     })
 
-    await user.click(page.getByTestId("hook-root"))
+    await user.click(page.getByRole("treeitem", { name: "Item" }))
 
     expect(onClickFromOptions).toHaveBeenCalledTimes(1)
     expect(onClickFromGetter).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Stabilize the `useTree` `getRootProps` merge test so it passes on every browser engine.

## Current behavior (updates)

The merge-root-props test rendered a bare `<ul />` and clicked it directly. With no children, the `<ul>` had a 0×0 bounding box, so Playwright's visibility/viewport check failed on every browser engine and the click timed out at ~10s. The shard that included this test failed deterministically on Chromium, Firefox, and WebKit.

## New behavior

Render a `treeitem` child so the root `<ul>` has a real bounding box, then click the `treeitem`. The click bubbles up to the root, firing the merged `onClick` handlers from both `useTree` options and `getRootProps`. Following the testing-library priority, the click target is selected via `getByRole` rather than `getByTestId`.

## Is this a breaking change (Yes/No):

No. Test-only change.

## Additional Information

Local check: \`pnpm react test:chromium --run src/components/tree/tree.test.tsx -t "should merge root props from useTree options and getRootProps"\` passes.