### PR TITLE
test(accordion): assert getItemProps args win over hook rest props

### DIFF
--- a/packages/react/src/components/accordion/accordion.test.tsx
+++ b/packages/react/src/components/accordion/accordion.test.tsx
@@ -504,7 +504,7 @@ describe("<Accordion />", () => {
 
     await expect.element(item).toHaveClass("rest-class")
     await expect.element(item).toHaveClass("args-class")
-    expect(itemEl.id).toBe("rest-id")
+    expect(itemEl.id).toBe("args-id")
     expect(itemEl).toBeInstanceOf(HTMLElement)
     const htmlItemEl = itemEl as HTMLElement
     expect(htmlItemEl.style.color).toBe("red")


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Align the \`getItemProps\` merge expectation with the documented contract so the Accordion suite passes on every browser engine.

## Current behavior (updates)

\`useAccordion\`'s \`getRootProps\` and \`getItemProps\` are documented to let user-supplied args override the hook-level rest defaults. The \`getRootProps\` test already asserts this (\`expect(rootProps.id).toBe("args-id")\`). The \`getItemProps\` test, however, expected the opposite (\`expect(itemEl.id).toBe("rest-id")\`), which contradicted both the implementation and its sibling test, and caused a deterministic failure on every browser engine.

## New behavior

Update the \`getItemProps\` assertion to expect \`args-id\`, matching both the implementation and the \`getRootProps\` companion test.

## Is this a breaking change (Yes/No):

No. Test-only change.

## Additional Information

Local check: \`pnpm react test:chromium --run src/components/accordion/accordion.test.tsx -t "merges props correctly in .getItemProps."\` passes.