### PR TITLE
fix(date-picker): keep already-selected date on Enter in multiple mode

### DIFF
--- a/.changeset/date-picker-multiple-enter-no-toggle.md
+++ b/.changeset/date-picker-multiple-enter-no-toggle.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fix DatePicker `multiple` mode so pressing `Enter` on an already-selected date in the input no longer removes it from the value array. The Enter handler now appends only when the date is not already selected and the `max` limit has not been reached, instead of toggling via the shared calendar-cell logic.

--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -892,7 +892,7 @@ describe("<DatePicker />", () => {
     const input = page.getByRole("textbox").first()
     const inputEl = await input.findElement()
     inputEl.focus()
-    await _user.type(input, "2024-01-15")
+    await _user.type(input, "2024-01-17")
     await _user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
@@ -905,6 +905,9 @@ describe("<DatePicker />", () => {
     await expect
       .element(page.getByRole("combobox").first())
       .toHaveTextContent("January 16, 2024")
+    await expect
+      .element(page.getByText("January 17, 2024").query())
+      .not.toBeInTheDocument()
   })
 
   test("handles onClear with multiple value", async () => {

--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -848,6 +848,65 @@ describe("<DatePicker />", () => {
     })
   })
 
+  test("handles Enter key on multiple date input keeps already-selected date", async () => {
+    const onChange = vi.fn()
+    const { user: _user } = await render(
+      <DatePicker
+        defaultOpen
+        defaultValue={[new Date(2024, 0, 15)]}
+        multiple
+        placeholder="Select dates"
+        onChange={onChange}
+      />,
+    )
+
+    const input = page.getByRole("textbox").first()
+    const inputEl = await input.findElement()
+    inputEl.focus()
+    await _user.type(input, "2024-01-15")
+    await _user.keyboard("{Enter}")
+
+    // Input cleared, but the existing date stays in the array (no toggle-off)
+    await vi.waitFor(async () => {
+      await expect.element(input).toHaveValue("")
+    })
+    expect(onChange).not.toHaveBeenCalled()
+    await expect
+      .element(page.getByRole("combobox").first())
+      .toHaveTextContent("January 15, 2024")
+  })
+
+  test("handles Enter key on multiple date input does not remove when max is reached", async () => {
+    const onChange = vi.fn()
+    const { user: _user } = await render(
+      <DatePicker
+        defaultOpen
+        defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
+        max={2}
+        multiple
+        placeholder="Select dates"
+        onChange={onChange}
+      />,
+    )
+
+    const input = page.getByRole("textbox").first()
+    const inputEl = await input.findElement()
+    inputEl.focus()
+    await _user.type(input, "2024-01-15")
+    await _user.keyboard("{Enter}")
+
+    await vi.waitFor(async () => {
+      await expect.element(input).toHaveValue("")
+    })
+    expect(onChange).not.toHaveBeenCalled()
+    await expect
+      .element(page.getByRole("combobox").first())
+      .toHaveTextContent("January 15, 2024")
+    await expect
+      .element(page.getByRole("combobox").first())
+      .toHaveTextContent("January 16, 2024")
+  })
+
   test("handles onClear with multiple value", async () => {
     const { user: _user } = await render(
       <DatePicker

--- a/packages/react/src/components/date-picker/use-date-picker.tsx
+++ b/packages/react/src/components/date-picker/use-date-picker.tsx
@@ -53,6 +53,7 @@ import {
   getAdjustedMonth,
   isAfterDate,
   isBeforeDate,
+  isIncludeDates,
   updateMaybeDateValue,
   useCalendarProps,
 } from "../calendar"
@@ -577,23 +578,7 @@ export const useDatePicker = <
           Enter: (ev) => {
             if (!open || !inputValue.length) return
 
-            if (isArray(value)) {
-              const date = stringToDate(inputValue)
-
-              if (!date) return
-
-              ev.preventDefault()
-
-              setInputValue("" as MaybeInputValue<Range>)
-
-              setValue(
-                (prev) =>
-                  updateMaybeDateValue(date, max)(prev) as MaybeDateValue<
-                    Multiple,
-                    Range
-                  >,
-              )
-            } else if (isObject(value) && !isDate(value)) {
+            if (isObject(value) && !isArray(value) && !isDate(value)) {
               const align = contains(endInputRef.current, ev.target)
                 ? "end"
                 : "start"
@@ -630,8 +615,20 @@ export const useDatePicker = <
 
               ev.preventDefault()
 
-              setInputValue(dateToString(date) as MaybeInputValue<Range>)
-              setValue(date as MaybeDateValue<Multiple, Range>)
+              if (isArray(value)) {
+                setInputValue("" as MaybeInputValue<Range>)
+
+                setValue((prev) =>
+                  isArray(prev) &&
+                  !isIncludeDates(date, prev) &&
+                  (!isNumber(max) || prev.length < max)
+                    ? ([...prev, date] as MaybeDateValue<Multiple, Range>)
+                    : prev,
+                )
+              } else {
+                setInputValue(dateToString(date) as MaybeInputValue<Range>)
+                setValue(date as MaybeDateValue<Multiple, Range>)
+              }
             }
           },
         },


### PR DESCRIPTION
Closes #7016

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix `DatePicker` `multiple` mode so that pressing `Enter` on an already-selected date in the input no longer removes it from the value array.

## Current behavior (updates)

In `DatePicker` with `multiple` mode, the Enter handler delegated to the shared `updateMaybeDateValue(date, max)` helper, which is also used by the calendar cell click. Its array branch toggles a date off when it is already included:

```ts
if (isIncludeDates(value, prev)) {
  return prev.filter((prevValue) => !isSameDate(prevValue, value))
}
```

That toggle makes sense for clicking the same calendar cell twice, but for the input + Enter path the user's intent is to commit a selection — silently removing the date is indistinguishable from a reset.

## New behavior

The Enter handler in `multiple` mode now appends only when the date is not already selected and the `max` limit has not been reached, otherwise it leaves the value unchanged. The single-mode and range-mode paths are unchanged. The input is still cleared as user feedback that the input was consumed.

The single and multiple branches were also consolidated into one block that shares the `stringToDate(inputValue)` parse, with the array-specific update logic inlined.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Tests added in `packages/react/src/components/date-picker/date-picker.test.tsx`:

- `handles Enter key on multiple date input keeps already-selected date` — reproduces #7016 and asserts the date stays in the array and `onChange` is not called.
- `handles Enter key on multiple date input does not remove when max is reached` — asserts no removal happens at the `max` boundary.

All 294 date-picker browser tests pass locally.

Related: #7012