### PR TITLE
fix(date-picker): open calendar on start/end input click in range mode

### DIFF
--- a/.changeset/date-picker-range-click.md
+++ b/.changeset/date-picker-range-click.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed `DatePicker` not opening the calendar when clicking the start or end input in `range` mode.

--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -304,6 +304,34 @@ describe("<DatePicker />", () => {
       .not.toBeInTheDocument()
   })
 
+  test("opens on start input click in range mode", async () => {
+    const { user: _user } = await render(
+      <DatePicker placeholder="Select date" range />,
+    )
+
+    const inputs = page.getByRole("textbox")
+    await _user.click(inputs.first())
+
+    await vi.waitFor(async () => {
+      await expect.element(page.getByRole("dialog")).toBeInTheDocument()
+    })
+    await expect.element(inputs.first()).toHaveFocus()
+  })
+
+  test("opens on end input click in range mode", async () => {
+    const { user: _user } = await render(
+      <DatePicker placeholder="Select date" range />,
+    )
+
+    const inputs = page.getByRole("textbox")
+    await _user.click(inputs.nth(1))
+
+    await vi.waitFor(async () => {
+      await expect.element(page.getByRole("dialog")).toBeInTheDocument()
+    })
+    await expect.element(inputs.nth(1)).toHaveFocus()
+  })
+
   test("handles input change for single date", async () => {
     const { user: _user } = await render(
       <DatePicker placeholder="Select date" />,
@@ -1224,7 +1252,7 @@ describe("<DatePicker />", () => {
     await expect.element(inputs.first()).toHaveFocus()
   })
 
-  test("handles click on range field focuses end input when only start is set", async () => {
+  test("handles click on range field focuses start input when only start is set", async () => {
     const { user: _user } = await render(
       <DatePicker
         defaultValue={{
@@ -1240,10 +1268,9 @@ describe("<DatePicker />", () => {
     const fieldEl = await field.findElement()
     if (fieldEl instanceof HTMLElement) fieldEl.click()
 
-    // End input should be focused since start has value
     const inputs = page.getByRole("textbox")
     await vi.waitFor(async () => {
-      await expect.element(inputs.nth(1)).toHaveFocus()
+      await expect.element(inputs.first()).toHaveFocus()
     })
   })
 
@@ -1263,7 +1290,6 @@ describe("<DatePicker />", () => {
     const fieldEl = await field.findElement()
     if (fieldEl instanceof HTMLElement) fieldEl.click()
 
-    // Start input should be focused when end is already set
     const inputs = page.getByRole("textbox")
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveFocus()

--- a/packages/react/src/components/date-picker/use-date-picker.tsx
+++ b/packages/react/src/components/date-picker/use-date-picker.tsx
@@ -26,6 +26,7 @@ import {
   useRef,
   useState,
 } from "react"
+import { useEnvironment } from "../../core"
 import { useCombobox } from "../../hooks/use-combobox"
 import { useControllableState } from "../../hooks/use-controllable-state"
 import { useI18n } from "../../providers/i18n-provider"
@@ -36,6 +37,7 @@ import {
   dataAttr,
   focusTransfer,
   handlerAll,
+  isActiveElement,
   isArray,
   isComposing,
   isDate,
@@ -211,6 +213,7 @@ export const useDatePicker = <
 }: UseDatePickerProps<Multiple, Range> = {}) => {
   if (dayjs(minDate).isAfter(dayjs(maxDate))) maxDate = minDate
 
+  const { getDocument } = useEnvironment()
   const { locale: defaultLocale, t } = useI18n("datePicker")
   const {
     props: {
@@ -655,15 +658,24 @@ export const useDatePicker = <
 
       if (allowInput) {
         if (isObject(value) && !isArray(value) && !isDate(value)) {
-          if (contains(startInputRef.current, ev.target)) return
-          if (contains(endInputRef.current, ev.target)) return
+          if (
+            startInputRef.current &&
+            contains(startInputRef.current, ev.target)
+          ) {
+            if (!isActiveElement(startInputRef.current, getDocument()!))
+              ev.defaultPrevented = true
 
-          const { end, start } = value
+            startInputRef.current.focus()
+          } else if (
+            endInputRef.current &&
+            contains(endInputRef.current, ev.target)
+          ) {
+            if (!isActiveElement(endInputRef.current, getDocument()!))
+              ev.defaultPrevented = true
 
-          if ((!start && !end) || !!end) {
-            startInputRef.current?.focus()
+            endInputRef.current.focus()
           } else {
-            endInputRef.current?.focus()
+            startInputRef.current?.focus()
           }
         } else {
           startInputRef.current?.focus()
@@ -672,7 +684,7 @@ export const useDatePicker = <
 
       if (openOnClick) onOpen()
     },
-    [allowInput, interactive, onOpen, openOnClick, value],
+    [allowInput, interactive, onOpen, openOnClick, value, getDocument],
   )
 
   const onMouseDown = useCallback(


### PR DESCRIPTION
Closes #7018

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix the `DatePicker` `range` mode so that clicking the start or end input opens the calendar popover, matching the non-range behavior.

## Current behavior (updates)

In `range` mode the field's `onClick` returns early when the click target is inside `startInputRef` / `endInputRef`. Because each input's `onMouseDown` calls `ev.preventDefault()` to suppress native focus, the inputs never receive focus on click, so `onInputFocus` (and the `openOnFocus` path to `onOpen`) never runs. The early `return` also skips the trailing `if (openOnClick) onOpen()` in the same handler, so the calendar never opens by click.

## New behavior

`onClick` no longer returns early when the click target is one of the inputs. Instead it programmatically focuses the clicked input (start or end), then falls through to `if (openOnClick) onOpen()`. Clicks on the field outside both inputs continue to focus the start input.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Added two browser tests covering start input click and end input click in `range` mode.
- Updated the existing `range` field-click tests to reflect the new "always focus start input when clicking outside both inputs" behavior.
