### PR TITLE
ci(merge-queue): add merge_group trigger and base sha handling

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -1,7 +1,6 @@
 name: Browser Test
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       TURBO_SCM_BASE:

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -3,6 +3,10 @@ name: Browser Test
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      TURBO_SCM_BASE:
+        required: true
+        type: string
     secrets:
       TURBO_TOKEN:
         required: false
@@ -12,6 +16,7 @@ on:
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_SCM_BASE: ${{ inputs.TURBO_SCM_BASE }}
 
 jobs:
   test:
@@ -70,7 +75,7 @@ jobs:
 
       - name: Run test (diff)
         if: steps.changed-files.outputs.full_any_changed != 'true' && steps.changed-files.outputs.diff_any_changed == 'true'
-        run: pnpm turbo run test:coverage:${{ matrix.browser }} --filter=./packages/react -- --retry=3 --changed origin/${{ github.base_ref }} --shard=${{ matrix.shard_index }}/4
+        run: pnpm turbo run test:coverage:${{ matrix.browser }} --filter=./packages/react -- --retry=3 --changed ${{ inputs.TURBO_SCM_BASE }} --shard=${{ matrix.shard_index }}/4
 
       - name: Upload coverage
         if: steps.changed-files.outputs.changed_keys != ''

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -16,7 +16,6 @@ env:
 jobs:
   test:
     name: React / ${{ matrix.name }} ${{ matrix.shard_index }}/4
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,7 +48,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}
 
   browser_test:
     name: Browser Test
@@ -58,7 +58,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}
 
   lint:
     name: Lint
@@ -84,7 +84,7 @@ jobs:
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}
 
   format:
     name: Format

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - v*
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,13 +19,13 @@ concurrency:
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
   NODE_OPTIONS: --max-old-space-size=8192
 
 jobs:
   build:
     name: Build
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -41,7 +42,7 @@ jobs:
 
   unit_test:
     name: Unit Test
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     uses: ./.github/workflows/unit-test.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -49,7 +50,7 @@ jobs:
 
   browser_test:
     name: Browser Test
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     uses: ./.github/workflows/browser-test.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -57,7 +58,7 @@ jobs:
 
   lint:
     name: Lint
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -74,16 +75,16 @@ jobs:
 
   typecheck:
     name: Typecheck
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     uses: ./.github/workflows/typecheck.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
 
   format:
     name: Format
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -109,7 +110,7 @@ jobs:
 
   changeset:
     name: Changeset
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,6 +47,8 @@ jobs:
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
 
   browser_test:
     name: Browser Test
@@ -55,6 +57,8 @@ jobs:
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
 
   lint:
     name: Lint

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,7 +48,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
 
   browser_test:
     name: Browser Test
@@ -58,7 +58,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
 
   lint:
     name: Lint
@@ -84,7 +84,7 @@ jobs:
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
 
   format:
     name: Format

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,6 +23,17 @@ env:
   NODE_OPTIONS: --max-old-space-size=8192
 
 jobs:
+  scm_base:
+    name: SCM Base
+    if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    outputs:
+      sha: ${{ steps.compute.outputs.sha }}
+    steps:
+      - id: compute
+        run: echo "sha=$TURBO_SCM_BASE" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
@@ -43,22 +54,24 @@ jobs:
   unit_test:
     name: Unit Test
     if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
+    needs: scm_base
     uses: ./.github/workflows/unit-test.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ needs.scm_base.outputs.sha }}
 
   browser_test:
     name: Browser Test
     if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
+    needs: scm_base
     uses: ./.github/workflows/browser-test.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ needs.scm_base.outputs.sha }}
 
   lint:
     name: Lint
@@ -80,11 +93,12 @@ jobs:
   typecheck:
     name: Typecheck
     if: ${{ github.event_name == 'merge_group' || !github.event.pull_request.draft }}
+    needs: scm_base
     uses: ./.github/workflows/typecheck.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     with:
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+      TURBO_SCM_BASE: ${{ needs.scm_base.outputs.sha }}
 
   format:
     name: Format

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,7 +1,6 @@
 name: Unit Test
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       TURBO_SCM_BASE:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,6 +3,10 @@ name: Unit Test
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      TURBO_SCM_BASE:
+        required: true
+        type: string
     secrets:
       TURBO_TOKEN:
         required: false
@@ -12,6 +16,7 @@ on:
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_SCM_BASE: ${{ inputs.TURBO_SCM_BASE }}
 
 jobs:
   test:
@@ -86,7 +91,7 @@ jobs:
 
       - name: Run test (diff)
         if: steps.changed-files.outputs.any_changed != 'true' && steps.changed-module-files.outputs.full_any_changed != 'true' && steps.changed-module-files.outputs.diff_any_changed == 'true'
-        run: pnpm turbo run ${{ matrix.script }} --filter=./packages/${{ matrix.id }} -- --retry=3 --changed origin/${{ github.base_ref }}
+        run: pnpm turbo run ${{ matrix.script }} --filter=./packages/${{ matrix.id }} -- --retry=3 --changed ${{ inputs.TURBO_SCM_BASE }}
 
       - name: Upload coverage
         if: steps.changed-files.outputs.any_changed == 'true' || steps.changed-module-files.outputs.changed_keys != ''


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Prepare CI workflows so the repository can opt in to GitHub Merge Queue without breaking required status checks.

## Current behavior (updates)

- `quality.yml` only triggers on `pull_request`, so once Merge Queue is enabled the queued PRs would never receive the required status checks and would block forever.
- `TURBO_SCM_BASE` falls back to `github.event.before` for non-PR events. Inside a `merge_group` run that points at the previous queue-branch commit, not at the main HEAD, so `--affected` would compute the wrong diff.
- `unit-test.yml` and `browser-test.yml` resolve their per-file diff base from `origin/${{ github.base_ref }}`, but `github.base_ref` is only populated for `pull_request` / `pull_request_target` events, so a `merge_group` run would resolve to `origin/` and fail.
- The per-job `if: !github.event.pull_request.draft` guard is fine for PRs but is not designed for the `merge_group` event.

## New behavior

- `quality.yml` now also reacts to `merge_group`, so the same Build / Lint / Typecheck / Format / Changeset / Unit Test / Browser Test jobs run inside the queue.
- `TURBO_SCM_BASE` now resolves to `github.event.merge_group.base_sha` for `merge_group` events, keeping `turbo --affected` and the changed-files diffs anchored to the main HEAD that the queue is merging into.
- `quality.yml` forwards `TURBO_SCM_BASE` to `unit-test.yml` and `browser-test.yml` (matching the existing `typecheck.yml` pattern), and those workflows now consume `inputs.TURBO_SCM_BASE` for their `--changed <sha>` calls instead of `origin/${{ github.base_ref }}`.
- The job-level `if:` guards now allow `merge_group` events through while still skipping draft PRs.

## Is this a breaking change (Yes/No):

No. The added trigger and expression branches are inert until Merge Queue is enabled in repository settings.

## Additional Information

VS Code's GitHub Actions extension reports `Context access might be invalid: merge_group` on the new expressions. This is a known false positive in the extension's type inference for the `merge_group` payload and does not affect runtime behavior.

Follow-up after this PR lands:

- Configure Branch Protection / Rulesets to enable Merge Queue and pin the required status check names.
- Decide how the Changesets "Updated packages" PR bypasses the queue.