### PR TITLE
docs(pr-merge-guide): update for merge queue activation

### DIFF
--- a/.agents/references/pr-merge-guide.md
+++ b/.agents/references/pr-merge-guide.md
@@ -13,20 +13,34 @@ The following branch protection rules are enabled on the `main` and `v*` branche
 ### Review
 
 - **Require review from specific teams**: At least 1 approval from each of the `Prime`, `Standard`, and `Growth` teams is required. `hirotomoyamada` belongs to all 3 teams, so a single approval satisfies every team requirement. `codex-for-yamada-ui` belongs to `Prime`, `claude-for-yamada-ui` belongs to `Standard`, and `composer-for-yamada-ui` belongs to `Growth`.
-- **Require review from Code Owners**: Approval from a Code Owner listed in [CODEOWNERS](../../.github/CODEOWNERS) is required.
+- **Require review from Code Owners**: Approval from a Code Owner listed in [CODEOWNERS](/.github/CODEOWNERS) is required.
 - **Require conversation resolution before merging**: All review comments and conversations must be resolved before merging.
 
 ### Status Checks
 
-- **Require status checks to pass**: All of the following required status checks must be green.
-  - Format
-  - TypeScript
-  - Lint
+- **Require status checks to pass**: All of the following required status checks must be green. The same checks run on both `pull_request` and `merge_group` events under the same names, and both are required.
   - Changeset
-  - Test / Chromium 1/4
-  - Test / Chromium 2/4
-  - Test / Chromium 3/4
-  - Test / Chromium 4/4
-  - Test / Firefox
-  - Test / Webkit
-- **Require branches to be up to date before merging**: The PR branch must be up to date with the base branch. Update it before merging if it is behind.
+  - Lint
+  - Format
+  - Typecheck / Packages
+  - Typecheck / Documentation
+  - Typecheck / Playgrounds
+  - Unit Test / CLI
+  - Unit Test / React
+  - Unit Test / Utils
+  - Browser Test / Chromium 1/4
+  - Browser Test / Chromium 2/4
+  - Browser Test / Chromium 3/4
+  - Browser Test / Chromium 4/4
+  - Browser Test / Firefox 1/4
+  - Browser Test / Firefox 2/4
+  - Browser Test / Firefox 3/4
+  - Browser Test / Firefox 4/4
+  - Browser Test / Webkit 1/4
+  - Browser Test / Webkit 2/4
+  - Browser Test / Webkit 3/4
+  - Browser Test / Webkit 4/4
+
+### Merge Queue
+
+The queue creates an internal merge candidate against the latest base, re-runs the same Quality jobs on a `merge_group` event, and merges only after they pass. If a required check fails on the merge candidate, the PR is removed from the queue and returned to its original state, and the author must address the failure and re-queue the PR.

--- a/.agents/references/pr-merge-guide.md
+++ b/.agents/references/pr-merge-guide.md
@@ -22,24 +22,25 @@ The following branch protection rules are enabled on the `main` and `v*` branche
   - Changeset
   - Lint
   - Format
+  - Build
   - Typecheck / Packages
   - Typecheck / Documentation
   - Typecheck / Playgrounds
   - Unit Test / CLI
   - Unit Test / React
   - Unit Test / Utils
-  - Browser Test / Chromium 1/4
-  - Browser Test / Chromium 2/4
-  - Browser Test / Chromium 3/4
-  - Browser Test / Chromium 4/4
-  - Browser Test / Firefox 1/4
-  - Browser Test / Firefox 2/4
-  - Browser Test / Firefox 3/4
-  - Browser Test / Firefox 4/4
-  - Browser Test / Webkit 1/4
-  - Browser Test / Webkit 2/4
-  - Browser Test / Webkit 3/4
-  - Browser Test / Webkit 4/4
+  - Browser Test / React / Chromium 1/4
+  - Browser Test / React / Chromium 2/4
+  - Browser Test / React / Chromium 3/4
+  - Browser Test / React / Chromium 4/4
+  - Browser Test / React / Firefox 1/4
+  - Browser Test / React / Firefox 2/4
+  - Browser Test / React / Firefox 3/4
+  - Browser Test / React / Firefox 4/4
+  - Browser Test / React / Webkit 1/4
+  - Browser Test / React / Webkit 2/4
+  - Browser Test / React / Webkit 3/4
+  - Browser Test / React / Webkit 4/4
 
 ### Merge Queue
 


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Update [.agents/references/pr-merge-guide.md](.agents/references/pr-merge-guide.md) to reflect the post-#7140 state of the repository — GitHub Merge Queue is now enabled on `main` (and `v*`), and CI runs the same Required status checks on both `pull_request` and `merge_group` events.

## Current behavior (updates)

- The guide described required status checks as if only `pull_request` runs counted, with a stale list of check names.
- The guide listed `Require branches to be up to date before merging` as an active rule, but with Merge Queue enabled this rule is redundant (the queue builds an internal merge candidate against the latest base) and has been switched off.
- There was no description of how Merge Queue actually behaves on this repository, in particular what happens when a required check fails on the merge candidate.

## New behavior

- The list of Required status checks is updated to the current names (Changeset, Lint, Format, Typecheck / *, Unit Test / *, Browser Test / *) and notes that the same names run on both `pull_request` and `merge_group`.
- Removed the `Require branches to be up to date before merging` entry (it is no longer enabled on the repository because Merge Queue supersedes it).
- Added a new \`### Merge Queue\` section explaining that the queue creates an internal merge candidate against the latest base, re-runs the Quality jobs on \`merge_group\`, and merges only after they pass — and that a failing required check removes the PR from the queue and returns it to its original state, requiring the author to fix and re-queue.

## Is this a breaking change (Yes/No):

No. Documentation-only change.

## Additional Information

Follow-up to #7140.