### PR TITLE
docs(review-anti-patterns): add Anti-pattern entry for tests that do not increase coverage

### DIFF
--- a/.agents/references/review-anti-patterns/index.md
+++ b/.agents/references/review-anti-patterns/index.md
@@ -8,4 +8,4 @@ Case library of past PRs where both bots approved something the maintainer rejec
 
 ## Adding a new entry
 
-When a merged PR surfaces a review miss, add a bullet above and a detail file containing: PR link, minimal diff, what was missed, rule of thumb.
+When a merged PR surfaces a review miss, add a bullet above and a detail file containing: minimal diff, what was missed, rule of thumb, and a PR link when a relevant public PR exists.

--- a/.agents/references/review-anti-patterns/index.md
+++ b/.agents/references/review-anti-patterns/index.md
@@ -4,6 +4,7 @@ Case library of past PRs where both bots approved something the maintainer rejec
 
 - [Utility over-application](utility-over-application.md): a utility (e.g. `mergeProps`, `useMergeRefs`) applied mechanically to many sites in one PR.
 - [Prop fan-out to elements without dynamic content](suppress-hydration-warning.md): `suppressHydrationWarning` forwarded or added to multiple elements.
+- [Tests that do not increase coverage](tests-without-coverage.md): demanding that removed assertions be re-added on the grounds of "preserving prior coverage" or "preserving the public contract" without a concrete coverage delta.
 
 ## Adding a new entry
 

--- a/.agents/references/review-anti-patterns/tests-without-coverage.md
+++ b/.agents/references/review-anti-patterns/tests-without-coverage.md
@@ -1,0 +1,29 @@
+# Tests that do not increase coverage
+
+**Diff**:
+
+```diff
+- test("sets `displayName` correctly", () => {
+-   expect(ButtonGroup.Root.name).toBe("ButtonGroupRoot")
+- })
+-
+- test("sets `className` correctly", async () => {
+-   await render(<ButtonGroup.Root>...</ButtonGroup.Root>)
+-   await expect.element(page.getByRole("group")).toHaveClass("ui-group")
+- })
+-
+- test("renders HTML tag correctly", async () => {
+-   await render(<ButtonGroup.Root>...</ButtonGroup.Root>)
+-   expect(page.getByRole("group").element().tagName).toBe("DIV")
+- })
+```
+
+**What was missed**: A reviewer asked to re-add removed assertions on the grounds of "preserving prior coverage" or "preserving the public contract", even though the PR description confirmed total coverage was unchanged. Re-adding the assertions would have reintroduced exactly the redundancy the PR aimed to eliminate.
+
+**Rule of thumb**: A test that does not increase coverage is not worth writing. Before asking that a test be added or re-added, ask:
+
+1. What line, branch, or behavior does this test exercise that nothing else in the suite covers? If you cannot point to a concrete coverage delta, do not ask for it.
+2. Did the PR description explicitly justify a removal with coverage numbers? If yes, the burden shifts to the reviewer to identify a concrete coverage gap, not restate that the assertion existed.
+3. Is the assertion reading a constant or a value already exercised by another rendering test (e.g., `displayName`, hardcoded `className`, fixed tag, identity props)? Constants and tautologies do not need their own tests.
+
+"Preserving prior coverage" / "preserving the public contract" is not a justification when prior coverage was already tautological.

--- a/.agents/references/review-anti-patterns/tests-without-coverage.md
+++ b/.agents/references/review-anti-patterns/tests-without-coverage.md
@@ -1,5 +1,7 @@
 # Tests that do not increase coverage
 
+**Example**: Internal review miss case in yamada-ui (no public PR link available).
+
 **Diff**:
 
 ```diff

--- a/.agents/references/review-anti-patterns/tests-without-coverage.md
+++ b/.agents/references/review-anti-patterns/tests-without-coverage.md
@@ -1,6 +1,6 @@
 # Tests that do not increase coverage
 
-**Example**: Internal review miss case in yamada-ui (no public PR link available).
+**Example**: [PR #7287](https://github.com/yamada-ui/yamada-ui/pull/7287) - "test(button): recategorize and clean up browser tests"
 
 **Diff**:
 


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a new entry to `.agents/references/review-anti-patterns/` that documents the review miss of demanding that removed assertions be re-added without a concrete coverage delta.

## Current behavior (updates)

`.agents/references/review-anti-patterns/index.md` indexes two entries (`utility-over-application`, `suppress-hydration-warning`).

## New behavior

Adds a third entry, `tests-without-coverage.md`, with the rule of thumb: a test that does not increase coverage is not worth writing. Re-adding removed assertions on the grounds of "preserving prior coverage" or "preserving the public contract" is not a justification when prior coverage was already tautological. The entry includes a `displayName` / `className` / `tagName` example as the concrete shape of the miss this surfaces.

## Is this a breaking change (Yes/No):

No. Documentation only.

## Additional Information

Surfaced while reviewing a button-tests cleanup PR. The bad direction was caught before merge, so this PR exists purely to harden the future review behavior.