### PR TITLE
docs(review-anti-patterns): add Anti-pattern entry for a11y in browser mode

### DIFF
--- a/.agents/references/review-anti-patterns/a11y-in-browser-mode.md
+++ b/.agents/references/review-anti-patterns/a11y-in-browser-mode.md
@@ -1,5 +1,7 @@
 # a11y in browser mode
 
+**Example**: [PR #7287](https://github.com/yamada-ui/yamada-ui/pull/7287) — "test(button): recategorize and clean up browser tests"
+
 **Diff**:
 
 ```diff
@@ -28,4 +30,4 @@
 2. Does it dispatch real events, observers, focus transitions, or browser APIs (clipboard, drag, canvas, FileReader, ...)? `a11y(...)` does none of these.
 3. Does the engine actually matter (`isWebKit` / `isFirefox` / `isChrome` branches, or assertions that differ per engine)? If not, multiplying the test across three engines is pure cost.
 
-`a11y(...)` belongs in jsdom by default; only move it to browser mode when the audited tree depends on engine-specific layout that jsdom cannot evaluate.
+`a11y(...)` belongs in jsdom by default; only move it to browser mode when the audited tree depends on browser-mode criteria from `test-categorization.md` (real layout measurement, real events, observers, focus operations, browser-only APIs, or engine-specific behavior) that jsdom cannot evaluate.

--- a/.agents/references/review-anti-patterns/a11y-in-browser-mode.md
+++ b/.agents/references/review-anti-patterns/a11y-in-browser-mode.md
@@ -1,0 +1,31 @@
+# a11y in browser mode
+
+**Diff**:
+
+```diff
+- import { a11y, page, render } from "#test/browser"
++ import { page, render } from "#test/browser"
+  import { ButtonGroup } from "./"
+
+  describe("<ButtonGroup />", () => {
+-   test("renders component correctly", async () => {
+-     await a11y(<ButtonGroup.Root>...</ButtonGroup.Root>)
+-   })
+-
+    test("`attached` column style is applied correctly", async () => {
+      // ...
+    })
+  })
+```
+
+(The `a11y` test is moved to the jsdom file `button-group.test.tsx`.)
+
+**What was missed**: A reviewer claimed the browser-mode test file should keep at least one `a11y(...)` case because it still renders the component, framing it as "browser-runtime accessibility verification". This conflicts with `.agents/rules/test-categorization.md`: a test belongs in `*.test.browser.{ts,tsx}` only when it depends on real DOM measurement, real events, observers, focus operations, or browser-only APIs. axe-core's accessibility audit is a static DOM/attribute check that runs correctly under jsdom, so it does not satisfy any of the browser-mode criteria. Forcing `a11y` into the browser suite triples its runtime cost (chromium / firefox / webkit) for no additional signal.
+
+**Rule of thumb**: Before asking that a test be placed in `*.test.browser.{ts,tsx}`, confirm at least one of the criteria in `test-categorization.md` actually applies:
+
+1. Does the assertion read live layout (`getBoundingClientRect`, `getComputedStyle`, `scrollTop`, `offsetHeight`, ...)? Without that, jsdom is sufficient.
+2. Does it dispatch real events, observers, focus transitions, or browser APIs (clipboard, drag, canvas, FileReader, ...)? `a11y(...)` does none of these.
+3. Does the engine actually matter (`isWebKit` / `isFirefox` / `isChrome` branches, or assertions that differ per engine)? If not, multiplying the test across three engines is pure cost.
+
+`a11y(...)` belongs in jsdom by default; only move it to browser mode when the audited tree depends on engine-specific layout that jsdom cannot evaluate.

--- a/.agents/references/review-anti-patterns/index.md
+++ b/.agents/references/review-anti-patterns/index.md
@@ -4,6 +4,7 @@ Case library of past PRs where both bots approved something the maintainer rejec
 
 - [Utility over-application](utility-over-application.md): a utility (e.g. `mergeProps`, `useMergeRefs`) applied mechanically to many sites in one PR.
 - [Prop fan-out to elements without dynamic content](suppress-hydration-warning.md): `suppressHydrationWarning` forwarded or added to multiple elements.
+- [a11y in browser mode](a11y-in-browser-mode.md): demanding that an `a11y(...)` case stay in `*.test.browser.{ts,tsx}` even though axe-core runs correctly under jsdom.
 
 ## Adding a new entry
 


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a new entry to `.agents/references/review-anti-patterns/` that documents the review miss of demanding `a11y(...)` cases stay in `*.test.browser.{ts,tsx}` even though axe-core runs correctly under jsdom.

## Current behavior (updates)

`.agents/references/review-anti-patterns/index.md` indexes entries that document review misses on production code (`utility-over-application`, `suppress-hydration-warning`), but no entry covers test-categorization misses.

## New behavior

Adds `a11y-in-browser-mode.md`, which restates the rule from `.agents/rules/test-categorization.md`: a test belongs in `*.test.browser.{ts,tsx}` only when it depends on real DOM measurement, real events, observers, focus, or browser-only APIs. axe-core's static DOM/attribute audit satisfies none of those criteria, so `a11y(...)` belongs in jsdom by default. Forcing it into the browser suite triples its runtime cost across chromium / firefox / webkit for no additional signal.

## Is this a breaking change (Yes/No):

No. Documentation only.

## Additional Information

Surfaced while reviewing a button-tests cleanup PR. The bad direction was caught before merge, so this PR exists purely to harden the future review behavior.