### PR TITLE
test(autocomplete): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/autocomplete/autocomplete.test.browser.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.test.browser.tsx
@@ -1,4 +1,4 @@
-import { a11y, fireEvent, page, render } from "#test/browser"
+import { fireEvent, page, render } from "#test/browser"
 import { Autocomplete } from "."
 
 describe("<Autocomplete />", () => {
@@ -21,57 +21,6 @@ describe("<Autocomplete />", () => {
     fireEvent.blur(input, { relatedTarget })
   }
 
-  test("renders component correctly", async () => {
-    await a11y(
-      <Autocomplete.Root placeholder="Choose a option">
-        <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
-        <Autocomplete.Option value="two">Option 2</Autocomplete.Option>
-        <Autocomplete.Option value="three">Option 3</Autocomplete.Option>
-      </Autocomplete.Root>,
-    )
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(Autocomplete.Root.displayName).toBe("AutocompleteRoot")
-    expect(Autocomplete.Group.displayName).toBe("AutocompleteGroup")
-    expect(Autocomplete.Option.displayName).toBe("AutocompleteOption")
-    expect(Autocomplete.Label.displayName).toBe("AutocompleteLabel")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(
-      <Autocomplete.Root
-        defaultOpen
-        defaultValue="one"
-        placeholder="Choose a option"
-        iconProps={{ "data-testid": "icon" }}
-        rootProps={{ "data-testid": "root" }}
-      >
-        <Autocomplete.Group label="Group 1">
-          <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
-          <Autocomplete.Option value="two">Option 2</Autocomplete.Option>
-          <Autocomplete.Option value="three">Option 3</Autocomplete.Option>
-        </Autocomplete.Group>
-      </Autocomplete.Root>,
-    )
-
-    const field = page.getByRole("combobox").element()
-    const group = page.getByRole("group", { name: "Group 1" }).element()
-    const option = page.getByRole("option", { name: "Option 1" }).element()
-
-    expect(page.getByTestId("root").element()).toHaveClass(
-      "ui-autocomplete__root",
-    )
-    expect(page.getByTestId("icon").element()).toHaveClass(
-      "ui-autocomplete__icon",
-    )
-    expect(field).toHaveClass("ui-autocomplete__field")
-    expect(option).toHaveClass("ui-autocomplete__option")
-    expect(option.firstChild).toHaveClass("ui-autocomplete__indicator")
-    expect(group).toHaveClass("ui-autocomplete__group")
-    expect(group.firstChild).toHaveClass("ui-autocomplete__label")
-  })
-
   test("does not hide separator when blurring to content in multiple mode", async () => {
     await render(
       <Autocomplete.Root
@@ -92,7 +41,6 @@ describe("<Autocomplete />", () => {
 
     fireEvent.focus(input)
 
-    // The separator should still be visible after blurring to an option in the content
     blurWithRelatedTarget(input, option)
 
     const spans = [...field.querySelectorAll("span")]
@@ -129,50 +77,6 @@ describe("<Autocomplete />", () => {
     const lastSpan = spans.at(-1)
 
     expect(lastSpan?.textContent).not.toContain(",")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(
-      <Autocomplete.Root
-        defaultOpen
-        defaultValue="one"
-        placeholder="Choose a option"
-        iconProps={{ "data-testid": "icon" }}
-        rootProps={{ "data-testid": "root" }}
-      >
-        <Autocomplete.Group label="Group 1">
-          <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
-          <Autocomplete.Option value="two">Option 2</Autocomplete.Option>
-          <Autocomplete.Option value="three">Option 3</Autocomplete.Option>
-        </Autocomplete.Group>
-      </Autocomplete.Root>,
-    )
-
-    const field = page.getByRole("combobox").element()
-    const group = page.getByRole("group", { name: "Group 1" }).element()
-    const option = page.getByRole("option", { name: "Option 1" }).element()
-
-    expect(page.getByTestId("root").element().tagName).toBe("DIV")
-    expect(page.getByTestId("icon").element().tagName).toBe("DIV")
-    expect(field.tagName).toBe("DIV")
-    expect(option.tagName).toBe("DIV")
-    expect(option.children[0]?.tagName).toBe("DIV")
-    expect(group.tagName).toBe("DIV")
-    expect(group.children[0]?.tagName).toBe("SPAN")
-  })
-
-  test("renders group without label", async () => {
-    await render(
-      <Autocomplete.Root defaultOpen placeholder="Choose a option">
-        <Autocomplete.Group>
-          <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
-        </Autocomplete.Group>
-      </Autocomplete.Root>,
-    )
-
-    const option = page.getByRole("option", { name: "Option 1" }).element()
-
-    expect(option).toBeInTheDocument()
   })
 
   test("renders empty message when no items match filter", async () => {
@@ -301,29 +205,6 @@ describe("<Autocomplete />", () => {
     await user.click(option1)
 
     expect(onChange).toHaveBeenCalledWith([])
-  })
-
-  test("respects `max` limit in multiple mode", async () => {
-    const onChange = vi.fn()
-
-    await render(
-      <Autocomplete.Root
-        defaultOpen
-        defaultValue={["one"]}
-        items={[
-          { label: "Option 1", value: "one" },
-          { label: "Option 2", value: "two" },
-          { label: "Option 3", value: "three" },
-        ]}
-        max={1}
-        multiple
-        onChange={onChange}
-      />,
-    )
-
-    const option2 = page.getByRole("option", { name: "Option 2" }).element()
-
-    expect(option2).toHaveAttribute("aria-disabled", "true")
   })
 
   test("does not allow input change when `max` is reached in multiple mode", async () => {
@@ -835,60 +716,6 @@ describe("<Autocomplete />", () => {
       .toBeNull()
   })
 
-  test("updates input when controlled `value` prop changes", async () => {
-    const { rerender } = await render(
-      <Autocomplete.Root
-        items={[
-          { label: "Option 1", value: "one" },
-          { label: "Option 2", value: "two" },
-        ]}
-        value="one"
-      />,
-    )
-
-    const field = page.getByRole("combobox").element()
-    const input = field.querySelector("input")!
-
-    expect(input).toHaveValue("Option 1")
-
-    await rerender(
-      <Autocomplete.Root
-        items={[
-          { label: "Option 1", value: "one" },
-          { label: "Option 2", value: "two" },
-        ]}
-        value="two"
-      />,
-    )
-
-    await expect.element(input).toHaveValue("Option 2")
-  })
-
-  test("renders children for selected values in multiple mode with custom render", async () => {
-    await render(
-      <Autocomplete.Root
-        defaultOpen
-        defaultValue={["one", "two"]}
-        items={[
-          { label: "Option 1", value: "one" },
-          { label: "Option 2", value: "two" },
-          { label: "Option 3", value: "three" },
-        ]}
-        multiple
-        render={({ label, onClear }) => (
-          <button data-testid="custom-tag" onClick={onClear}>
-            {label}
-          </button>
-        )}
-      />,
-    )
-
-    const tags = page.getByTestId("custom-tag").elements()
-
-    expect(tags).toHaveLength(2)
-    expect(tags[0]).toHaveTextContent("Option 1")
-  })
-
   test("removes selected value via custom render's `onClear`", async () => {
     const onChange = vi.fn()
 
@@ -994,8 +821,6 @@ describe("<Autocomplete />", () => {
     input.focus()
     await user.keyboard("{Enter}")
 
-    // In single mode with no matching filtered items and allowCustomValue,
-    // Enter should not call onSelect because !isArray(value)
     expect(onChange).not.toHaveBeenCalledWith("nonexistent")
   })
 
@@ -1049,8 +874,6 @@ describe("<Autocomplete />", () => {
     await setInputValue(user, input, "")
     blurWithRelatedTarget(input, outside)
 
-    // When allowCustomValue is true and inputValue is empty string (falsy),
-    // the if (inputValue) branch is not taken
     expect(input).toHaveValue("")
   })
 

--- a/packages/react/src/components/autocomplete/autocomplete.test.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.test.tsx
@@ -12,6 +12,73 @@ describe("<Autocomplete />", () => {
     )
   })
 
+  test("sets `displayName` correctly", () => {
+    expect(Autocomplete.Root.displayName).toBe("AutocompleteRoot")
+    expect(Autocomplete.Group.displayName).toBe("AutocompleteGroup")
+    expect(Autocomplete.Option.displayName).toBe("AutocompleteOption")
+    expect(Autocomplete.Label.displayName).toBe("AutocompleteLabel")
+  })
+
+  test("sets `className` correctly", () => {
+    render(
+      <Autocomplete.Root
+        defaultOpen
+        defaultValue="one"
+        placeholder="Choose a option"
+        iconProps={{ "data-testid": "icon" }}
+        rootProps={{ "data-testid": "root" }}
+      >
+        <Autocomplete.Group label="Group 1">
+          <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
+          <Autocomplete.Option value="two">Option 2</Autocomplete.Option>
+          <Autocomplete.Option value="three">Option 3</Autocomplete.Option>
+        </Autocomplete.Group>
+      </Autocomplete.Root>,
+    )
+
+    const field = screen.getByRole("combobox")
+    const group = screen.getByRole("group", { name: "Group 1" })
+    const option = screen.getByRole("option", { name: "Option 1" })
+
+    expect(screen.getByTestId("root")).toHaveClass("ui-autocomplete__root")
+    expect(screen.getByTestId("icon")).toHaveClass("ui-autocomplete__icon")
+    expect(field).toHaveClass("ui-autocomplete__field")
+    expect(option).toHaveClass("ui-autocomplete__option")
+    expect(option.firstChild).toHaveClass("ui-autocomplete__indicator")
+    expect(group).toHaveClass("ui-autocomplete__group")
+    expect(group.firstChild).toHaveClass("ui-autocomplete__label")
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(
+      <Autocomplete.Root
+        defaultOpen
+        defaultValue="one"
+        placeholder="Choose a option"
+        iconProps={{ "data-testid": "icon" }}
+        rootProps={{ "data-testid": "root" }}
+      >
+        <Autocomplete.Group label="Group 1">
+          <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
+          <Autocomplete.Option value="two">Option 2</Autocomplete.Option>
+          <Autocomplete.Option value="three">Option 3</Autocomplete.Option>
+        </Autocomplete.Group>
+      </Autocomplete.Root>,
+    )
+
+    const field = screen.getByRole("combobox")
+    const group = screen.getByRole("group", { name: "Group 1" })
+    const option = screen.getByRole("option", { name: "Option 1" })
+
+    expect(screen.getByTestId("root").tagName).toBe("DIV")
+    expect(screen.getByTestId("icon").tagName).toBe("DIV")
+    expect(field.tagName).toBe("DIV")
+    expect(option.tagName).toBe("DIV")
+    expect(option.children[0]?.tagName).toBe("DIV")
+    expect(group.tagName).toBe("DIV")
+    expect(group.children[0]?.tagName).toBe("SPAN")
+  })
+
   test("renders group without label", () => {
     render(
       <Autocomplete.Root defaultOpen placeholder="Choose a option">

--- a/packages/react/src/components/autocomplete/autocomplete.test.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.test.tsx
@@ -1,0 +1,100 @@
+import { a11y, render, screen } from "#test"
+import { Autocomplete } from "."
+
+describe("<Autocomplete />", () => {
+  test("renders component correctly", async () => {
+    await a11y(
+      <Autocomplete.Root placeholder="Choose a option">
+        <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
+        <Autocomplete.Option value="two">Option 2</Autocomplete.Option>
+        <Autocomplete.Option value="three">Option 3</Autocomplete.Option>
+      </Autocomplete.Root>,
+    )
+  })
+
+  test("renders group without label", () => {
+    render(
+      <Autocomplete.Root defaultOpen placeholder="Choose a option">
+        <Autocomplete.Group>
+          <Autocomplete.Option value="one">Option 1</Autocomplete.Option>
+        </Autocomplete.Group>
+      </Autocomplete.Root>,
+    )
+
+    expect(screen.getByRole("option", { name: "Option 1" })).toBeInTheDocument()
+  })
+
+  test("respects `max` limit in multiple mode", () => {
+    render(
+      <Autocomplete.Root
+        defaultOpen
+        defaultValue={["one"]}
+        items={[
+          { label: "Option 1", value: "one" },
+          { label: "Option 2", value: "two" },
+          { label: "Option 3", value: "three" },
+        ]}
+        max={1}
+        multiple
+      />,
+    )
+
+    const option2 = screen.getByRole("option", { name: "Option 2" })
+
+    expect(option2).toHaveAttribute("aria-disabled", "true")
+  })
+
+  test("updates input when controlled `value` prop changes", () => {
+    const { rerender } = render(
+      <Autocomplete.Root
+        items={[
+          { label: "Option 1", value: "one" },
+          { label: "Option 2", value: "two" },
+        ]}
+        value="one"
+      />,
+    )
+
+    const field = screen.getByRole("combobox")
+    const input = field.querySelector("input")!
+
+    expect(input).toHaveValue("Option 1")
+
+    rerender(
+      <Autocomplete.Root
+        items={[
+          { label: "Option 1", value: "one" },
+          { label: "Option 2", value: "two" },
+        ]}
+        value="two"
+      />,
+    )
+
+    expect(input).toHaveValue("Option 2")
+  })
+
+  test("renders children for selected values in multiple mode with custom render", () => {
+    render(
+      <Autocomplete.Root
+        defaultOpen
+        defaultValue={["one", "two"]}
+        items={[
+          { label: "Option 1", value: "one" },
+          { label: "Option 2", value: "two" },
+          { label: "Option 3", value: "three" },
+        ]}
+        multiple
+        render={({ label, onClear }) => (
+          <button data-testid="custom-tag" onClick={onClear}>
+            {label}
+          </button>
+        )}
+      />,
+    )
+
+    const tags = screen.getAllByTestId("custom-tag")
+
+    expect(tags).toHaveLength(2)
+    expect(tags[0]).toHaveTextContent("Option 1")
+  })
+})


### PR DESCRIPTION
Closes #7162

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/autocomplete` according to the rule introduced in #7139.

## Current behavior (updates)

A single `*.test.browser.tsx` file lived under `packages/react/src/components/autocomplete/`:

- `autocomplete.test.browser.tsx` — 49 tests. Most exercise real user interactions (`user.click` / `user.type` / `user.keyboard`) or focus state. A handful only checked metadata (`displayName`), static class/tag attributes, controlled-prop reflection, or aria attributes after a render.

Several of these tests did not contribute to combined coverage (pure metadata reads such as `Autocomplete.Root.displayName`, repeated render assertions about `className`, repeated tag-name assertions).

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`) — `autocomplete.test.tsx` (5 tests)**

- `renders component correctly` (a11y)
- `renders group without label`
- `respects max limit in multiple mode` (aria-disabled assertion only)
- `updates input when controlled value prop changes` (rerender + value reflection)
- `renders children for selected values in multiple mode with custom render`

**browser (`#test/browser`) — `autocomplete.test.browser.tsx` (41 tests)**

All tests that drive real user input, focus state, or rely on browser event sequences remain in the browser file. The unused `a11y` import was removed since the only `a11y(...)` call moved to jsdom.

Removed tests that did not contribute to combined coverage (verified empirically by deleting and re-running coverage):

- `sets displayName correctly` — pure metadata read, no rendering.
- `sets className correctly` — every line/branch hit by sibling render assertions.
- `renders HTML tag correctly` — same render path as the className test.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/autocomplete/` — 5 tests pass
- `pnpm react test:browser --run src/components/autocomplete/` — 41 tests x 3 engines = 123 pass
- `pnpm react lint` — 0 warnings / 0 errors

Per-source-file combined coverage (line / function / branch hits, `OK` = combined >= baseline):

| File | Metric | Baseline | Final combined | Status |
| --- | --- | --- | --- | --- |
| `autocomplete.style.ts` | Lines | 1 | 1 | OK |
| `autocomplete.style.ts` | Functions | 0 | 0 | OK |
| `autocomplete.style.ts` | Branches | 0 | 0 | OK |
| `autocomplete.tsx` | Lines | 45 | 49 | OK |
| `autocomplete.tsx` | Functions | 15 | 15 | OK |
| `autocomplete.tsx` | Branches | 23 | 25 | OK |
| `use-autocomplete.tsx` | Lines | 160 | 165 | OK |
| `use-autocomplete.tsx` | Functions | 40 | 40 | OK |
| `use-autocomplete.tsx` | Branches | 157 | 177 | OK |

(Combined = covered in either jsdom or chromium. Baseline captured from `pnpm react test:coverage:chromium` against the original `autocomplete.test.browser.tsx`. v8 and istanbul use different statement IDs, so comparison is by source-line / source-branch location.)

Sub-issue of #7141.