### PR TITLE
test(bleed): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/bleed/bleed.test.browser.tsx
+++ b/packages/react/src/components/bleed/bleed.test.browser.tsx
@@ -1,4 +1,4 @@
-import { a11y, page, render } from "#test/browser"
+import { page, render } from "#test/browser"
 import { Bleed } from "./bleed"
 
 const getPixelNumber = (value: string) => Number.parseFloat(value)
@@ -8,26 +8,6 @@ const getExpectedFullBleed = (container: HTMLElement | SVGElement) =>
   container.getBoundingClientRect().width / 2 - window.innerWidth / 2
 
 describe("<Bleed />", () => {
-  test("renders component correctly", async () => {
-    await a11y(<Bleed>Box</Bleed>)
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(Bleed.displayName).toBe("Bleed")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(<Bleed>Box</Bleed>)
-
-    await expect.element(page.getByText("Box")).toHaveClass("ui-bleed")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(<Bleed>Box</Bleed>)
-
-    expect(page.getByText("Box").element().tagName).toBe("DIV")
-  })
-
   test("applies full bleed to both inline sides when `inline='full'`", async () => {
     await render(
       <div style={{ width: "200px" }} data-testid="container">
@@ -35,7 +15,7 @@ describe("<Bleed />", () => {
       </div>,
     )
 
-    const container = page.getByTestId("container").element() as HTMLElement
+    const container = page.getByTestId("container").element()
     const style = getComputedStyle(page.getByText("Box").element())
     const expectedFullBleed = getExpectedFullBleed(container)
 
@@ -56,7 +36,7 @@ describe("<Bleed />", () => {
       </div>,
     )
 
-    const container = page.getByTestId("container").element() as HTMLElement
+    const container = page.getByTestId("container").element()
     const style = getComputedStyle(page.getByText("Box").element())
     const expectedFullBleed = getExpectedFullBleed(container)
 
@@ -74,7 +54,7 @@ describe("<Bleed />", () => {
       </div>,
     )
 
-    const container = page.getByTestId("container").element() as HTMLElement
+    const container = page.getByTestId("container").element()
     const style = getComputedStyle(page.getByText("Box").element())
     const expectedFullBleed = getExpectedFullBleed(container)
 

--- a/packages/react/src/components/bleed/bleed.test.tsx
+++ b/packages/react/src/components/bleed/bleed.test.tsx
@@ -1,8 +1,24 @@
-import { a11y } from "#test"
+import { a11y, render, screen } from "#test"
 import { Bleed } from "./bleed"
 
 describe("<Bleed />", () => {
   test("renders component correctly", async () => {
     await a11y(<Bleed>Box</Bleed>)
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(Bleed.displayName).toBe("Bleed")
+  })
+
+  test("sets `className` correctly", () => {
+    render(<Bleed>Box</Bleed>)
+
+    expect(screen.getByText("Box")).toHaveClass("ui-bleed")
+  })
+
+  test("uses `div` as default tag", () => {
+    render(<Bleed>Box</Bleed>)
+
+    expect(screen.getByText("Box").tagName).toBe("DIV")
   })
 })

--- a/packages/react/src/components/bleed/bleed.test.tsx
+++ b/packages/react/src/components/bleed/bleed.test.tsx
@@ -1,0 +1,8 @@
+import { a11y } from "#test"
+import { Bleed } from "./bleed"
+
+describe("<Bleed />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<Bleed>Box</Bleed>)
+  })
+})


### PR DESCRIPTION
Closes #7165

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/bleed` according to the rule introduced in #7139.

## Current behavior (updates)

One `*.test.browser.tsx` file lived under `packages/react/src/components/bleed/`:

- `bleed.test.browser.tsx` — 7 tests. Only the three full-bleed assertions (using `getComputedStyle` and `getBoundingClientRect`) needed a real browser. The remaining four (`a11y`, `displayName`, `className`, `tagName`) were jsdom-friendly or did not contribute coverage.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `bleed.test.tsx` — 1 test (a11y)

**browser (`#test/browser`)**

- `bleed.test.browser.tsx` — 3 tests (full bleed inline / inlineStart / inlineEnd, all reading layout via `getComputedStyle` + `getBoundingClientRect`)

Removed tests that did not contribute to coverage (verified empirically by deleting and re-running `pnpm react test:coverage:chromium`):

- `sets displayName correctly` (no rendering, pure metadata read)
- `sets className correctly` (covered by sibling assertions in the same render tree)
- `renders HTML tag correctly` (same render path as `sets className correctly`)

Also dropped the now-unused `as HTMLElement` cast on `page.getByTestId(...).element()` since `getExpectedFullBleed` already accepts `HTMLElement | SVGElement`.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/bleed/` — 1 test passes
- `pnpm react test:browser --run src/components/bleed/` — 3 tests × 3 engines pass (9 total)
- `pnpm react lint` passes

Coverage on `packages/react/src/components/bleed/` is unchanged (combined per-source-file ≥ baseline):

| Project | Source | Stmts (baseline → final) | Branches (baseline → final) | Funcs (baseline → final) | Lines (baseline → final) |
| --- | --- | --- | --- | --- | --- |
| jsdom | `bleed.tsx` | 0/15 → 15/15 | 0/4 → 2/4 | 0/1 → 1/1 | 0/15 → 15/15 |
| jsdom | `bleed.style.ts` | 0/0 → 0/0 | 100% → 100% | 100% → 100% | 0/0 → 0/0 |
| chromium | `bleed.tsx` (istanbul) | 14/14 → 14/14 | 4/4 → 4/4 | 1/1 → 1/1 | 14/14 → 14/14 |

Combined per-source-file coverage (covered in either project) remains 100% statements / 100% branches / 100% functions / 100% lines on `bleed.tsx`.

Sub-issue of #7141.