### PR TITLE
docs: clarify tests-required rule by coverage delta criterion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Yamada UI is a React UI component library built with CSS-in-JS (Emotion).
 
 ## Critical Rules
 
-- **Tests are required**: Always write tests when fixing bugs or adding new features.
+- **Tests are required**: Add or update tests when a change introduces a new branch, contract, or regression path that is not already covered by existing tests (in the same package or in dependency units). Coverage delta — not the presence of a test in the diff — is the criterion.
 - **Accessibility is required**: All components must support ARIA attributes, keyboard navigation, and screen readers. Report any concerns.
 - **Do not bundle multiple fixes**: If you encounter a separate issue while working on a fix, do not fix it in the same PR. Create a separate issue and submit a separate PR.
 - **Do not run format, lint, or typecheck unless explicitly asked**: Format, lint and typecheck are handled by lefthook on commit. However, run tests for the changed files locally to verify that the implementation works correctly.


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Refines the `Tests are required` rule in `AGENTS.md` so that reviewers and contributors evaluate test obligations by coverage delta rather than by the mere presence of a test in the diff.

The previous wording `Always write tests when fixing bugs or adding new features.` was being applied mechanically by reviewers (especially under `magi-pr-review`), producing redundant test demands such as requesting `mergeProps` re-tests on every consuming component when `mergeProps` itself is already covered by its own unit tests.

## Current behavior (updates)

> - **Tests are required**: Always write tests when fixing bugs or adding new features.

This phrasing makes the criterion `does the PR diff contain a new test?`, which leads to demands for tests that do not increase coverage.

## New behavior

> - **Tests are required**: Add or update tests when a change introduces a new branch, contract, or regression path that is not already covered by existing tests (in the same package or in dependency units). Coverage delta — not the presence of a test in the diff — is the criterion.

The criterion is now `does the change introduce a new branch, contract, or regression path that no existing test (in the same package or in dependency units) covers?`. Tests that do not increase coverage are no longer required, and tests still are required when a genuinely uncovered path is introduced.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Paired with a `review-guide.md` change on the local `magi-pr-review` skill that aligns perspective #5 (`テスト`) with the same coverage-delta criterion.