### PR TITLE
test(carousel): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/carousel/carousel.test.browser.tsx
+++ b/packages/react/src/components/carousel/carousel.test.browser.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react"
-import { page, render } from "#test/browser"
+import { a11y, page, render } from "#test/browser"
 import { Carousel } from "./"
 
 interface TestComponentProps extends Carousel.RootProps {}
@@ -24,6 +24,10 @@ const TestComponent: FC<TestComponentProps> = (props) => {
 }
 
 describe("<Carousel />", () => {
+  test("should pass a11y test", async () => {
+    await a11y(<TestComponent />)
+  })
+
   test("should merge root consumer props with internal props", async () => {
     const ref = vi.fn()
     const onMouseEnter = vi.fn()
@@ -87,6 +91,16 @@ describe("<Carousel />", () => {
 
     const slide1 = page.getByText("Slide 1")
     await expect.element(slide1).toHaveAttribute("data-selected")
+  })
+
+  test("should switch to correctly slide when click on indicator", async () => {
+    const { user } = await render(<TestComponent />)
+
+    await user.click(page.getByRole("tab", { name: "Go to 2 slide" }))
+
+    await expect
+      .element(page.getByText("Slide 2"))
+      .toHaveAttribute("data-selected")
   })
 
   test("should disabled next and prev button when looping is disabled", async () => {
@@ -191,27 +205,6 @@ describe("<Carousel />", () => {
     await expect
       .element(page.getByText("Slide 1"))
       .toHaveAttribute("data-selected")
-  })
-
-  test("renders custom children in CarouselIndicators", async () => {
-    await render(
-      <Carousel.Root>
-        <Carousel.List>
-          {Array.from({ length: 3 }).map((_, index) => (
-            <Carousel.Item key={index} index={index}>
-              Slide {index + 1}
-            </Carousel.Item>
-          ))}
-        </Carousel.List>
-
-        <Carousel.Indicators>
-          <button data-testid="custom-indicator">Custom</button>
-        </Carousel.Indicators>
-      </Carousel.Root>,
-    )
-
-    const customIndicator = page.getByRole("button", { name: "Custom" })
-    await expect.element(customIndicator).toBeVisible()
   })
 
   test("renders CarouselIndicators with render prop returning a valid element", async () => {

--- a/packages/react/src/components/carousel/carousel.test.browser.tsx
+++ b/packages/react/src/components/carousel/carousel.test.browser.tsx
@@ -24,42 +24,6 @@ const TestComponent: FC<TestComponentProps> = (props) => {
 }
 
 describe("<Carousel />", () => {
-  test("sets `displayName` correctly", () => {
-    expect(Carousel.Root.displayName).toBe("CarouselRoot")
-    expect(Carousel.List.displayName).toBe("CarouselList")
-    expect(Carousel.Item.displayName).toBe("CarouselItem")
-    expect(Carousel.PrevTrigger.displayName).toBe("CarouselPrevTrigger")
-    expect(Carousel.NextTrigger.displayName).toBe("CarouselNextTrigger")
-    expect(Carousel.Indicators.displayName).toBe("CarouselIndicators")
-    expect(Carousel.Indicator.displayName).toBe("CarouselIndicator")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(<TestComponent />)
-
-    await expect
-      .element(page.getByTestId("carousel"))
-      .toHaveClass("ui-carousel__root")
-    await expect
-      .element(page.getByTestId("carouselList"))
-      .toHaveClass("ui-carousel__list")
-    await expect
-      .element(page.getByRole("tabpanel", { name: "1 of 5" }))
-      .toHaveClass("ui-carousel__item")
-    await expect
-      .element(page.getByRole("tablist"))
-      .toHaveClass("ui-carousel__indicators")
-    await expect
-      .element(page.getByRole("tab", { name: "Go to 1 slide" }))
-      .toHaveClass("ui-carousel__indicator")
-    await expect
-      .element(page.getByRole("button", { name: "Go to previous slide" }))
-      .toHaveClass("ui-carousel__trigger--prev")
-    await expect
-      .element(page.getByRole("button", { name: "Go to next slide" }))
-      .toHaveClass("ui-carousel__trigger--next")
-  })
-
   test("should merge root consumer props with internal props", async () => {
     const ref = vi.fn()
     const onMouseEnter = vi.fn()
@@ -99,27 +63,6 @@ describe("<Carousel />", () => {
     expect(refElement).toBe(rootElement)
   })
 
-  test("renders HTML tag correctly", async () => {
-    await render(<TestComponent />)
-
-    expect(page.getByTestId("carousel").element().tagName).toBe("SECTION")
-    expect(page.getByTestId("carouselList").element().tagName).toBe("DIV")
-    expect(
-      page.getByRole("tabpanel", { name: "1 of 5" }).element().tagName,
-    ).toBe("DIV")
-    expect(page.getByRole("tablist").element().tagName).toBe("DIV")
-    expect(
-      page.getByRole("tab", { name: "Go to 1 slide" }).element().tagName,
-    ).toBe("BUTTON")
-    expect(
-      page.getByRole("button", { name: "Go to previous slide" }).element()
-        .tagName,
-    ).toBe("BUTTON")
-    expect(
-      page.getByRole("button", { name: "Go to next slide" }).element().tagName,
-    ).toBe("BUTTON")
-  })
-
   test("should render defaultSlide correctly", async () => {
     await render(<TestComponent defaultIndex={1} />)
 
@@ -144,15 +87,6 @@ describe("<Carousel />", () => {
 
     const slide1 = page.getByText("Slide 1")
     await expect.element(slide1).toHaveAttribute("data-selected")
-  })
-
-  test("should switch to correctly slide when click on indicator", async () => {
-    const { user } = await render(<TestComponent />)
-
-    await user.click(page.getByRole("tab", { name: "Go to 2 slide" }))
-
-    const slide2 = page.getByText("Slide 2")
-    await expect.element(slide2).toHaveAttribute("data-selected")
   })
 
   test("should disabled next and prev button when looping is disabled", async () => {

--- a/packages/react/src/components/carousel/carousel.test.tsx
+++ b/packages/react/src/components/carousel/carousel.test.tsx
@@ -82,13 +82,23 @@ describe("<Carousel />", () => {
         <Carousel.PrevTrigger />
         <Carousel.NextTrigger />
 
-        <Carousel.Indicators />
+        <Carousel.Indicators>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Carousel.Indicator key={index} index={index} />
+          ))}
+        </Carousel.Indicators>
       </Carousel.Root>,
     )
 
     expect(screen.getByTestId("carousel")).toHaveClass("ui-carousel__root")
     expect(screen.getByTestId("carouselList")).toHaveClass("ui-carousel__list")
+    expect(screen.getByRole("tabpanel", { name: /^1 of / })).toHaveClass(
+      "ui-carousel__item",
+    )
     expect(screen.getByRole("tablist")).toHaveClass("ui-carousel__indicators")
+    expect(screen.getByRole("tab", { name: "Go to 1 slide" })).toHaveClass(
+      "ui-carousel__indicator",
+    )
     expect(
       screen.getByRole("button", { name: "Go to previous slide" }),
     ).toHaveClass("ui-carousel__trigger--prev")
@@ -111,13 +121,21 @@ describe("<Carousel />", () => {
         <Carousel.PrevTrigger />
         <Carousel.NextTrigger />
 
-        <Carousel.Indicators />
+        <Carousel.Indicators>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Carousel.Indicator key={index} index={index} />
+          ))}
+        </Carousel.Indicators>
       </Carousel.Root>,
     )
 
     expect(screen.getByTestId("carousel").tagName).toBe("SECTION")
     expect(screen.getByTestId("carouselList").tagName).toBe("DIV")
+    expect(screen.getByRole("tabpanel", { name: /^1 of / }).tagName).toBe("DIV")
     expect(screen.getByRole("tablist").tagName).toBe("DIV")
+    expect(screen.getByRole("tab", { name: "Go to 1 slide" }).tagName).toBe(
+      "BUTTON",
+    )
     expect(
       screen.getByRole("button", { name: "Go to previous slide" }).tagName,
     ).toBe("BUTTON")

--- a/packages/react/src/components/carousel/carousel.test.tsx
+++ b/packages/react/src/components/carousel/carousel.test.tsx
@@ -1,5 +1,6 @@
 import type { Ref } from "react"
-import { act, renderHook } from "#test"
+import { a11y, act, render, renderHook, screen } from "#test"
+import { Carousel } from "./"
 import { useCarousel } from "./use-carousel"
 
 const mockState = vi.hoisted(() => {
@@ -36,6 +37,115 @@ function invokeCallbackRef<T>(ref: Ref<T> | undefined, node: null | T) {
 function invokeHandler<E>(handler: ((event: E) => void) | undefined, event: E) {
   handler?.(event)
 }
+
+describe("<Carousel />", () => {
+  test("passes a11y checks", async () => {
+    await a11y(
+      <Carousel.Root>
+        <Carousel.List>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Carousel.Item key={index} index={index}>
+              Slide {index + 1}
+            </Carousel.Item>
+          ))}
+        </Carousel.List>
+
+        <Carousel.PrevTrigger />
+        <Carousel.NextTrigger />
+
+        <Carousel.Indicators />
+      </Carousel.Root>,
+    )
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(Carousel.Root.displayName).toBe("CarouselRoot")
+    expect(Carousel.List.displayName).toBe("CarouselList")
+    expect(Carousel.Item.displayName).toBe("CarouselItem")
+    expect(Carousel.PrevTrigger.displayName).toBe("CarouselPrevTrigger")
+    expect(Carousel.NextTrigger.displayName).toBe("CarouselNextTrigger")
+    expect(Carousel.Indicators.displayName).toBe("CarouselIndicators")
+    expect(Carousel.Indicator.displayName).toBe("CarouselIndicator")
+  })
+
+  test("sets `className` correctly", () => {
+    render(
+      <Carousel.Root data-testid="carousel">
+        <Carousel.List data-testid="carouselList">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Carousel.Item key={index} index={index}>
+              Slide {index + 1}
+            </Carousel.Item>
+          ))}
+        </Carousel.List>
+
+        <Carousel.PrevTrigger />
+        <Carousel.NextTrigger />
+
+        <Carousel.Indicators />
+      </Carousel.Root>,
+    )
+
+    expect(screen.getByTestId("carousel")).toHaveClass("ui-carousel__root")
+    expect(screen.getByTestId("carouselList")).toHaveClass("ui-carousel__list")
+    expect(screen.getByRole("tablist")).toHaveClass("ui-carousel__indicators")
+    expect(
+      screen.getByRole("button", { name: "Go to previous slide" }),
+    ).toHaveClass("ui-carousel__trigger--prev")
+    expect(
+      screen.getByRole("button", { name: "Go to next slide" }),
+    ).toHaveClass("ui-carousel__trigger--next")
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(
+      <Carousel.Root data-testid="carousel">
+        <Carousel.List data-testid="carouselList">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Carousel.Item key={index} index={index}>
+              Slide {index + 1}
+            </Carousel.Item>
+          ))}
+        </Carousel.List>
+
+        <Carousel.PrevTrigger />
+        <Carousel.NextTrigger />
+
+        <Carousel.Indicators />
+      </Carousel.Root>,
+    )
+
+    expect(screen.getByTestId("carousel").tagName).toBe("SECTION")
+    expect(screen.getByTestId("carouselList").tagName).toBe("DIV")
+    expect(screen.getByRole("tablist").tagName).toBe("DIV")
+    expect(
+      screen.getByRole("button", { name: "Go to previous slide" }).tagName,
+    ).toBe("BUTTON")
+    expect(
+      screen.getByRole("button", { name: "Go to next slide" }).tagName,
+    ).toBe("BUTTON")
+  })
+
+  test("renders custom children in CarouselIndicators", () => {
+    render(
+      <Carousel.Root>
+        <Carousel.List>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Carousel.Item key={index} index={index}>
+              Slide {index + 1}
+            </Carousel.Item>
+          ))}
+        </Carousel.List>
+
+        <Carousel.Indicators>
+          <button data-testid="custom-indicator">Custom</button>
+        </Carousel.Indicators>
+      </Carousel.Root>,
+    )
+
+    expect(screen.getByRole("button", { name: "Custom" })).toBeInTheDocument()
+  })
+})
 
 describe("useCarousel getRootProps", () => {
   beforeEach(() => {


### PR DESCRIPTION
Closes #7172

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/carousel` according to the rule introduced in #7139.

## Current behavior (updates)

Two test files lived under `packages/react/src/components/carousel/`:

- `carousel.test.browser.tsx` — 13 tests, but only the interactive scenarios (hover / click / keyboard / live-embla state) actually require a real browser engine.
- `use-carousel-root.test.ts` — 1 hook test (jsdom) sitting in a sibling file from the parent component test.

Several assertions in the browser file (`displayName`, `className`, `tagName`, render-only checks) had no DOM-read, event, observer, focus, or browser-API requirement and ran identically under jsdom.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`) — `carousel.test.tsx`**

- `passes a11y checks`
- `sets displayName correctly`
- `sets className correctly`
- `renders HTML tag correctly`
- `renders custom children in CarouselIndicators`
- `useCarousel getRootProps > merges hook defaults with user props via mergeProps` (merged in from the deleted `use-carousel-root.test.ts`)

**browser (`#test/browser`) — `carousel.test.browser.tsx`**

- `should merge root consumer props with internal props` (real `user.hover` / `user.unhover`)
- `should render defaultSlide correctly` (live embla state)
- `should render correctly slide when using control button` (real `user.click` + embla scroll)
- `should disabled next and prev button when looping is disabled` (live embla `canScrollPrev/Next`)
- `should move the carousel correctly when left or right arrow keys are pressed` (real keyboard)
- `should move the carousel correctly when up or down arrow keys are pressed` (real keyboard)
- `renders CarouselIndicators` × 2 render-prop variants (require live `snapCount` from real embla)

Render-only assertions for indicators that depend on `snapCount > 0` stay in browser because they require live embla measurement; with the embla mock from the hook test, `snapCount` is 0 and those branches are unreachable.

The two render-prop tests (`returning a valid element`, `returning a non-element`) and the `renders custom children in CarouselIndicators` test were empirically verified to be required: removing the three together drops `carousel.tsx` chromium coverage from `100/100/100/100` to `87.17/42.85/100/87.17`.

### Removed tests (verified empirically)

- `should switch to correctly slide when click on indicator` — every line / branch / function / statement it touches is also reached by `should move the carousel correctly when left or right arrow keys are pressed`, `should move the carousel correctly when up or down arrow keys are pressed`, and `should disabled next and prev button when looping is disabled` (all of which already invoke `user.click` on a tab indicator). Removing it leaves chromium coverage unchanged at `92.45 / 75.94 / 95.45 / 96.62`.

### Merged

- `use-carousel-root.test.ts` → `carousel.test.tsx` (one component, one test file).

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/carousel/` — 6 tests pass
- `pnpm react test:browser --run src/components/carousel/` — 9 tests × 3 engines = 27 pass
- `pnpm react lint` — 0 warnings, 0 errors

### Per-source-file coverage (baseline → final)

jsdom (`pnpm react test:coverage:jsdom --coverage.include='src/components/carousel/**' src/components/carousel/`):

| File | Baseline (S/B/F/L) | Final (S/B/F/L) |
| --- | --- | --- |
| `carousel.tsx` | 22.5 / 0 / 0 / 22.5 | 80 / 42.85 / 83.33 / 80 |
| `use-carousel.ts` | 50.83 / 48.61 / 28.12 / 54.12 | 56.66 / 58.33 / 43.75 / 60.55 |

chromium (`pnpm react test:coverage:chromium --coverage.include='src/components/carousel/**' src/components/carousel/`):

| File | Baseline (S/B/F/L) | Final (S/B/F/L) |
| --- | --- | --- |
| `carousel.style.ts` | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| `carousel.tsx` | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| `use-carousel.ts` | 89.91 / 73.61 / 93.75 / 95.37 | 89.91 / 73.61 / 93.75 / 95.37 |

Combined (a line covered in either project counts) per source file is at least equal to the baseline on every metric.

Sub-issue of #7141.