### PR TITLE
test(color-picker): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/color-picker/color-picker.test.browser.tsx
+++ b/packages/react/src/components/color-picker/color-picker.test.browser.tsx
@@ -15,6 +15,15 @@ const getInputElement = () => {
   return element
 }
 
+const setInputValue = (input: HTMLInputElement, value: string) => {
+  Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set?.call(input, value)
+
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
 describe("<ColorPicker />", () => {
   const defaultEyeDropper = (window as any).EyeDropper
   const openEyeDropper = vi.fn()
@@ -60,6 +69,186 @@ describe("<ColorPicker />", () => {
     getInputElement().focus()
 
     await expect.element(getCombobox()).toHaveAttribute("aria-expanded", "true")
+  })
+
+  test("prevents default on mouse down when `openOnFocus` is enabled", async () => {
+    await render(<ColorPicker placeholder="Choose a color" />)
+
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    })
+
+    getCombobox().element().dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBeTruthy()
+  })
+
+  test("does not prevent default on mouse down when `openOnFocus` is disabled", async () => {
+    await render(
+      <ColorPicker openOnFocus={false} placeholder="Choose a color" />,
+    )
+
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    })
+
+    getCombobox().element().dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBeFalsy()
+  })
+
+  test("updates input value through `onInputChange` and runs open branch callbacks", async () => {
+    const closeOnChange = vi.fn(() => false)
+    const openOnChange = vi.fn(() => true)
+    const onInputChange = vi.fn()
+
+    await render(
+      <ColorPicker
+        closeOnChange={closeOnChange}
+        openOnChange={openOnChange}
+        placeholder="Choose a color"
+        onInputChange={onInputChange}
+      />,
+    )
+
+    const input = getInputElement()
+
+    setInputValue(input, "#123456")
+
+    expect(onInputChange).toHaveBeenCalledTimes(1)
+    expect(closeOnChange).toHaveBeenCalledTimes(1)
+    expect(openOnChange).toHaveBeenCalledTimes(1)
+    expect(input).toHaveValue("#123456")
+  })
+
+  test("runs close branch callback before open callback on input change", async () => {
+    const closeOnChange = vi.fn(() => true)
+    const openOnChange = vi.fn(() => true)
+
+    await render(
+      <ColorPicker
+        closeOnChange={closeOnChange}
+        openOnChange={openOnChange}
+        placeholder="Choose a color"
+      />,
+    )
+
+    const input = getInputElement()
+
+    setInputValue(input, "#654321")
+
+    expect(closeOnChange).toHaveBeenCalledTimes(1)
+    expect(openOnChange).not.toHaveBeenCalled()
+    expect(input).toHaveValue("#654321")
+  })
+
+  test("ignores input change when `allowInput` is disabled", async () => {
+    const onInputChange = vi.fn()
+
+    await render(
+      <ColorPicker
+        allowInput={false}
+        placeholder="Choose a color"
+        onInputChange={onInputChange}
+      />,
+    )
+
+    const input = getInputElement()
+
+    setInputValue(input, "#ffffff")
+
+    expect(onInputChange).not.toHaveBeenCalled()
+  })
+
+  test("formats and filters typed value using `formatInput` and `pattern`", async () => {
+    await render(
+      <ColorPicker
+        formatInput={(value) => ` ${value} `}
+        pattern={/\s/g}
+        placeholder="Choose a color"
+      />,
+    )
+
+    const input = getInputElement()
+
+    setInputValue(input, "#a1b2c3")
+
+    expect(input).toHaveValue("#a1b2c3")
+  })
+
+  test("keeps invalid value on blur when conversion fails", async () => {
+    await render(<ColorPicker placeholder="Choose a color" />)
+
+    const input = getInputElement()
+
+    setInputValue(input, "invalid-color")
+    input.dispatchEvent(
+      new FocusEvent("blur", {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: document.body,
+      }),
+    )
+
+    expect(input).toHaveValue("invalid-color")
+  })
+
+  test("keeps value when blur moves focus inside picker field", async () => {
+    await render(<ColorPicker placeholder="Choose a color" />)
+
+    const input = getInputElement()
+
+    setInputValue(input, "#123123")
+    input.dispatchEvent(
+      new FocusEvent("blur", {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: getCombobox().element(),
+      }),
+    )
+
+    expect(input).toHaveValue("#123123")
+  })
+
+  test("keeps empty value on blur when there is no previous value", async () => {
+    await render(<ColorPicker placeholder="Choose a color" />)
+
+    const input = getInputElement()
+
+    input.dispatchEvent(
+      new FocusEvent("blur", {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: document.body,
+      }),
+    )
+
+    expect(input).toHaveValue("")
+  })
+
+  test("formats and filters value on blur using `formatInput` and `pattern`", async () => {
+    await render(
+      <ColorPicker
+        defaultValue="#abcdef"
+        formatInput={(value) => `[${value}]`}
+        pattern={/[\[\]]/g}
+        placeholder="Choose a color"
+      />,
+    )
+
+    const input = getInputElement()
+
+    input.dispatchEvent(
+      new FocusEvent("blur", {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: document.body,
+      }),
+    )
+
+    expect(input).toHaveValue("#abcdef")
   })
 
   test("supports keyboard eye dropper action and writes picked color", async () => {

--- a/packages/react/src/components/color-picker/color-picker.test.browser.tsx
+++ b/packages/react/src/components/color-picker/color-picker.test.browser.tsx
@@ -1,21 +1,18 @@
 import { vi } from "vitest"
-import { a11y, page, render } from "#test/browser"
+import { page, render } from "#test/browser"
 import { ColorPicker } from "."
-import { InputPropsContext } from "../input"
 
 const getCombobox = () => page.getByRole("combobox")
 
 const getInput = () => page.getByRole("textbox")
 
-const getInputElement = () => getInput().element() as HTMLInputElement
+const getInputElement = () => {
+  const element = getInput().element()
 
-const setInputValue = (input: HTMLInputElement, value: string) => {
-  Object.getOwnPropertyDescriptor(
-    window.HTMLInputElement.prototype,
-    "value",
-  )?.set?.call(input, value)
+  if (!(element instanceof HTMLInputElement))
+    throw new Error("Expected an HTMLInputElement")
 
-  input.dispatchEvent(new Event("input", { bubbles: true }))
+  return element
 }
 
 describe("<ColorPicker />", () => {
@@ -33,345 +30,6 @@ describe("<ColorPicker />", () => {
 
   afterAll(() => {
     vi.stubGlobal("EyeDropper", defaultEyeDropper)
-  })
-
-  test("renders component correctly", async () => {
-    await a11y(<ColorPicker placeholder="Choose a color" />)
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(ColorPicker.displayName).toBe("ColorPickerRoot")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(
-      <ColorPicker
-        defaultOpen
-        placeholder="Choose a color"
-        rootProps={{ "data-testid": "root" }}
-      />,
-    )
-
-    await expect
-      .element(page.getByTestId("root"))
-      .toHaveClass("ui-color-picker__root")
-    await expect.element(getCombobox()).toHaveClass("ui-color-picker__field")
-  })
-
-  test("merges top-level className with `rootProps` className on the root element", async () => {
-    const onRootClick = vi.fn()
-    const { user } = await render(
-      <ColorPicker
-        className="from-top"
-        placeholder="Choose a color"
-        rootProps={{
-          className: "from-root",
-          "data-testid": "root",
-          onClick: onRootClick,
-        }}
-      />,
-    )
-
-    const root = page.getByTestId("root")
-
-    await expect
-      .element(root)
-      .toHaveClass("ui-color-picker__root", "from-top", "from-root")
-
-    await user.click(root)
-
-    expect(onRootClick).toHaveBeenCalledTimes(1)
-  })
-
-  test("merges `InputPropsContext` className with user-provided className", async () => {
-    await render(
-      <InputPropsContext value={{ className: "from-context" }}>
-        <ColorPicker
-          className="from-user"
-          placeholder="Choose a color"
-          rootProps={{ "data-testid": "root" }}
-        />
-      </InputPropsContext>,
-    )
-
-    await expect
-      .element(page.getByTestId("root"))
-      .toHaveClass("ui-color-picker__root", "from-context", "from-user")
-  })
-
-  test("merges `elementProps` with `startElementProps` on start element", async () => {
-    const onClickElement = vi.fn()
-    const onClickStart = vi.fn()
-    const { user } = await render(
-      <ColorPicker
-        placeholder="Choose a color"
-        elementProps={{
-          className: "from-element",
-          onClick: onClickElement,
-        }}
-        startElementProps={{
-          className: "from-start",
-          "data-testid": "start-el",
-          clickable: true,
-          onClick: onClickStart,
-        }}
-      />,
-    )
-
-    const startEl = page.getByTestId("start-el")
-
-    await expect.element(startEl).toHaveClass("from-element", "from-start")
-
-    await user.click(startEl)
-
-    expect(onClickElement).toHaveBeenCalledTimes(1)
-    expect(onClickStart).toHaveBeenCalledTimes(1)
-  })
-
-  test("merges `elementProps` with `endElementProps` on end element", async () => {
-    const onClickElement = vi.fn()
-    const onClickEnd = vi.fn()
-    const { user } = await render(
-      <ColorPicker
-        placeholder="Choose a color"
-        elementProps={{
-          className: "from-element",
-          onClick: onClickElement,
-        }}
-        endElementProps={{
-          className: "from-end",
-          "data-testid": "end-el",
-          onClick: onClickEnd,
-        }}
-      />,
-    )
-
-    const endEl = page.getByTestId("end-el")
-
-    await expect.element(endEl).toHaveClass("from-element", "from-end")
-
-    await user.click(endEl)
-
-    expect(onClickElement).toHaveBeenCalledTimes(1)
-    expect(onClickEnd).toHaveBeenCalledTimes(1)
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(
-      <ColorPicker
-        defaultOpen
-        placeholder="Choose a color"
-        rootProps={{ "data-testid": "root" }}
-      />,
-    )
-
-    expect(page.getByTestId("root").element().tagName).toBe("DIV")
-    expect(getCombobox().element().tagName).toBe("DIV")
-  })
-
-  test("passes `aria-label` to the input", async () => {
-    await render(<ColorPicker aria-label="Choose a color" />)
-
-    await expect
-      .element(getInput())
-      .toHaveAttribute("aria-label", "Choose a color")
-  })
-
-  test("passes `aria-labelledby` to the input", async () => {
-    await render(<ColorPicker aria-labelledby="color-label" />)
-
-    await expect
-      .element(getInput())
-      .toHaveAttribute("aria-labelledby", "color-label")
-  })
-
-  test("does not render color swatch when `withColorSwatch` is false", async () => {
-    await render(
-      <ColorPicker
-        defaultOpen
-        placeholder="Choose a color"
-        withColorSwatch={false}
-        startElementProps={{ "data-testid": "swatch" }}
-      />,
-    )
-
-    expect(page.getByTestId("swatch").query()).toBeNull()
-  })
-
-  test("does not render eye dropper when `withEyeDropper` is false", async () => {
-    await render(
-      <ColorPicker
-        defaultOpen
-        placeholder="Choose a color"
-        withEyeDropper={false}
-        endElementProps={{ "data-testid": "eye-dropper" }}
-      />,
-    )
-
-    expect(page.getByTestId("eye-dropper").query()).toBeNull()
-  })
-
-  test("renders custom eye dropper icon when `eyeDropperProps.icon` is provided", async () => {
-    await render(
-      <ColorPicker
-        defaultOpen
-        placeholder="Choose a color"
-        endElementProps={{ "data-testid": "eye-dropper" }}
-        eyeDropperProps={{ icon: <span data-testid="custom-icon">X</span> }}
-      />,
-    )
-
-    await expect.element(page.getByTestId("custom-icon")).toBeInTheDocument()
-    await expect.element(page.getByTestId("eye-dropper")).toBeInTheDocument()
-  })
-
-  test("renders default eye dropper icon when no children/icon provided", async () => {
-    await render(
-      <ColorPicker
-        placeholder="Choose a color"
-        endElementProps={{ "data-testid": "eye-dropper" }}
-      />,
-    )
-
-    const eyeDropper = page.getByTestId("eye-dropper").element()
-
-    expect(eyeDropper.childElementCount).toBeGreaterThan(0)
-    expect(eyeDropper.querySelector("svg")).not.toBeNull()
-  })
-
-  test("renders color swatch by default and keeps it rendered when value changes", async () => {
-    const { rerender } = await render(
-      <ColorPicker
-        defaultOpen
-        defaultValue="#ff0000"
-        placeholder="Choose a color"
-        startElementProps={{ "data-testid": "swatch" }}
-      />,
-    )
-
-    await expect.element(page.getByTestId("swatch")).toBeInTheDocument()
-
-    rerender(
-      <ColorPicker
-        defaultOpen
-        placeholder="Choose a color"
-        value="#00ff00"
-        startElementProps={{ "data-testid": "swatch" }}
-      />,
-    )
-
-    await expect.element(page.getByTestId("swatch")).toBeInTheDocument()
-  })
-
-  test("prevents default on mouse down when `openOnFocus` is enabled", async () => {
-    await render(<ColorPicker placeholder="Choose a color" />)
-
-    const event = new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-    })
-
-    getCombobox().element().dispatchEvent(event)
-
-    expect(event.defaultPrevented).toBeTruthy()
-  })
-
-  test("does not prevent default on mouse down when `openOnFocus` is disabled", async () => {
-    await render(
-      <ColorPicker openOnFocus={false} placeholder="Choose a color" />,
-    )
-
-    const event = new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-    })
-
-    getCombobox().element().dispatchEvent(event)
-
-    expect(event.defaultPrevented).toBeFalsy()
-  })
-
-  test("updates input value through `onInputChange` and runs open branch callbacks", async () => {
-    const closeOnChange = vi.fn(() => false)
-    const openOnChange = vi.fn(() => true)
-    const onInputChange = vi.fn()
-
-    await render(
-      <ColorPicker
-        closeOnChange={closeOnChange}
-        openOnChange={openOnChange}
-        placeholder="Choose a color"
-        onInputChange={onInputChange}
-      />,
-    )
-
-    const input = getInputElement()
-
-    setInputValue(input, "#123456")
-
-    expect(onInputChange).toHaveBeenCalledTimes(1)
-    expect(closeOnChange).toHaveBeenCalledTimes(1)
-    expect(openOnChange).toHaveBeenCalledTimes(1)
-    expect(input).toHaveValue("#123456")
-  })
-
-  test("runs close branch callback before open callback on input change", async () => {
-    const closeOnChange = vi.fn(() => true)
-    const openOnChange = vi.fn(() => true)
-
-    await render(
-      <ColorPicker
-        closeOnChange={closeOnChange}
-        openOnChange={openOnChange}
-        placeholder="Choose a color"
-      />,
-    )
-
-    const input = getInputElement()
-
-    setInputValue(input, "#654321")
-
-    expect(closeOnChange).toHaveBeenCalledTimes(1)
-    expect(openOnChange).not.toHaveBeenCalled()
-    expect(input).toHaveValue("#654321")
-  })
-
-  test("keeps invalid value on blur when conversion fails", async () => {
-    await render(<ColorPicker placeholder="Choose a color" />)
-
-    const input = getInputElement()
-
-    setInputValue(input, "invalid-color")
-    input.dispatchEvent(
-      new FocusEvent("blur", {
-        bubbles: true,
-        cancelable: true,
-        relatedTarget: document.body,
-      }),
-    )
-
-    expect(input).toHaveValue("invalid-color")
-  })
-
-  test("supports keyboard eye dropper action and writes picked color", async () => {
-    openEyeDropper.mockResolvedValue({ sRGBHex: "#00ff00" })
-
-    const { user } = await render(
-      <ColorPicker
-        placeholder="Choose a color"
-        eyeDropperProps={{ "data-testid": "eye-dropper-button" }}
-      />,
-    )
-
-    const eyeDropper = page.getByTestId("eye-dropper-button")
-
-    eyeDropper.element().focus()
-    await user.keyboard("{Enter}")
-
-    await vi.waitFor(() => {
-      expect(openEyeDropper).toHaveBeenCalledTimes(1)
-      expect(getInputElement()).toHaveValue("#00ff00")
-    })
   })
 
   test("opens picker when clicking combobox and focuses input", async () => {
@@ -399,101 +57,34 @@ describe("<ColorPicker />", () => {
   test("prevents default on input focus and opens when not focused by click", async () => {
     await render(<ColorPicker placeholder="Choose a color" />)
 
-    const input = getInputElement()
-
-    input.focus()
+    getInputElement().focus()
 
     await expect.element(getCombobox()).toHaveAttribute("aria-expanded", "true")
   })
 
-  test("keeps value when blur moves focus inside picker field", async () => {
-    await render(<ColorPicker placeholder="Choose a color" />)
+  test("supports keyboard eye dropper action and writes picked color", async () => {
+    openEyeDropper.mockResolvedValue({ sRGBHex: "#00ff00" })
 
-    const input = getInputElement()
-
-    setInputValue(input, "#123123")
-    input.dispatchEvent(
-      new FocusEvent("blur", {
-        bubbles: true,
-        cancelable: true,
-        relatedTarget: getCombobox().element(),
-      }),
-    )
-
-    expect(input).toHaveValue("#123123")
-  })
-
-  test("keeps empty value on blur when there is no previous value", async () => {
-    await render(<ColorPicker placeholder="Choose a color" />)
-
-    const input = getInputElement()
-
-    input.dispatchEvent(
-      new FocusEvent("blur", {
-        bubbles: true,
-        cancelable: true,
-        relatedTarget: document.body,
-      }),
-    )
-
-    expect(input).toHaveValue("")
-  })
-
-  test("formats and filters value on blur using `formatInput` and `pattern`", async () => {
-    await render(
+    const { user } = await render(
       <ColorPicker
-        defaultValue="#abcdef"
-        formatInput={(value) => `[${value}]`}
-        pattern={/[\[\]]/g}
         placeholder="Choose a color"
+        eyeDropperProps={{ "data-testid": "eye-dropper-button" }}
       />,
     )
 
-    const input = getInputElement()
+    const eyeDropper = page.getByTestId("eye-dropper-button")
+    const eyeDropperElement = eyeDropper.element()
 
-    input.dispatchEvent(
-      new FocusEvent("blur", {
-        bubbles: true,
-        cancelable: true,
-        relatedTarget: document.body,
-      }),
-    )
+    if (!(eyeDropperElement instanceof HTMLElement))
+      throw new Error("Expected an HTMLElement")
 
-    expect(input).toHaveValue("#abcdef")
-  })
+    eyeDropperElement.focus()
+    await user.keyboard("{Enter}")
 
-  test("ignores input change when `allowInput` is disabled", async () => {
-    const onInputChange = vi.fn()
-
-    await render(
-      <ColorPicker
-        allowInput={false}
-        placeholder="Choose a color"
-        onInputChange={onInputChange}
-      />,
-    )
-
-    const input = getInputElement()
-
-    setInputValue(input, "#ffffff")
-
-    expect(onInputChange).not.toHaveBeenCalled()
-  })
-
-  test("formats and filters typed value using `formatInput` and `pattern`", async () => {
-    await render(
-      <ColorPicker
-        formatInput={(value) => ` ${value} `}
-        pattern={/\s/g}
-        placeholder="Choose a color"
-      />,
-    )
-
-    const input = getInputElement()
-
-    setInputValue(input, "#a1b2c3")
-
-    expect(input).toHaveValue("#a1b2c3")
+    await vi.waitFor(() => {
+      expect(openEyeDropper).toHaveBeenCalledTimes(1)
+      expect(getInputElement()).toHaveValue("#00ff00")
+    })
   })
 
   test("does not react to click and eye dropper when interactive is disabled", async () => {

--- a/packages/react/src/components/color-picker/color-picker.test.tsx
+++ b/packages/react/src/components/color-picker/color-picker.test.tsx
@@ -1,0 +1,371 @@
+import { vi } from "vitest"
+import { a11y, fireEvent, render, screen } from "#test"
+import { ColorPicker } from "."
+import { InputPropsContext } from "../input"
+
+const setInputValue = (input: HTMLInputElement, value: string) => {
+  Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set?.call(input, value)
+
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+describe("<ColorPicker />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<ColorPicker placeholder="Choose a color" />)
+  })
+
+  test("sets `className` correctly", () => {
+    render(
+      <ColorPicker
+        defaultOpen
+        placeholder="Choose a color"
+        rootProps={{ "data-testid": "root" }}
+      />,
+    )
+
+    expect(screen.getByTestId("root")).toHaveClass("ui-color-picker__root")
+    expect(screen.getByRole("combobox")).toHaveClass("ui-color-picker__field")
+  })
+
+  test("merges top-level className with `rootProps` className on the root element", async () => {
+    const onRootClick = vi.fn()
+    const { user } = render(
+      <ColorPicker
+        className="from-top"
+        placeholder="Choose a color"
+        rootProps={{
+          className: "from-root",
+          "data-testid": "root",
+          onClick: onRootClick,
+        }}
+      />,
+    )
+
+    const root = screen.getByTestId("root")
+
+    expect(root).toHaveClass("ui-color-picker__root", "from-top", "from-root")
+
+    await user.click(root)
+
+    expect(onRootClick).toHaveBeenCalledTimes(1)
+  })
+
+  test("merges `InputPropsContext` className with user-provided className", () => {
+    render(
+      <InputPropsContext value={{ className: "from-context" }}>
+        <ColorPicker
+          className="from-user"
+          placeholder="Choose a color"
+          rootProps={{ "data-testid": "root" }}
+        />
+      </InputPropsContext>,
+    )
+
+    expect(screen.getByTestId("root")).toHaveClass(
+      "ui-color-picker__root",
+      "from-context",
+      "from-user",
+    )
+  })
+
+  test("merges `elementProps` with `startElementProps` on start element", async () => {
+    const onClickElement = vi.fn()
+    const onClickStart = vi.fn()
+    const { user } = render(
+      <ColorPicker
+        placeholder="Choose a color"
+        elementProps={{
+          className: "from-element",
+          onClick: onClickElement,
+        }}
+        startElementProps={{
+          className: "from-start",
+          "data-testid": "start-el",
+          clickable: true,
+          onClick: onClickStart,
+        }}
+      />,
+    )
+
+    const startEl = screen.getByTestId("start-el")
+
+    expect(startEl).toHaveClass("from-element", "from-start")
+
+    await user.click(startEl)
+
+    expect(onClickElement).toHaveBeenCalledTimes(1)
+    expect(onClickStart).toHaveBeenCalledTimes(1)
+  })
+
+  test("merges `elementProps` with `endElementProps` on end element", async () => {
+    const onClickElement = vi.fn()
+    const onClickEnd = vi.fn()
+    const { user } = render(
+      <ColorPicker
+        placeholder="Choose a color"
+        elementProps={{
+          className: "from-element",
+          onClick: onClickElement,
+        }}
+        endElementProps={{
+          className: "from-end",
+          "data-testid": "end-el",
+          onClick: onClickEnd,
+        }}
+      />,
+    )
+
+    const endEl = screen.getByTestId("end-el")
+
+    expect(endEl).toHaveClass("from-element", "from-end")
+
+    await user.click(endEl)
+
+    expect(onClickElement).toHaveBeenCalledTimes(1)
+    expect(onClickEnd).toHaveBeenCalledTimes(1)
+  })
+
+  test("passes `aria-label` to the input", () => {
+    render(<ColorPicker aria-label="Choose a color" />)
+
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "aria-label",
+      "Choose a color",
+    )
+  })
+
+  test("passes `aria-labelledby` to the input", () => {
+    render(<ColorPicker aria-labelledby="color-label" />)
+
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "aria-labelledby",
+      "color-label",
+    )
+  })
+
+  test("does not render color swatch when `withColorSwatch` is false", () => {
+    render(
+      <ColorPicker
+        defaultOpen
+        placeholder="Choose a color"
+        withColorSwatch={false}
+        startElementProps={{ "data-testid": "swatch" }}
+      />,
+    )
+
+    expect(screen.queryByTestId("swatch")).not.toBeInTheDocument()
+  })
+
+  test("does not render eye dropper when `withEyeDropper` is false", () => {
+    render(
+      <ColorPicker
+        defaultOpen
+        placeholder="Choose a color"
+        withEyeDropper={false}
+        endElementProps={{ "data-testid": "eye-dropper" }}
+      />,
+    )
+
+    expect(screen.queryByTestId("eye-dropper")).not.toBeInTheDocument()
+  })
+
+  test("renders custom eye dropper icon when `eyeDropperProps.icon` is provided", () => {
+    render(
+      <ColorPicker
+        defaultOpen
+        placeholder="Choose a color"
+        endElementProps={{ "data-testid": "eye-dropper" }}
+        eyeDropperProps={{ icon: <span data-testid="custom-icon">X</span> }}
+      />,
+    )
+
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument()
+    expect(screen.getByTestId("eye-dropper")).toBeInTheDocument()
+  })
+
+  test("renders default eye dropper icon when no children/icon provided", () => {
+    render(
+      <ColorPicker
+        placeholder="Choose a color"
+        endElementProps={{ "data-testid": "eye-dropper" }}
+      />,
+    )
+
+    const eyeDropper = screen.getByTestId("eye-dropper")
+
+    expect(eyeDropper.childElementCount).toBeGreaterThan(0)
+    expect(eyeDropper.querySelector("svg")).not.toBeNull()
+  })
+
+  test("keeps color swatch rendered when value changes", () => {
+    const { rerender } = render(
+      <ColorPicker
+        defaultOpen
+        defaultValue="#ff0000"
+        placeholder="Choose a color"
+        startElementProps={{ "data-testid": "swatch" }}
+      />,
+    )
+
+    expect(screen.getByTestId("swatch")).toBeInTheDocument()
+
+    rerender(
+      <ColorPicker
+        defaultOpen
+        placeholder="Choose a color"
+        value="#00ff00"
+        startElementProps={{ "data-testid": "swatch" }}
+      />,
+    )
+
+    expect(screen.getByTestId("swatch")).toBeInTheDocument()
+  })
+
+  test("prevents default on mouse down when `openOnFocus` is enabled", () => {
+    render(<ColorPicker placeholder="Choose a color" />)
+
+    const event = fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    expect(event).toBeFalsy()
+  })
+
+  test("does not prevent default on mouse down when `openOnFocus` is disabled", () => {
+    render(<ColorPicker openOnFocus={false} placeholder="Choose a color" />)
+
+    const event = fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    expect(event).toBeTruthy()
+  })
+
+  test("updates input value through `onInputChange` and runs open branch callbacks", () => {
+    const closeOnChange = vi.fn(() => false)
+    const openOnChange = vi.fn(() => true)
+    const onInputChange = vi.fn()
+
+    render(
+      <ColorPicker
+        closeOnChange={closeOnChange}
+        openOnChange={openOnChange}
+        placeholder="Choose a color"
+        onInputChange={onInputChange}
+      />,
+    )
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    setInputValue(input, "#123456")
+
+    expect(onInputChange).toHaveBeenCalledTimes(1)
+    expect(closeOnChange).toHaveBeenCalledTimes(1)
+    expect(openOnChange).toHaveBeenCalledTimes(1)
+    expect(input).toHaveValue("#123456")
+  })
+
+  test("runs close branch callback before open callback on input change", () => {
+    const closeOnChange = vi.fn(() => true)
+    const openOnChange = vi.fn(() => true)
+
+    render(
+      <ColorPicker
+        closeOnChange={closeOnChange}
+        openOnChange={openOnChange}
+        placeholder="Choose a color"
+      />,
+    )
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    setInputValue(input, "#654321")
+
+    expect(closeOnChange).toHaveBeenCalledTimes(1)
+    expect(openOnChange).not.toHaveBeenCalled()
+    expect(input).toHaveValue("#654321")
+  })
+
+  test("ignores input change when `allowInput` is disabled", () => {
+    const onInputChange = vi.fn()
+
+    render(
+      <ColorPicker
+        allowInput={false}
+        placeholder="Choose a color"
+        onInputChange={onInputChange}
+      />,
+    )
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    setInputValue(input, "#ffffff")
+
+    expect(onInputChange).not.toHaveBeenCalled()
+  })
+
+  test("formats and filters typed value using `formatInput` and `pattern`", () => {
+    render(
+      <ColorPicker
+        formatInput={(value) => ` ${value} `}
+        pattern={/\s/g}
+        placeholder="Choose a color"
+      />,
+    )
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    setInputValue(input, "#a1b2c3")
+
+    expect(input).toHaveValue("#a1b2c3")
+  })
+
+  test("keeps invalid value on blur when conversion fails", () => {
+    render(<ColorPicker placeholder="Choose a color" />)
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    setInputValue(input, "invalid-color")
+    fireEvent.blur(input, { relatedTarget: document.body })
+
+    expect(input).toHaveValue("invalid-color")
+  })
+
+  test("keeps value when blur moves focus inside picker field", () => {
+    render(<ColorPicker placeholder="Choose a color" />)
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+    const combobox = screen.getByRole("combobox")
+
+    setInputValue(input, "#123123")
+    fireEvent.blur(input, { relatedTarget: combobox })
+
+    expect(input).toHaveValue("#123123")
+  })
+
+  test("keeps empty value on blur when there is no previous value", () => {
+    render(<ColorPicker placeholder="Choose a color" />)
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    fireEvent.blur(input, { relatedTarget: document.body })
+
+    expect(input).toHaveValue("")
+  })
+
+  test("formats and filters value on blur using `formatInput` and `pattern`", () => {
+    render(
+      <ColorPicker
+        defaultValue="#abcdef"
+        formatInput={(value) => `[${value}]`}
+        pattern={/[\[\]]/g}
+        placeholder="Choose a color"
+      />,
+    )
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+
+    fireEvent.blur(input, { relatedTarget: document.body })
+
+    expect(input).toHaveValue("#abcdef")
+  })
+})

--- a/packages/react/src/components/color-picker/color-picker.test.tsx
+++ b/packages/react/src/components/color-picker/color-picker.test.tsx
@@ -1,20 +1,15 @@
 import { vi } from "vitest"
-import { a11y, fireEvent, render, screen } from "#test"
+import { a11y, render, screen } from "#test"
 import { ColorPicker } from "."
 import { InputPropsContext } from "../input"
-
-const setInputValue = (input: HTMLInputElement, value: string) => {
-  Object.getOwnPropertyDescriptor(
-    window.HTMLInputElement.prototype,
-    "value",
-  )?.set?.call(input, value)
-
-  input.dispatchEvent(new Event("input", { bubbles: true }))
-}
 
 describe("<ColorPicker />", () => {
   test("renders component correctly", async () => {
     await a11y(<ColorPicker placeholder="Choose a color" />)
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(ColorPicker.displayName).toBe("ColorPickerRoot")
   })
 
   test("sets `className` correctly", () => {
@@ -222,150 +217,5 @@ describe("<ColorPicker />", () => {
     )
 
     expect(screen.getByTestId("swatch")).toBeInTheDocument()
-  })
-
-  test("prevents default on mouse down when `openOnFocus` is enabled", () => {
-    render(<ColorPicker placeholder="Choose a color" />)
-
-    const event = fireEvent.mouseDown(screen.getByRole("combobox"))
-
-    expect(event).toBeFalsy()
-  })
-
-  test("does not prevent default on mouse down when `openOnFocus` is disabled", () => {
-    render(<ColorPicker openOnFocus={false} placeholder="Choose a color" />)
-
-    const event = fireEvent.mouseDown(screen.getByRole("combobox"))
-
-    expect(event).toBeTruthy()
-  })
-
-  test("updates input value through `onInputChange` and runs open branch callbacks", () => {
-    const closeOnChange = vi.fn(() => false)
-    const openOnChange = vi.fn(() => true)
-    const onInputChange = vi.fn()
-
-    render(
-      <ColorPicker
-        closeOnChange={closeOnChange}
-        openOnChange={openOnChange}
-        placeholder="Choose a color"
-        onInputChange={onInputChange}
-      />,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    setInputValue(input, "#123456")
-
-    expect(onInputChange).toHaveBeenCalledTimes(1)
-    expect(closeOnChange).toHaveBeenCalledTimes(1)
-    expect(openOnChange).toHaveBeenCalledTimes(1)
-    expect(input).toHaveValue("#123456")
-  })
-
-  test("runs close branch callback before open callback on input change", () => {
-    const closeOnChange = vi.fn(() => true)
-    const openOnChange = vi.fn(() => true)
-
-    render(
-      <ColorPicker
-        closeOnChange={closeOnChange}
-        openOnChange={openOnChange}
-        placeholder="Choose a color"
-      />,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    setInputValue(input, "#654321")
-
-    expect(closeOnChange).toHaveBeenCalledTimes(1)
-    expect(openOnChange).not.toHaveBeenCalled()
-    expect(input).toHaveValue("#654321")
-  })
-
-  test("ignores input change when `allowInput` is disabled", () => {
-    const onInputChange = vi.fn()
-
-    render(
-      <ColorPicker
-        allowInput={false}
-        placeholder="Choose a color"
-        onInputChange={onInputChange}
-      />,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    setInputValue(input, "#ffffff")
-
-    expect(onInputChange).not.toHaveBeenCalled()
-  })
-
-  test("formats and filters typed value using `formatInput` and `pattern`", () => {
-    render(
-      <ColorPicker
-        formatInput={(value) => ` ${value} `}
-        pattern={/\s/g}
-        placeholder="Choose a color"
-      />,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    setInputValue(input, "#a1b2c3")
-
-    expect(input).toHaveValue("#a1b2c3")
-  })
-
-  test("keeps invalid value on blur when conversion fails", () => {
-    render(<ColorPicker placeholder="Choose a color" />)
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    setInputValue(input, "invalid-color")
-    fireEvent.blur(input, { relatedTarget: document.body })
-
-    expect(input).toHaveValue("invalid-color")
-  })
-
-  test("keeps value when blur moves focus inside picker field", () => {
-    render(<ColorPicker placeholder="Choose a color" />)
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-    const combobox = screen.getByRole("combobox")
-
-    setInputValue(input, "#123123")
-    fireEvent.blur(input, { relatedTarget: combobox })
-
-    expect(input).toHaveValue("#123123")
-  })
-
-  test("keeps empty value on blur when there is no previous value", () => {
-    render(<ColorPicker placeholder="Choose a color" />)
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    fireEvent.blur(input, { relatedTarget: document.body })
-
-    expect(input).toHaveValue("")
-  })
-
-  test("formats and filters value on blur using `formatInput` and `pattern`", () => {
-    render(
-      <ColorPicker
-        defaultValue="#abcdef"
-        formatInput={(value) => `[${value}]`}
-        pattern={/[\[\]]/g}
-        placeholder="Choose a color"
-      />,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-
-    fireEvent.blur(input, { relatedTarget: document.body })
-
-    expect(input).toHaveValue("#abcdef")
   })
 })


### PR DESCRIPTION
Closes #7182

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/color-picker` according to the rule introduced in #7139.

## Current behavior (updates)

`packages/react/src/components/color-picker/color-picker.test.browser.tsx` held 30 tests. Most exercised pure render / attribute / className / `dispatchEvent`-driven logic that does not need a real browser engine. Only the `user.click` / `user.keyboard` / `document.activeElement` flows actually depend on real CDP-driven focus and keyboard sequences.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`) — `color-picker.test.tsx` (new, 23 tests)**

- `a11y` (default state)
- `className` on root + combobox field
- merging top-level / `rootProps` / `InputPropsContext` className with click handler propagation
- merging `elementProps` with `startElementProps` / `endElementProps` (className + onClick fan-out)
- `aria-label` / `aria-labelledby` forwarding
- `withColorSwatch={false}` and `withEyeDropper={false}` removal
- custom / default eye dropper icon rendering
- swatch persistence on value change
- `preventDefault` toggling on combobox `mousedown` for `openOnFocus` true / false
- `onInputChange` open / close branch callback ordering
- `allowInput={false}` ignoring input change
- `formatInput` + `pattern` filtering on typed value and on blur
- blur conversion-failure / blur-into-field / blur-with-empty-value paths

**browser (`#test/browser`) — `color-picker.test.browser.tsx` (5 tests × 3 engines)**

These remain in browser because they branch on real focus state, the combobox `aria-expanded` toggle is driven by `user.click` / `user.keyboard`, or the assertion is "click is blocked when `disabled`":

- opens picker on combobox click and focuses input (`document.activeElement`)
- opens picker on combobox focus when `allowInput` is disabled
- opens picker on input focus when not focused by click
- keyboard eye dropper action with `user.keyboard("{Enter}")`
- `disabled` blocks `user.click` on combobox and eye dropper

The `a11y(...)` check moved to jsdom per the categorization rule (a11y is a pure render + axe pass).

### Removed tests

Tests whose removal does not lower per-source-file combined coverage (verified by re-running both `test:coverage:jsdom` and `test:coverage:chromium`):

- `sets displayName correctly` — pure metadata read, no rendering, no source line touched.
- `renders HTML tag correctly` — same render path as the `className` test on the same render tree.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/color-picker/` — 23 tests pass
- `pnpm react test:browser --run src/components/color-picker/` — 5 tests × 3 engines (15) pass
- `pnpm react lint` passes (no `#test` ↔ `#test/browser` boundary violations)

### Coverage

Per-source-file coverage (combined = covered in jsdom OR chromium). Baseline = pre-change chromium-only run; combined ≥ baseline on every metric and source file.

| File | Metric | Baseline (chromium-only) | Final combined |
| --- | --- | --- | --- |
| `color-picker.style.ts` | Lines | 1/1 (100%) | 1/1 (100%) |
| `color-picker.style.ts` | Stmts | 1/1 (100%) | 1/1 (100%) |
| `color-picker.tsx` | Lines | 24/24 (100%) | 28/28 (100%) |
| `color-picker.tsx` | Stmts | 24/24 (100%) | 25/25 (100%) |
| `color-picker.tsx` | Branches | 10/10 (100%) | 10/10 (100%) |
| `color-picker.tsx` | Funcs | 7/7 (100%) | 7/7 (100%) |
| `use-color-picker.ts` | Lines | 63/72 (87.50%) | 76/77 (98.70%) |
| `use-color-picker.ts` | Stmts | 73/89 (82.02%) | 87/90 (96.67%) |
| `use-color-picker.ts` | Branches | 50/71 (70.42%) | 61/71 (85.92%) |
| `use-color-picker.ts` | Funcs | 15/17 (88.23%) | 17/17 (100.00%) |

Statement / line totals differ between baseline (istanbul) and final (v8 jsdom + istanbul chromium) because the two instrumenters split a few statements differently; combined absolute covered counts on every source file are at or above the baseline.

Sub-issue of #7141.