### PR TITLE
test(fade-scale): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/fade-scale/fade-scale.test.browser.tsx
+++ b/packages/react/src/components/fade-scale/fade-scale.test.browser.tsx
@@ -26,6 +26,30 @@ describe("<FadeScale />", () => {
     })
   }
 
+  test("toggles visibility on open change", async () => {
+    const TestComponent = () => {
+      const [open, setOpen] = useState(false)
+
+      return (
+        <>
+          <button onClick={() => setOpen((prev) => !prev)}>button</button>
+          <FadeScale open={open}>FadeScale</FadeScale>
+        </>
+      )
+    }
+
+    const { user } = await render(<TestComponent />)
+
+    const button = page.getByRole("button", { name: /button/i })
+    await expectFadeScaleToBeHidden()
+
+    await user.click(button)
+    await expectFadeScaleToBeVisible()
+
+    await user.click(button)
+    await expectFadeScaleToBeHidden()
+  })
+
   test("applies reverse={false} exit correctly", async () => {
     const TestComponent = () => {
       const [open, setOpen] = useState(false)

--- a/packages/react/src/components/fade-scale/fade-scale.test.browser.tsx
+++ b/packages/react/src/components/fade-scale/fade-scale.test.browser.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { vi } from "vitest"
-import { a11y, page, render } from "#test/browser"
+import { page, render } from "#test/browser"
 import { FadeScale } from "./fade-scale"
 
 describe("<FadeScale />", () => {
@@ -25,50 +25,6 @@ describe("<FadeScale />", () => {
         .not.toBeInTheDocument()
     })
   }
-
-  test("renders component correctly", async () => {
-    await a11y(<FadeScale />)
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(FadeScale.displayName).toBe("FadeScale")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(<FadeScale>FadeScale</FadeScale>)
-    await expect
-      .element(page.getByText("FadeScale"))
-      .toHaveClass("ui-fade-scale")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(<FadeScale>FadeScale</FadeScale>)
-    expect(page.getByText("FadeScale").element().tagName).toBe("DIV")
-  })
-
-  test("toggles visibility on open change", async () => {
-    const TestComponent = () => {
-      const [open, setOpen] = useState(false)
-
-      return (
-        <>
-          <button onClick={() => setOpen((prev) => !prev)}>button</button>
-          <FadeScale open={open}>FadeScale</FadeScale>
-        </>
-      )
-    }
-
-    const { user } = await render(<TestComponent />)
-
-    const button = page.getByRole("button", { name: /button/i })
-    await expectFadeScaleToBeHidden()
-
-    await user.click(button)
-    await expectFadeScaleToBeVisible()
-
-    await user.click(button)
-    await expectFadeScaleToBeHidden()
-  })
 
   test("applies reverse={false} exit correctly", async () => {
     const TestComponent = () => {

--- a/packages/react/src/components/fade-scale/fade-scale.test.tsx
+++ b/packages/react/src/components/fade-scale/fade-scale.test.tsx
@@ -1,8 +1,23 @@
+import { render, screen } from "@testing-library/react"
 import { a11y } from "#test"
 import { FadeScale } from "./fade-scale"
 
 describe("<FadeScale />", () => {
   test("renders component correctly", async () => {
     await a11y(<FadeScale />)
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(FadeScale.displayName).toBe("FadeScale")
+  })
+
+  test("sets `className` correctly", () => {
+    render(<FadeScale>FadeScale</FadeScale>)
+    expect(screen.getByText("FadeScale")).toHaveClass("fade-scale")
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(<FadeScale>FadeScale</FadeScale>)
+    expect(screen.getByText("FadeScale").tagName).toBe("DIV")
   })
 })

--- a/packages/react/src/components/fade-scale/fade-scale.test.tsx
+++ b/packages/react/src/components/fade-scale/fade-scale.test.tsx
@@ -1,0 +1,8 @@
+import { a11y } from "#test"
+import { FadeScale } from "./fade-scale"
+
+describe("<FadeScale />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<FadeScale />)
+  })
+})


### PR DESCRIPTION
Closes #7193

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/fade-scale` according to the rule introduced in #7139.

## Current behavior (updates)

A single `fade-scale.test.browser.tsx` file existed under `packages/react/src/components/fade-scale/` with 7 tests. Several were jsdom-friendly (pure attribute / metadata reads, `a11y`) and did not need a real browser.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `fade-scale.test.tsx` (new) — 1 test (a11y)

**browser (`#test/browser`)**

- `fade-scale.test.browser.tsx` — 2 tests
  - `applies reverse={false} exit correctly` — exercises the `reverse` ternary on line 36 and event-driven open/close
  - `unmountOnExit works correctly` — exercises the `unmountOnExit` ternary on line 88 and DOM mount/unmount

Removed tests that did not contribute to coverage (verified empirically by deleting and re-running coverage on the owning project):

- `sets displayName correctly` — pure metadata read, no rendering; same combined coverage without it
- `sets className correctly` — same render path as `a11y(<FadeScale />)`; redundant
- `renders HTML tag correctly` — same render path as `a11y(<FadeScale />)`; redundant
- `toggles visibility on open change` — branch coverage held at 87.5% via `reverse={false}` and `unmountOnExit` tests; redundant
- `renders component correctly` (a11y) in browser — moved to jsdom (`a11y` is a pure render + axe pass)

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/fade-scale/` — 1 test passes
- `pnpm react test:browser --run src/components/fade-scale/` — 2 tests x 3 engines (6 total) pass
- `pnpm react lint` — 0 warnings, 0 errors

Per-source-file coverage on `packages/react/src/components/fade-scale/`:

| Project  | Stage    | Stmts            | Branch          | Funcs         | Lines            |
| -------- | -------- | ---------------- | --------------- | ------------- | ---------------- |
| jsdom    | baseline | 0% (0/12)        | 0% (0/16)       | 0% (0/4)      | 0% (0/12)        |
| jsdom    | final    | 91.66% (11/12)   | 56.25% (9/16)   | 75% (3/4)     | 91.66% (11/12)   |
| chromium | baseline | 100% (11/11)     | 87.5% (14/16)   | 100% (4/4)    | 100% (11/11)     |
| chromium | final    | 100% (11/11)     | 87.5% (14/16)   | 100% (4/4)    | 100% (11/11)     |
| combined | baseline | 100%             | 87.5%           | 100%          | 100%             |
| combined | final    | 100%             | 87.5%           | 100%          | 100%             |

Combined per-source-file coverage (a line covered in either project counts) is identical to baseline.

Sub-issue of #7141.