### PR TITLE
test(date-picker): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.test.browser.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.browser.tsx
@@ -966,15 +966,16 @@ describe("<DatePicker />", () => {
   })
 
   test("handles click on range field focuses start input when both empty", async () => {
-    const { user } = await render(
-      <DatePicker placeholder="Select date" range />,
-    )
+    await render(<DatePicker placeholder="Select date" range />)
 
     const field = page.getByRole("combobox").first()
-    await user.click(field)
+    const fieldEl = await field.findElement()
+    if (fieldEl instanceof HTMLElement) fieldEl.click()
 
     const inputs = page.getByRole("textbox")
-    await expect.element(inputs.first()).toHaveFocus()
+    await vi.waitFor(async () => {
+      await expect.element(inputs.first()).toHaveFocus()
+    })
   })
 
   test("handles click on range field focuses start input when only start is set", async () => {

--- a/packages/react/src/components/date-picker/date-picker.test.browser.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.browser.tsx
@@ -1,51 +1,15 @@
-import type { DatePickerProps } from "."
 import { useState } from "react"
 import { vi } from "vitest"
-import { a11y, page, render } from "#test/browser"
+import { page, render } from "#test/browser"
 import { DatePicker } from "."
 import { InputPropsContext } from "../input"
 
-const ControlledDatePicker = ({ defaultValue, ...props }: DatePickerProps) => {
-  const [value, setValue] = useState<Date | undefined>(defaultValue as Date)
-
-  return <DatePicker value={value} onChange={setValue} {...props} />
-}
-
 describe("<DatePicker />", () => {
-  test("renders component correctly", async () => {
-    await a11y(<DatePicker />)
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(DatePicker.displayName).toBe("DatePickerRoot")
-  })
-
-  test("sets `className` correctly", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultOpen
-        placeholder="Choose a option"
-        iconProps={{ "data-testid": "icon" }}
-        rootProps={{ "data-testid": "root" }}
-      />,
-    )
-
-    await expect
-      .element(page.getByTestId("root"))
-      .toHaveClass("ui-date-picker__root")
-    await expect
-      .element(page.getByTestId("icon"))
-      .toHaveClass("ui-date-picker__icon")
-    await expect
-      .element(page.getByRole("combobox").first())
-      .toHaveClass("ui-date-picker__field")
-  })
-
   test("merges root props without overwriting user props", async () => {
     const onRootClick = vi.fn()
     const onUserClick = vi.fn()
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         className="from-root"
         defaultOpen
@@ -63,7 +27,7 @@ describe("<DatePicker />", () => {
     )
 
     const el = page.getByTestId("root")
-    await _user.click(page.getByRole("combobox").first())
+    await user.click(page.getByRole("combobox").first())
 
     await expect.element(el).toHaveClass("from-root", "from-user")
     await expect.element(el).toHaveStyle({ color: "rgb(255, 0, 0)" })
@@ -76,7 +40,7 @@ describe("<DatePicker />", () => {
     const onRootClick = vi.fn()
     const onUserClick = vi.fn()
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <InputPropsContext
         value={{
           className: "from-root",
@@ -97,7 +61,7 @@ describe("<DatePicker />", () => {
     const root = page.getByTestId("root")
     const el = page.getByRole("combobox").first()
 
-    await _user.click(el)
+    await user.click(el)
 
     await expect.element(root).toHaveClass("from-root", "from-user")
     await expect.element(el).toHaveStyle({ color: "rgb(255, 0, 0)" })
@@ -106,79 +70,8 @@ describe("<DatePicker />", () => {
     expect(onUserClick).toHaveBeenCalledTimes(1)
   })
 
-  test("renders HTML tag correctly", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultOpen
-        placeholder="Choose a option"
-        iconProps={{ "data-testid": "icon" }}
-        rootProps={{ "data-testid": "root" }}
-      />,
-    )
-
-    await expect
-      .element(page.getByTestId("root"))
-      .toHaveProperty("tagName", "DIV")
-    await expect
-      .element(page.getByTestId("icon"))
-      .toHaveProperty("tagName", "DIV")
-    await expect
-      .element(page.getByRole("combobox").first())
-      .toHaveProperty("tagName", "DIV")
-  })
-
-  test("renders with defaultValue", async () => {
-    const { user: _user } = await render(
-      <DatePicker defaultValue={new Date(2024, 0, 15)} />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveValue("January 15, 2024")
-  })
-
-  test("renders with range mode", async () => {
-    const { user: _user } = await render(
-      <DatePicker range rootProps={{ "data-testid": "root" }} />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    await expect.element(inputs.first()).toBeInTheDocument()
-    await expect.element(inputs.nth(1)).toBeInTheDocument()
-    await expect.element(inputs.nth(2).query()).not.toBeInTheDocument()
-  })
-
-  test("renders with multiple mode", async () => {
-    const { user: _user } = await render(
-      <DatePicker multiple placeholder="Select dates" />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toBeInTheDocument()
-  })
-
-  test("shows clear icon when value exists", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={new Date(2024, 0, 15)}
-        iconProps={{ "data-testid": "icon" }}
-      />,
-    )
-
-    const icon = page.getByTestId("icon")
-    await expect.element(icon).toHaveAttribute("role", "button")
-  })
-
-  test("shows calendar icon when no value exists", async () => {
-    const { user: _user } = await render(
-      <DatePicker clearable iconProps={{ "data-testid": "icon" }} />,
-    )
-
-    const icon = page.getByTestId("icon")
-    await expect.element(icon).not.toHaveAttribute("role", "button")
-  })
-
   test("clears value when clear icon is clicked", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
@@ -189,7 +82,7 @@ describe("<DatePicker />", () => {
     await expect.element(input).toHaveValue("January 15, 2024")
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
+    await user.click(icon)
 
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("")
@@ -197,7 +90,7 @@ describe("<DatePicker />", () => {
   })
 
   test("clears range value when clear icon is clicked", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -213,7 +106,7 @@ describe("<DatePicker />", () => {
     await expect.element(inputs.nth(1)).toHaveValue("January 20, 2024")
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
+    await user.click(icon)
 
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveValue("")
@@ -221,58 +114,11 @@ describe("<DatePicker />", () => {
     })
   })
 
-  test("shows clear icon for range value with start only", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={{
-          end: undefined,
-          start: new Date(2024, 0, 15),
-        }}
-        range
-        iconProps={{ "data-testid": "icon" }}
-      />,
-    )
-
-    const icon = page.getByTestId("icon")
-    await expect.element(icon).toHaveAttribute("role", "button")
-  })
-
-  test("shows clear icon for range value with end only", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={{
-          end: new Date(2024, 0, 20),
-          start: undefined,
-        }}
-        range
-        iconProps={{ "data-testid": "icon" }}
-      />,
-    )
-
-    const icon = page.getByTestId("icon")
-    await expect.element(icon).toHaveAttribute("role", "button")
-  })
-
-  test("renders with clearable=false", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        clearable={false}
-        defaultValue={new Date(2024, 0, 15)}
-        iconProps={{ "data-testid": "icon" }}
-      />,
-    )
-
-    const icon = page.getByTestId("icon")
-    await expect.element(icon).not.toHaveAttribute("role", "button")
-  })
-
   test("opens on click", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Select date" />,
-    )
+    const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const field = page.getByRole("combobox").first()
-    await _user.click(field)
+    await user.click(field)
 
     await vi.waitFor(async () => {
       await expect.element(page.getByRole("dialog")).toBeInTheDocument()
@@ -280,12 +126,10 @@ describe("<DatePicker />", () => {
   })
 
   test("opens on input focus when openOnFocus is true", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Select date" />,
-    )
+    const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
+    await user.click(input)
 
     await vi.waitFor(async () => {
       await expect.element(page.getByRole("dialog")).toBeInTheDocument()
@@ -305,12 +149,12 @@ describe("<DatePicker />", () => {
   })
 
   test("opens on start input click in range mode", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.first())
+    await user.click(inputs.first())
 
     await vi.waitFor(async () => {
       await expect.element(page.getByRole("dialog")).toBeInTheDocument()
@@ -319,12 +163,12 @@ describe("<DatePicker />", () => {
   })
 
   test("opens on end input click in range mode", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.nth(1))
+    await user.click(inputs.nth(1))
 
     await vi.waitFor(async () => {
       await expect.element(page.getByRole("dialog")).toBeInTheDocument()
@@ -333,41 +177,39 @@ describe("<DatePicker />", () => {
   })
 
   test("handles input change for single date", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Select date" />,
-    )
+    const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
 
     await expect.element(input).toHaveValue("2024-01-15")
   })
 
   test("handles input change for range date", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.first())
-    await _user.clear(inputs.first())
-    await _user.type(inputs.first(), "2024-01-15")
+    await user.click(inputs.first())
+    await user.clear(inputs.first())
+    await user.type(inputs.first(), "2024-01-15")
 
     await expect.element(inputs.first()).toHaveValue("2024-01-15")
   })
 
   test("handles Enter key on single date input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("January 15, 2024")
@@ -375,15 +217,15 @@ describe("<DatePicker />", () => {
   })
 
   test("handles Enter key on range date start input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" range />,
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.first())
-    await _user.clear(inputs.first())
-    await _user.type(inputs.first(), "2024-01-15")
-    await _user.keyboard("{Enter}")
+    await user.click(inputs.first())
+    await user.clear(inputs.first())
+    await user.type(inputs.first(), "2024-01-15")
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveValue("January 15, 2024")
@@ -391,7 +233,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles Enter key on range date end input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={{
@@ -404,10 +246,10 @@ describe("<DatePicker />", () => {
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.nth(1))
-    await _user.clear(inputs.nth(1))
-    await _user.type(inputs.nth(1), "2024-01-20")
-    await _user.keyboard("{Enter}")
+    await user.click(inputs.nth(1))
+    await user.clear(inputs.nth(1))
+    await user.type(inputs.nth(1), "2024-01-20")
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
       await expect.element(inputs.nth(1)).toHaveValue("January 20, 2024")
@@ -415,7 +257,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles Backspace key on multiple date input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
@@ -427,7 +269,7 @@ describe("<DatePicker />", () => {
     const input = page.getByRole("textbox").first()
     const inputEl = await input.findElement()
     inputEl.focus()
-    await _user.keyboard("{Backspace}")
+    await user.keyboard("{Backspace}")
 
     await vi.waitFor(async () => {
       await expect
@@ -440,7 +282,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles Backspace key on range date end input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={{
@@ -453,14 +295,12 @@ describe("<DatePicker />", () => {
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.nth(1))
+    await user.click(inputs.nth(1))
 
-    // Clear the end input value first
-    await _user.clear(inputs.nth(1))
-    await _user.click(inputs.nth(1))
-    await _user.keyboard("{Backspace}")
+    await user.clear(inputs.nth(1))
+    await user.click(inputs.nth(1))
+    await user.keyboard("{Backspace}")
 
-    // After backspace on empty end input, should clear both and focus start
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveValue("")
       await expect.element(inputs.nth(1)).toHaveValue("")
@@ -468,7 +308,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles blur on single date", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         openOnChange={false}
         openOnClick={false}
@@ -478,19 +318,18 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "invalid")
-    await _user.tab()
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "invalid")
+    await user.tab()
 
-    // On blur with invalid value, input should be cleared
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("")
     })
   })
 
   test("handles blur on range date resets input value", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -505,24 +344,21 @@ describe("<DatePicker />", () => {
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.first())
+    await user.click(inputs.first())
 
-    // Type a valid date string within range as input
-    await _user.clear(inputs.first())
-    await _user.type(inputs.first(), "2024-01-18")
+    await user.clear(inputs.first())
+    await user.type(inputs.first(), "2024-01-18")
 
-    // Tab twice: start → end → outside field
-    await _user.tab()
-    await _user.tab()
+    await user.tab()
+    await user.tab()
 
-    // On blur, range input should show the formatted date value (clamped within range)
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveValue("January 18, 2024")
     })
   })
 
   test("handles blur on multiple date input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15)]}
         multiple
@@ -536,70 +372,51 @@ describe("<DatePicker />", () => {
     const input = page.getByRole("textbox").first()
     const inputEl = await input.findElement()
     inputEl.focus()
-    await _user.type(input, "something")
-    await _user.tab()
+    await user.type(input, "something")
+    await user.tab()
 
-    // On blur with multiple, input value should be cleared
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("")
     })
   })
 
   test("handles input with pattern", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker pattern={/[^0-9-]/g} placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "abc2024-01-15xyz")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "abc2024-01-15xyz")
 
     await expect.element(input).toHaveValue("2024-01-15")
   })
 
   test("does not allow input when allowInput is false", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker allowInput={false} placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
 
     await expect.element(input).toHaveValue("")
-  })
-
-  test("handles disabled state", async () => {
-    const { user: _user } = await render(
-      <DatePicker disabled placeholder="Select date" />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toBeDisabled()
-  })
-
-  test("handles readOnly state", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Select date" readOnly />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveAttribute("readOnly")
   })
 
   test("handles onChange callback", async () => {
     const onChange = vi.fn()
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select" onChange={onChange} />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(expect.any(Date))
@@ -609,14 +426,14 @@ describe("<DatePicker />", () => {
   test("handles onInputChange callback", async () => {
     const onInputChange = vi.fn()
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker placeholder="Select" onInputChange={onInputChange} />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
 
     await vi.waitFor(() => {
       expect(onInputChange).toHaveBeenCalledWith("2024-01-15")
@@ -624,14 +441,14 @@ describe("<DatePicker />", () => {
   })
 
   test("handles closeOnChange", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker closeOnChange defaultOpen placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
 
     await expect
       .element(page.getByRole("dialog").query())
@@ -639,7 +456,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles closeOnChange as function", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         closeOnChange={(ev) => ev.target.value.length > 5}
         defaultOpen
@@ -649,9 +466,9 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-15")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-15")
 
     await expect
       .element(page.getByRole("dialog").query())
@@ -659,7 +476,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles openOnChange as function", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         openOnChange={(ev) => ev.target.value.length > 1}
         openOnFocus={false}
@@ -668,83 +485,16 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.clear(input)
-    await _user.type(input, "20")
+    await user.clear(input)
+    await user.type(input, "20")
 
     await vi.waitFor(async () => {
       await expect.element(page.getByRole("dialog")).toBeInTheDocument()
     })
   })
 
-  test("handles defaultInputValue", async () => {
-    const { user: _user } = await render(
-      <DatePicker defaultInputValue="2024-01-15" />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveValue("January 15, 2024")
-  })
-
-  test("handles defaultInputValue for range", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultInputValue={{ end: "2024-01-20", start: "2024-01-15" }}
-        range
-      />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    await expect.element(inputs.first()).toHaveValue("January 15, 2024")
-    await expect.element(inputs.nth(1)).toHaveValue("January 20, 2024")
-  })
-
-  test("handles defaultInputValue with invalid date string for range", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultInputValue={{ end: "invalid", start: "invalid" }}
-        range
-      />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    await expect.element(inputs.first()).toHaveValue("invalid")
-    await expect.element(inputs.nth(1)).toHaveValue("invalid")
-  })
-
-  test("handles defaultInputValue with invalid date string for single", async () => {
-    const { user: _user } = await render(
-      <DatePicker defaultInputValue="invalid-date" />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveValue("invalid-date")
-  })
-
-  test("handles format with null input", async () => {
-    const { user: _user } = await render(
-      <DatePicker format={{ input: null }} />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toBeInTheDocument()
-  })
-
-  test("handles custom separator", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
-        multiple
-        separator=";"
-      />,
-    )
-
-    await expect
-      .element(page.getByRole("combobox").first())
-      .toHaveTextContent(";")
-  })
-
   test("handles max for multiple mode", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
         max={2}
@@ -754,15 +504,14 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.clear(input)
-    await _user.type(input, "2024-01-17")
+    await user.clear(input)
+    await user.type(input, "2024-01-17")
 
-    // Should not add more when max is reached
     await expect.element(input).toHaveValue("")
   })
 
   test("handles excludeDate", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         excludeDate={(date) => date.getDay() === 0}
@@ -771,22 +520,20 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
+    await user.click(input)
 
-    // Try to type a Sunday
-    await _user.clear(input)
-    await _user.type(input, "2024-01-07")
-    await _user.click(input)
-    await _user.keyboard("{Enter}")
+    await user.clear(input)
+    await user.type(input, "2024-01-07")
+    await user.click(input)
+    await user.keyboard("{Enter}")
 
-    // The excluded date should not be set
     await expect.element(input).toHaveValue("2024-01-07")
   })
 
   test("handles allowInputBeyond=false with minDate", async () => {
     const minDate = new Date(2024, 0, 10)
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         allowInputBeyond={false}
         defaultOpen
@@ -796,12 +543,11 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-05")
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-05")
+    await user.keyboard("{Enter}")
 
-    // Should clamp to minDate
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("January 10, 2024")
     })
@@ -810,7 +556,7 @@ describe("<DatePicker />", () => {
   test("handles allowInputBeyond=false with maxDate", async () => {
     const maxDate = new Date(2024, 0, 20)
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         allowInputBeyond={false}
         defaultOpen
@@ -820,19 +566,18 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-25")
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-25")
+    await user.keyboard("{Enter}")
 
-    // Should clamp to maxDate
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("January 20, 2024")
     })
   })
 
   test("handles allowInputBeyond=true", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         allowInputBeyond
         defaultOpen
@@ -843,19 +588,18 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-01-05")
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-01-05")
+    await user.keyboard("{Enter}")
 
-    // Should allow dates beyond bounds
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("January 5, 2024")
     })
   })
 
   test("handles Enter key on multiple date input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={[new Date(2024, 0, 15)]}
@@ -867,10 +611,9 @@ describe("<DatePicker />", () => {
     const input = page.getByRole("textbox").first()
     const inputEl = await input.findElement()
     inputEl.focus()
-    await _user.type(input, "2024-01-16")
-    await _user.keyboard("{Enter}")
+    await user.type(input, "2024-01-16")
+    await user.keyboard("{Enter}")
 
-    // Input should be cleared after adding
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("")
     })
@@ -878,7 +621,7 @@ describe("<DatePicker />", () => {
 
   test("handles Enter key on multiple date input keeps already-selected date", async () => {
     const onChange = vi.fn()
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={[new Date(2024, 0, 15)]}
@@ -891,10 +634,9 @@ describe("<DatePicker />", () => {
     const input = page.getByRole("textbox").first()
     const inputEl = await input.findElement()
     inputEl.focus()
-    await _user.type(input, "2024-01-15")
-    await _user.keyboard("{Enter}")
+    await user.type(input, "2024-01-15")
+    await user.keyboard("{Enter}")
 
-    // Input cleared, but the existing date stays in the array (no toggle-off)
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("")
     })
@@ -906,7 +648,7 @@ describe("<DatePicker />", () => {
 
   test("handles Enter key on multiple date input does not remove when max is reached", async () => {
     const onChange = vi.fn()
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
@@ -920,8 +662,8 @@ describe("<DatePicker />", () => {
     const input = page.getByRole("textbox").first()
     const inputEl = await input.findElement()
     inputEl.focus()
-    await _user.type(input, "2024-01-17")
-    await _user.keyboard("{Enter}")
+    await user.type(input, "2024-01-17")
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("")
@@ -939,7 +681,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles onClear with multiple value", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15)]}
         multiple
@@ -948,9 +690,8 @@ describe("<DatePicker />", () => {
     )
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
+    await user.click(icon)
 
-    // After clear, no tags should remain
     await vi.waitFor(async () => {
       await expect
         .element(page.getByText(/January 15, 2024/).query())
@@ -959,7 +700,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles focusOnClear=false", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         focusOnClear={false}
@@ -968,7 +709,7 @@ describe("<DatePicker />", () => {
     )
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
+    await user.click(icon)
 
     await vi.waitFor(async () => {
       const input = page.getByRole("textbox").first()
@@ -977,7 +718,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles focusOnClear with allowInput=false", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         allowInput={false}
         defaultValue={new Date(2024, 0, 15)}
@@ -987,7 +728,7 @@ describe("<DatePicker />", () => {
     )
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
+    await user.click(icon)
 
     await vi.waitFor(async () => {
       const input = page.getByRole("textbox").first()
@@ -996,15 +737,14 @@ describe("<DatePicker />", () => {
   })
 
   test("handles closeOnSelect for single date via calendar click", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" />,
     )
 
     const validDay = page.getByRole("gridcell").first()
 
-    await _user.click(validDay)
+    await user.click(validDay)
 
-    // closeOnSelect defaults to true for single, so dialog should close
     await vi.waitFor(async () => {
       await expect
         .element(page.getByRole("dialog").query())
@@ -1013,7 +753,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles closeOnSelect=false keeps dialog open after calendar click", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         closeOnSelect={false}
         defaultOpen
@@ -1023,14 +763,13 @@ describe("<DatePicker />", () => {
 
     const validDay = page.getByRole("gridcell").first()
 
-    await _user.click(validDay)
+    await user.click(validDay)
 
-    // closeOnSelect is false, so dialog should remain open
     await expect.element(page.getByRole("dialog")).toBeInTheDocument()
   })
 
   test("handles openOnClick=false", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         openOnClick={false}
         openOnFocus={false}
@@ -1039,7 +778,7 @@ describe("<DatePicker />", () => {
     )
 
     const field = page.getByRole("combobox").first()
-    await _user.click(field)
+    await user.click(field)
 
     await expect
       .element(page.getByRole("dialog").query())
@@ -1047,12 +786,12 @@ describe("<DatePicker />", () => {
   })
 
   test("handles onFieldFocus when allowInput is false and openOnFocus is true", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker allowInput={false} openOnFocus placeholder="Select date" />,
     )
 
     const field = page.getByRole("combobox").first()
-    await _user.click(field)
+    await user.click(field)
 
     await vi.waitFor(async () => {
       await expect.element(page.getByRole("dialog")).toBeInTheDocument()
@@ -1065,9 +804,7 @@ describe("<DatePicker />", () => {
     document.addEventListener("mousedown", onMouseDown)
 
     try {
-      const { user: _user } = await render(
-        <DatePicker placeholder="Select date" />,
-      )
+      await render(<DatePicker placeholder="Select date" />)
 
       const field = page.getByRole("combobox").first()
       const fieldEl = await field.findElement()
@@ -1077,7 +814,6 @@ describe("<DatePicker />", () => {
         ),
       ).toBeFalsy()
 
-      // mouseDown should be prevented and stopped
       expect(onMouseDown).not.toHaveBeenCalled()
     } finally {
       document.removeEventListener("mousedown", onMouseDown)
@@ -1085,7 +821,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles clear icon keyboard events", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
@@ -1093,8 +829,8 @@ describe("<DatePicker />", () => {
     )
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
-    await _user.keyboard("{Enter}")
+    await user.click(icon)
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
       const input = page.getByRole("textbox").first()
@@ -1105,7 +841,7 @@ describe("<DatePicker />", () => {
   test("handles clear icon Space key", async () => {
     const onChange = vi.fn()
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={new Date(2024, 0, 15)}
         iconProps={{ "data-testid": "icon" }}
@@ -1114,22 +850,12 @@ describe("<DatePicker />", () => {
     )
 
     const icon = page.getByTestId("icon")
-    await _user.click(icon)
-    await _user.keyboard(" ")
+    await user.click(icon)
+    await user.keyboard(" ")
 
-    // The onClear should have been triggered via Space key
     await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(undefined)
     })
-  })
-
-  test("handles controlled value update", async () => {
-    const { user: _user } = await render(
-      <ControlledDatePicker placeholder="Select date" />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveValue("")
   })
 
   test("handles valueProp update for range", async () => {
@@ -1157,12 +883,12 @@ describe("<DatePicker />", () => {
       )
     }
 
-    const { user: _user } = await render(<RangeControlled />)
+    const { user } = await render(<RangeControlled />)
 
     const inputs = page.getByRole("textbox")
     await expect.element(inputs.first()).toHaveValue("")
 
-    await _user.click(page.getByTestId("set-value"))
+    await user.click(page.getByTestId("set-value"))
 
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveValue("January 15, 2024")
@@ -1187,12 +913,12 @@ describe("<DatePicker />", () => {
       )
     }
 
-    const { user: _user } = await render(<SingleControlled />)
+    const { user } = await render(<SingleControlled />)
 
     const input = page.getByRole("textbox").first()
     await expect.element(input).toHaveValue("")
 
-    await _user.click(page.getByTestId("set-value"))
+    await user.click(page.getByTestId("set-value"))
 
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("January 15, 2024")
@@ -1200,7 +926,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles input change for range with existing start value", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={{
           end: undefined,
@@ -1212,15 +938,15 @@ describe("<DatePicker />", () => {
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.nth(1))
-    await _user.clear(inputs.nth(1))
-    await _user.type(inputs.nth(1), "2024-01-20")
+    await user.click(inputs.nth(1))
+    await user.clear(inputs.nth(1))
+    await user.type(inputs.nth(1), "2024-01-20")
 
     await expect.element(inputs.nth(1)).toHaveValue("2024-01-20")
   })
 
   test("handles input change for range with existing end value", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -1232,28 +958,27 @@ describe("<DatePicker />", () => {
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.first())
-    await _user.clear(inputs.first())
-    await _user.type(inputs.first(), "2024-01-15")
+    await user.click(inputs.first())
+    await user.clear(inputs.first())
+    await user.type(inputs.first(), "2024-01-15")
 
     await expect.element(inputs.first()).toHaveValue("2024-01-15")
   })
 
   test("handles click on range field focuses start input when both empty", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )
 
     const field = page.getByRole("combobox").first()
-    await _user.click(field)
+    await user.click(field)
 
-    // Start input should be focused
     const inputs = page.getByRole("textbox")
     await expect.element(inputs.first()).toHaveFocus()
   })
 
   test("handles click on range field focuses start input when only start is set", async () => {
-    const { user: _user } = await render(
+    await render(
       <DatePicker
         defaultValue={{
           end: undefined,
@@ -1275,7 +1000,7 @@ describe("<DatePicker />", () => {
   })
 
   test("handles click on range field focuses start input when end is set", async () => {
-    const { user: _user } = await render(
+    await render(
       <DatePicker
         defaultValue={{
           end: new Date(2024, 0, 20),
@@ -1296,27 +1021,8 @@ describe("<DatePicker />", () => {
     })
   })
 
-  test("handles custom render for multiple mode", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={[new Date(2024, 0, 15)]}
-        multiple
-        render={({ value, onClear }) => (
-          <button data-testid="custom-tag" onClick={onClear}>
-            {value}
-          </button>
-        )}
-      />,
-    )
-
-    await expect.element(page.getByTestId("custom-tag")).toBeInTheDocument()
-    await expect
-      .element(page.getByTestId("custom-tag"))
-      .toHaveTextContent("January 15, 2024")
-  })
-
   test("handles custom render onClear removes item", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
         multiple
@@ -1329,7 +1035,7 @@ describe("<DatePicker />", () => {
     )
 
     const tag = page.getByTestId("tag-January 15, 2024")
-    await _user.click(tag)
+    await user.click(tag)
 
     await vi.waitFor(async () => {
       await expect
@@ -1354,7 +1060,7 @@ describe("<DatePicker />", () => {
       return undefined
     })
 
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         parseDate={parseDate}
@@ -1363,148 +1069,63 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024/1/15")
-    await _user.click(input)
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024/1/15")
+    await user.click(input)
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(() => {
       expect(parseDate).toHaveBeenCalledWith("2024/1/15")
     })
   })
 
-  test("handles minDate after maxDate correction", async () => {
-    // When minDate > maxDate, maxDate should be set to minDate
-    const { user: _user } = await render(
-      <DatePicker
-        maxDate={new Date(2024, 0, 1)}
-        minDate={new Date(2024, 5, 1)}
-        placeholder="Select date"
-      />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toBeInTheDocument()
-  })
-
-  test("handles defaultValue for range with inputValue", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={{
-          end: new Date(2024, 0, 20),
-          start: new Date(2024, 0, 15),
-        }}
-        range
-      />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    await expect.element(inputs.first()).toHaveValue("January 15, 2024")
-    await expect.element(inputs.nth(1)).toHaveValue("January 20, 2024")
-  })
-
-  test("handles input id and name for range mode", async () => {
-    const { user: _user } = await render(
-      <DatePicker id="test-id" name="test-name" range />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    // When start is empty, start input gets id/name
-    await expect.element(inputs.first()).toHaveAttribute("id", "test-id")
-    await expect.element(inputs.first()).toHaveAttribute("name", "test-name")
-  })
-
-  test("handles input id and name for range mode with start value", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        id="test-id"
-        name="test-name"
-        defaultValue={{
-          end: undefined,
-          start: new Date(2024, 0, 15),
-        }}
-        range
-      />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    // When start has value, end input gets id/name
-    await expect.element(inputs.nth(1)).toHaveAttribute("id", "test-id")
-    await expect.element(inputs.nth(1)).toHaveAttribute("name", "test-name")
-  })
-
   test("handles Enter key on range start input moves focus to end input", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" range />,
     )
 
     const inputs = page.getByRole("textbox")
-    await _user.click(inputs.first())
-    await _user.clear(inputs.first())
-    await _user.type(inputs.first(), "2024-01-15")
-    await _user.keyboard("{Enter}")
+    await user.click(inputs.first())
+    await user.clear(inputs.first())
+    await user.type(inputs.first(), "2024-01-15")
+    await user.keyboard("{Enter}")
 
-    // After entering start date, focus should move to end input
     await vi.waitFor(async () => {
       await expect.element(inputs.nth(1)).toHaveFocus()
     })
   })
 
   test("handles Enter key with invalid date does nothing", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "invalid")
-    await _user.click(input)
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "invalid")
+    await user.click(input)
+    await user.keyboard("{Enter}")
 
-    // Should not update the value for invalid date
     await expect.element(input).toHaveValue("invalid")
   })
 
   test("handles Enter key with empty value does nothing", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.click(input)
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.click(input)
+    await user.keyboard("{Enter}")
 
     await expect.element(input).toHaveValue("")
   })
 
-  test("handles custom placeholder", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Custom placeholder" />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect
-      .element(input)
-      .toHaveAttribute("placeholder", "Custom placeholder")
-  })
-
-  test("handles custom placeholder for range", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Custom" range />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    await expect
-      .element(inputs.first())
-      .toHaveAttribute("placeholder", "Custom")
-    await expect.element(inputs.nth(1)).toHaveAttribute("placeholder", "Custom")
-  })
-
   test("handles Backspace on single date input edits text normally", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={new Date(2024, 0, 15)}
@@ -1513,84 +1134,29 @@ describe("<DatePicker />", () => {
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.keyboard("{Backspace}")
+    await user.click(input)
+    await user.keyboard("{Backspace}")
 
-    // Single date allows normal text editing on Backspace
     await vi.waitFor(async () => {
       await expect.element(input).toHaveValue("January 15, 202")
     })
   })
 
-  test("handles defaultMonth with minDate", async () => {
-    const minDate = new Date(2025, 5, 1)
-
-    const { user: _user } = await render(
-      <DatePicker defaultMonth={new Date(2024, 0, 1)} minDate={minDate} />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toBeInTheDocument()
-  })
-
-  test("handles defaultMonth with valueProp", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultMonth={new Date(2024, 0, 1)}
-        value={new Date(2024, 5, 15)}
-      />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveValue("June 15, 2024")
-  })
-
-  test("handles defaultMonth with defaultValue", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultMonth={new Date(2024, 0, 1)}
-        defaultValue={new Date(2024, 5, 15)}
-      />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toHaveValue("June 15, 2024")
-  })
-
   test("handles input change for multiple with valid date updates month", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen multiple placeholder="Select dates" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
-    await _user.clear(input)
-    await _user.type(input, "2024-06-15")
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, "2024-06-15")
 
-    // The month should be updated
     await expect.element(input).toHaveValue("2024-06-15")
   })
 
-  test("handles range separator", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultValue={{
-          end: new Date(2024, 0, 20),
-          start: new Date(2024, 0, 15),
-        }}
-        range
-        separator="~"
-      />,
-    )
-
-    // Range uses separator between inputs
-    await expect
-      .element(page.getByRole("combobox").first())
-      .toHaveTextContent("~")
-  })
-
   test("handles Enter key on range end input with existing start value", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker
         defaultOpen
         defaultValue={{
@@ -1604,11 +1170,10 @@ describe("<DatePicker />", () => {
 
     const inputs = page.getByRole("textbox")
 
-    // Focus on start and update with minDate constraint from end value
-    await _user.click(inputs.first())
-    await _user.clear(inputs.first())
-    await _user.type(inputs.first(), "2024-01-10")
-    await _user.keyboard("{Enter}")
+    await user.click(inputs.first())
+    await user.clear(inputs.first())
+    await user.type(inputs.first(), "2024-01-10")
+    await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
       await expect.element(inputs.first()).toHaveValue("January 10, 2024")
@@ -1616,20 +1181,18 @@ describe("<DatePicker />", () => {
   })
 
   test("handles input with composing state (IME)", async () => {
-    const { user: _user } = await render(
+    const { user } = await render(
       <DatePicker defaultOpen placeholder="Select date" />,
     )
 
     const input = page.getByRole("textbox").first()
-    await _user.click(input)
+    await user.click(input)
 
-    // Simulate composition
     const inputEl = await input.findElement()
     inputEl.dispatchEvent(new Event("compositionstart", { bubbles: true }))
-    await _user.click(input)
-    await _user.keyboard("{Enter}")
+    await user.click(input)
+    await user.keyboard("{Enter}")
 
-    // Should not process during IME composition
     await expect.element(input).toHaveValue("")
   })
 
@@ -1643,68 +1206,5 @@ describe("<DatePicker />", () => {
     )
 
     await expect.element(input).toHaveValue("")
-  })
-
-  test("handles contentProps", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultOpen
-        contentProps={{ "data-testid": "content" } as any}
-      />,
-    )
-
-    await expect.element(page.getByTestId("content")).toBeInTheDocument()
-  })
-
-  test("handles custom icon", async () => {
-    const { user: _user } = await render(
-      <DatePicker icon={<span data-testid="custom-icon">icon</span>} />,
-    )
-
-    await expect.element(page.getByTestId("custom-icon")).toBeInTheDocument()
-  })
-
-  test("handles animationScheme prop", async () => {
-    const { user: _user } = await render(
-      <DatePicker animationScheme="inline-start" defaultOpen />,
-    )
-
-    await expect.element(page.getByRole("dialog")).toBeInTheDocument()
-  })
-
-  test("handles calendarProps", async () => {
-    const { user: _user } = await render(
-      <DatePicker
-        defaultOpen
-        calendarProps={{ "data-testid": "calendar" } as any}
-      />,
-    )
-
-    await expect.element(page.getByTestId("calendar")).toBeInTheDocument()
-  })
-
-  test("handles duration prop", async () => {
-    const { user: _user } = await render(
-      <DatePicker defaultOpen duration={0} />,
-    )
-
-    await expect.element(page.getByRole("dialog")).toBeInTheDocument()
-  })
-
-  test("handles elementProps", async () => {
-    const { user: _user } = await render(
-      <DatePicker elementProps={{ "data-testid": "element" } as any} />,
-    )
-
-    await expect.element(page.getByTestId("element")).toBeInTheDocument()
-  })
-
-  test("handles required prop", async () => {
-    const { user: _user } = await render(
-      <DatePicker placeholder="Select date" required />,
-    )
-
-    const input = page.getByRole("textbox").first()
-    await expect.element(input).toBeRequired()
   })
 })

--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -1,0 +1,396 @@
+import type { DatePickerProps } from "."
+import { useState } from "react"
+import { a11y, render, screen } from "#test"
+import { DatePicker } from "."
+
+const ControlledDatePicker = ({ defaultValue, ...props }: DatePickerProps) => {
+  const [value, setValue] = useState<Date | undefined>(defaultValue as Date)
+
+  return <DatePicker value={value} onChange={setValue} {...props} />
+}
+
+describe("<DatePicker />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<DatePicker />)
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(DatePicker.displayName).toBe("DatePickerRoot")
+  })
+
+  test("sets `className` correctly", () => {
+    render(
+      <DatePicker
+        defaultOpen
+        placeholder="Choose a option"
+        iconProps={{ "data-testid": "icon" }}
+        rootProps={{ "data-testid": "root" }}
+      />,
+    )
+
+    expect(screen.getByTestId("root")).toHaveClass("ui-date-picker__root")
+    expect(screen.getByTestId("icon")).toHaveClass("ui-date-picker__icon")
+    expect(screen.getAllByRole("combobox")[0]).toHaveClass(
+      "ui-date-picker__field",
+    )
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(
+      <DatePicker
+        defaultOpen
+        placeholder="Choose a option"
+        iconProps={{ "data-testid": "icon" }}
+        rootProps={{ "data-testid": "root" }}
+      />,
+    )
+
+    expect(screen.getByTestId("root").tagName).toBe("DIV")
+    expect(screen.getByTestId("icon").tagName).toBe("DIV")
+    expect(screen.getAllByRole("combobox")[0]?.tagName).toBe("DIV")
+  })
+
+  test("renders with defaultValue", () => {
+    render(<DatePicker defaultValue={new Date(2024, 0, 15)} />)
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("January 15, 2024")
+  })
+
+  test("renders with range mode", () => {
+    render(<DatePicker range rootProps={{ "data-testid": "root" }} />)
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[0]).toBeInTheDocument()
+    expect(inputs[1]).toBeInTheDocument()
+    expect(inputs[2]).toBeUndefined()
+  })
+
+  test("renders with multiple mode", () => {
+    render(<DatePicker multiple placeholder="Select dates" />)
+
+    expect(screen.getAllByRole("textbox")[0]).toBeInTheDocument()
+  })
+
+  test("shows clear icon when value exists", () => {
+    render(
+      <DatePicker
+        defaultValue={new Date(2024, 0, 15)}
+        iconProps={{ "data-testid": "icon" }}
+      />,
+    )
+
+    expect(screen.getByTestId("icon")).toHaveAttribute("role", "button")
+  })
+
+  test("shows calendar icon when no value exists", () => {
+    render(<DatePicker clearable iconProps={{ "data-testid": "icon" }} />)
+
+    expect(screen.getByTestId("icon")).not.toHaveAttribute("role", "button")
+  })
+
+  test("shows clear icon for range value with start only", () => {
+    render(
+      <DatePicker
+        defaultValue={{
+          end: undefined,
+          start: new Date(2024, 0, 15),
+        }}
+        range
+        iconProps={{ "data-testid": "icon" }}
+      />,
+    )
+
+    expect(screen.getByTestId("icon")).toHaveAttribute("role", "button")
+  })
+
+  test("shows clear icon for range value with end only", () => {
+    render(
+      <DatePicker
+        defaultValue={{
+          end: new Date(2024, 0, 20),
+          start: undefined,
+        }}
+        range
+        iconProps={{ "data-testid": "icon" }}
+      />,
+    )
+
+    expect(screen.getByTestId("icon")).toHaveAttribute("role", "button")
+  })
+
+  test("renders with clearable=false", () => {
+    render(
+      <DatePicker
+        clearable={false}
+        defaultValue={new Date(2024, 0, 15)}
+        iconProps={{ "data-testid": "icon" }}
+      />,
+    )
+
+    expect(screen.getByTestId("icon")).not.toHaveAttribute("role", "button")
+  })
+
+  test("handles disabled state", () => {
+    render(<DatePicker disabled placeholder="Select date" />)
+
+    expect(screen.getAllByRole("textbox")[0]).toBeDisabled()
+  })
+
+  test("handles readOnly state", () => {
+    render(<DatePicker placeholder="Select date" readOnly />)
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveAttribute("readOnly")
+  })
+
+  test("handles defaultInputValue", () => {
+    render(<DatePicker defaultInputValue="2024-01-15" />)
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("January 15, 2024")
+  })
+
+  test("handles defaultInputValue for range", () => {
+    render(
+      <DatePicker
+        defaultInputValue={{ end: "2024-01-20", start: "2024-01-15" }}
+        range
+      />,
+    )
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[0]).toHaveValue("January 15, 2024")
+    expect(inputs[1]).toHaveValue("January 20, 2024")
+  })
+
+  test("handles defaultInputValue with invalid date string for range", () => {
+    render(
+      <DatePicker
+        defaultInputValue={{ end: "invalid", start: "invalid" }}
+        range
+      />,
+    )
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[0]).toHaveValue("invalid")
+    expect(inputs[1]).toHaveValue("invalid")
+  })
+
+  test("handles defaultInputValue with invalid date string for single", () => {
+    render(<DatePicker defaultInputValue="invalid-date" />)
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("invalid-date")
+  })
+
+  test("handles format with null input", () => {
+    render(<DatePicker format={{ input: null }} />)
+
+    expect(screen.getAllByRole("textbox")[0]).toBeInTheDocument()
+  })
+
+  test("handles custom separator", () => {
+    render(
+      <DatePicker
+        defaultValue={[new Date(2024, 0, 15), new Date(2024, 0, 16)]}
+        multiple
+        separator=";"
+      />,
+    )
+
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent(";")
+  })
+
+  test("handles defaultValue for range with inputValue", () => {
+    render(
+      <DatePicker
+        defaultValue={{
+          end: new Date(2024, 0, 20),
+          start: new Date(2024, 0, 15),
+        }}
+        range
+      />,
+    )
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[0]).toHaveValue("January 15, 2024")
+    expect(inputs[1]).toHaveValue("January 20, 2024")
+  })
+
+  test("handles custom render for multiple mode", () => {
+    render(
+      <DatePicker
+        defaultValue={[new Date(2024, 0, 15)]}
+        multiple
+        render={({ value, onClear }) => (
+          <button data-testid="custom-tag" onClick={onClear}>
+            {value}
+          </button>
+        )}
+      />,
+    )
+
+    expect(screen.getByTestId("custom-tag")).toBeInTheDocument()
+    expect(screen.getByTestId("custom-tag")).toHaveTextContent(
+      "January 15, 2024",
+    )
+  })
+
+  test("handles minDate after maxDate correction", () => {
+    render(
+      <DatePicker
+        maxDate={new Date(2024, 0, 1)}
+        minDate={new Date(2024, 5, 1)}
+        placeholder="Select date"
+      />,
+    )
+
+    expect(screen.getAllByRole("textbox")[0]).toBeInTheDocument()
+  })
+
+  test("handles input id and name for range mode", () => {
+    render(<DatePicker id="test-id" name="test-name" range />)
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[0]).toHaveAttribute("id", "test-id")
+    expect(inputs[0]).toHaveAttribute("name", "test-name")
+  })
+
+  test("handles input id and name for range mode with start value", () => {
+    render(
+      <DatePicker
+        id="test-id"
+        name="test-name"
+        defaultValue={{
+          end: undefined,
+          start: new Date(2024, 0, 15),
+        }}
+        range
+      />,
+    )
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[1]).toHaveAttribute("id", "test-id")
+    expect(inputs[1]).toHaveAttribute("name", "test-name")
+  })
+
+  test("handles custom placeholder", () => {
+    render(<DatePicker placeholder="Custom placeholder" />)
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveAttribute(
+      "placeholder",
+      "Custom placeholder",
+    )
+  })
+
+  test("handles custom placeholder for range", () => {
+    render(<DatePicker placeholder="Custom" range />)
+
+    const inputs = screen.getAllByRole("textbox")
+    expect(inputs[0]).toHaveAttribute("placeholder", "Custom")
+    expect(inputs[1]).toHaveAttribute("placeholder", "Custom")
+  })
+
+  test("handles defaultMonth with minDate", () => {
+    render(
+      <DatePicker
+        defaultMonth={new Date(2024, 0, 1)}
+        minDate={new Date(2025, 5, 1)}
+      />,
+    )
+
+    expect(screen.getAllByRole("textbox")[0]).toBeInTheDocument()
+  })
+
+  test("handles defaultMonth with valueProp", () => {
+    render(
+      <DatePicker
+        defaultMonth={new Date(2024, 0, 1)}
+        value={new Date(2024, 5, 15)}
+      />,
+    )
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("June 15, 2024")
+  })
+
+  test("handles defaultMonth with defaultValue", () => {
+    render(
+      <DatePicker
+        defaultMonth={new Date(2024, 0, 1)}
+        defaultValue={new Date(2024, 5, 15)}
+      />,
+    )
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("June 15, 2024")
+  })
+
+  test("handles range separator", () => {
+    render(
+      <DatePicker
+        defaultValue={{
+          end: new Date(2024, 0, 20),
+          start: new Date(2024, 0, 15),
+        }}
+        range
+        separator="~"
+      />,
+    )
+
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("~")
+  })
+
+  test("handles contentProps", () => {
+    render(
+      <DatePicker
+        defaultOpen
+        contentProps={{ "data-testid": "content" } as any}
+      />,
+    )
+
+    expect(screen.getByTestId("content")).toBeInTheDocument()
+  })
+
+  test("handles custom icon", () => {
+    render(<DatePicker icon={<span data-testid="custom-icon">icon</span>} />)
+
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument()
+  })
+
+  test("handles animationScheme prop", () => {
+    render(<DatePicker animationScheme="inline-start" defaultOpen />)
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  test("handles calendarProps", () => {
+    render(
+      <DatePicker
+        defaultOpen
+        calendarProps={{ "data-testid": "calendar" } as any}
+      />,
+    )
+
+    expect(screen.getByTestId("calendar")).toBeInTheDocument()
+  })
+
+  test("handles duration prop", () => {
+    render(<DatePicker defaultOpen duration={0} />)
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  test("handles elementProps", () => {
+    render(<DatePicker elementProps={{ "data-testid": "element" } as any} />)
+
+    expect(screen.getByTestId("element")).toBeInTheDocument()
+  })
+
+  test("handles required prop", () => {
+    render(<DatePicker placeholder="Select date" required />)
+
+    expect(screen.getAllByRole("textbox")[0]).toBeRequired()
+  })
+
+  test("handles controlled value update", () => {
+    render(<ControlledDatePicker placeholder="Select date" />)
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("")
+  })
+})


### PR DESCRIPTION
Closes #7187

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize and consolidate the browser tests in `packages/react/src/components/date-picker` according to the rule introduced in #7139.

## Current behavior (updates)

`date-picker.test.browser.tsx` contained 100 tests, all running in chromium / firefox / webkit. The majority were jsdom-friendly: pure render assertions, attribute / class / role / placeholder checks, default-value rendering, popover content reachability via `defaultOpen`, and the `a11y(...)` axe pass. Only tests that relied on real focus, full event sequences (`pointerdown`/`mousedown`/`focus`/`pointerup`/`mouseup`/`click`), real keyboard input, IME composition, real blur, or `dispatchEvent`-driven keyboard / mouse cancellability needed a real browser engine.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md). Per the rule, `a11y(...)` defaults to `#test` (jsdom).

**jsdom (`date-picker.test.tsx`, `#test`) — 39 tests**

- `a11y` pass + `displayName`
- Class / tag / role / placeholder / id / name / required / readOnly / disabled attribute checks
- `defaultValue`, `defaultInputValue` (range, multiple, invalid, format=null) rendering
- Range / multiple mode rendering, separator text content, custom render output
- Clear-icon `role="button"` toggling on `clearable` × value combinations
- `defaultOpen`-driven content rendering (`contentProps`, `calendarProps`, `elementProps`, `animationScheme`, `duration`)
- Custom icon, custom placeholder, `defaultMonth` x value combinations, `minDate > maxDate` correction, `format={{ input: null }}`
- Controlled value baseline render

**browser (`date-picker.test.browser.tsx`, `#test/browser`) — 61 tests**

Tests that exercise behavior the five-axis checklist marks as browser-only:

- Real `user.click` / `user.type` / `user.keyboard` / `user.tab` / `user.clear` driven flows: open-on-click, open-on-focus, range field click → focus, input change, Enter / Backspace / Space, blur, range input migration, clamping with `allowInputBeyond`, `excludeDate`, `pattern`, `parseDate`, multi-date Enter / max enforcement, controlled value swap via `setValue`, custom-render `onClear` removal, `closeOnChange` / `openOnChange` / `closeOnSelect` callbacks, `focusOnClear` variants, clear icon keyboard activation, props merging with real click flow.
- `toHaveFocus()` assertions tied to real `focus` movement.
- IME composition (`compositionstart` + Enter) and the `mousedown` cancellability check (`fieldEl.dispatchEvent(...)` returning `false`).

## Removed tests

None. Re-categorization only — no test deleted by inspection.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/date-picker/` — 39 tests pass.
- `pnpm react test:browser --run src/components/date-picker/` — 61 tests × 3 engines = 183 tests pass.
- `pnpm react lint` — no `#test` / `#test/browser` boundary violations.

### Coverage delta (per source file, baseline = chromium-only before this change)

Coverage was captured per the issue: `pnpm react test:coverage:jsdom --coverage.include='src/components/date-picker/**' src/components/date-picker/` and the chromium equivalent.

Baseline (chromium istanbul) and final combined (covered in either project, mapped onto the chromium-tracked stmt-start lines / stmts / fns / branches):

| File | Baseline lines | Final combined lines | Baseline stmts | Final combined stmts | Baseline fns | Final combined fns | Baseline branches | Final combined branches |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `date-picker.style.ts` | 1/1 | 1/1 | 1/1 | 1/1 | 0/0 | 0/0 | 0/0 | 0/0 |
| `date-picker.tsx` | 31/31 | 31/31 | 31/31 | 31/31 | 9/9 | 9/9 | 24/24 | 24/24 |
| `use-date-picker.tsx` | 255/261 | 255/261 | 276/292 | 292/292 | 42/43 | 42/43 | 276/305 | 277/305 |

Per-source-file combined coverage is at or above baseline on every metric, and the six baseline-uncovered lines (`435`, `461`, `463`, `474`, `765`, `984`) remain the only uncovered lines.

Sub-issue of #7141.