### PR TITLE
test(float): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/float/float.test.browser.tsx
+++ b/packages/react/src/components/float/float.test.browser.tsx
@@ -1,32 +1,7 @@
-import { a11y, page, render } from "#test/browser"
-import { Box } from "../box"
+import { page, render } from "#test/browser"
 import { Float } from "./"
 
 describe("<Float />", () => {
-  test("renders component correctly", async () => {
-    await a11y(
-      <Box position="relative">
-        <Float>New</Float>
-      </Box>,
-    )
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(Float.displayName).toBe("Float")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(<Float>Float</Float>)
-
-    await expect.element(page.getByText("Float")).toHaveClass("ui-float")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(<Float>Float</Float>)
-
-    expect(page.getByText("Float").element().tagName).toBe("DIV")
-  })
-
   test("applies to both block and inline given a single offset", async () => {
     await render(<Float offset="2">Float</Float>)
 

--- a/packages/react/src/components/float/float.test.tsx
+++ b/packages/react/src/components/float/float.test.tsx
@@ -1,0 +1,13 @@
+import { a11y } from "#test"
+import { Box } from "../box"
+import { Float } from "./"
+
+describe("<Float />", () => {
+  test("renders component correctly", async () => {
+    await a11y(
+      <Box position="relative">
+        <Float>New</Float>
+      </Box>,
+    )
+  })
+})


### PR DESCRIPTION
Closes #7200

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/float` according to the rule introduced in #7139.

## Current behavior (updates)

One `*.test.browser.tsx` file lived under `packages/react/src/components/float/`:

- `float.test.browser.tsx` — 7 tests. Three of those (`getComputedStyle` assertions on `--offset-block` / `--offset-inline`) need a real browser; the rest (`a11y`, `displayName`, `className`, HTML tag) are jsdom-friendly.

Several of these tests did not contribute to coverage (pure metadata reads such as `Float.displayName`, repeated render assertions covered by sibling cases, and the bare HTML-tag assertion).

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md). `a11y(...)` is run from `#test` (jsdom) per the rule.

**jsdom (`#test`)**

- `float.test.tsx` — 1 test (a11y)

**browser (`#test/browser`)**

- `float.test.browser.tsx` — 3 tests (single `offset`, array `offset`, empty `offset`) all using `getComputedStyle`

Removed tests that did not contribute to coverage:

- `sets displayName correctly` (no rendering, pure metadata read)
- `renders HTML tag correctly` (same render path as `sets className correctly`)
- `sets className correctly` (covered by sibling assertions in the same render tree)

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/float/` — 1 test passes
- `pnpm react test:browser --run src/components/float/` — 3 tests x 3 engines pass (9 total)
- `pnpm react lint` passes

Coverage on `packages/react/src/components/float/`:

| Project  | Phase    | Statements    | Branches    | Functions   | Lines         |
| -------- | -------- | ------------- | ----------- | ----------- | ------------- |
| jsdom    | Baseline | 0% (0/6)      | 0% (0/2)    | 0% (0/1)    | 0% (0/6)      |
| jsdom    | Final    | 100% (6/6)    | 50% (1/2)   | 100% (1/1)  | 100% (6/6)    |
| chromium | Baseline | 100% (5/5)    | 100% (2/2)  | 100% (1/1)  | 100% (5/5)    |
| chromium | Final    | 100% (5/5)    | 100% (2/2)  | 100% (1/1)  | 100% (5/5)    |

Combined per-source-file coverage stays at 100% across all four axes (the missing `isArray=true` branch in jsdom is covered by the `offset={["2", "4"]}` browser test).

Sub-issue of #7141.