### PR TITLE
test(for): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/for/for.test.tsx
+++ b/packages/react/src/components/for/for.test.tsx
@@ -1,8 +1,8 @@
-import { a11y, page, render } from "#test/browser"
+import { a11y, render, screen } from "#test"
 import { For } from "."
 
 describe("<For />", () => {
-  test("renders component correctly", async () => {
+  test("passes a11y checks", async () => {
     await a11y(
       <For each={["One", "Two", "Three"]}>
         {(item, index) => <div key={index}>{item}</div>}
@@ -10,35 +10,27 @@ describe("<For />", () => {
     )
   })
 
-  test("sets `displayName` correctly", () => {
-    expect(For.name).toBe("For")
-  })
-
-  test("For renders fallback when array is empty", async () => {
-    await render(
+  test("renders fallback when array is empty", () => {
+    render(
       <For each={[]} fallback={<p>There are no items to show</p>}>
         {(item, index) => <p key={index}>{item}</p>}
       </For>,
     )
-    await expect
-      .element(page.getByText("There are no items to show"))
-      .toBeInTheDocument()
+    expect(screen.getByText("There are no items to show")).toBeInTheDocument()
   })
 
-  test("For renders fallback when array is undefined", async () => {
-    await render(
+  test("renders fallback when array is undefined", () => {
+    render(
       <For each={undefined} fallback={<p>There are no items to show</p>}>
         {(_, index) => <p key={index}>Item</p>}
       </For>,
     )
-    await expect
-      .element(page.getByText("There are no items to show"))
-      .toBeInTheDocument()
+    expect(screen.getByText("There are no items to show")).toBeInTheDocument()
   })
 
-  test("For correctly passes index to children", async () => {
+  test("passes index to children", () => {
     const each = [0, 1, 2, 3, 4]
-    await render(
+    render(
       <For each={each}>
         {(item, index) => {
           expect(item).toBe(index)
@@ -48,44 +40,42 @@ describe("<For />", () => {
     )
   })
 
-  test("For renders correctly with filter", async () => {
-    await render(
+  test("renders correctly with filter", () => {
+    render(
       <For each={["One", "Two", "Three"]} filter={(item) => item !== "Two"}>
         {(item, index) => <p key={index}>{item}</p>}
       </For>,
     )
-    await expect.element(page.getByText("One")).toBeInTheDocument()
-    await expect.element(page.getByText("Three")).toBeInTheDocument()
-    await expect.element(page.getByText("Two").query()).not.toBeInTheDocument()
+    expect(screen.getByText("One")).toBeInTheDocument()
+    expect(screen.getByText("Three")).toBeInTheDocument()
+    expect(screen.queryByText("Two")).not.toBeInTheDocument()
   })
 
-  test("For renders correctly with limit", async () => {
-    await render(
+  test("renders correctly with limit", () => {
+    render(
       <For each={["One", "Two", "Three"]} limit={2}>
         {(item, index) => <div key={index}>{item}</div>}
       </For>,
     )
-    await expect.element(page.getByText("One")).toBeInTheDocument()
-    await expect.element(page.getByText("Two")).toBeInTheDocument()
-    await expect
-      .element(page.getByText("Three").query())
-      .not.toBeInTheDocument()
+    expect(screen.getByText("One")).toBeInTheDocument()
+    expect(screen.getByText("Two")).toBeInTheDocument()
+    expect(screen.queryByText("Three")).not.toBeInTheDocument()
   })
 
-  test("For renders correctly with offset", async () => {
-    await render(
+  test("renders correctly with offset", () => {
+    render(
       <For each={["One", "Two", "Three"]} offset={1}>
         {(item, index) => <div key={index}>{item}</div>}
       </For>,
     )
-    await expect.element(page.getByText("Two")).toBeInTheDocument()
-    await expect.element(page.getByText("Three")).toBeInTheDocument()
-    await expect.element(page.getByText("One").query()).not.toBeInTheDocument()
+    expect(screen.getByText("Two")).toBeInTheDocument()
+    expect(screen.getByText("Three")).toBeInTheDocument()
+    expect(screen.queryByText("One")).not.toBeInTheDocument()
   })
 
-  test("For renders correctly with reverse", async () => {
-    let indexes: number[] = []
-    await render(
+  test("renders correctly with reverse", () => {
+    const indexes: number[] = []
+    render(
       <For each={["One", "Two", "Three"]} reverse>
         {(item, index) => {
           indexes.push(index)
@@ -97,16 +87,13 @@ describe("<For />", () => {
         }}
       </For>,
     )
-    const items = page
-      .getByTestId("for")
-      .elements()
-      .map((el) => el.textContent)
+    const items = screen.getAllByTestId("for").map((el) => el.textContent)
     expect(items).toStrictEqual(["Three", "Two", "One"])
     expect(indexes).toStrictEqual([0, 1, 2])
   })
 
-  test("For renders correctly with sort", async () => {
-    await render(
+  test("renders correctly with sort", () => {
+    render(
       <For each={["One", "Two", "Three"]} sort={(a, b) => a.localeCompare(b)}>
         {(item, index) => (
           <div key={index} data-testid="for">
@@ -115,15 +102,12 @@ describe("<For />", () => {
         )}
       </For>,
     )
-    const items = page
-      .getByTestId("for")
-      .elements()
-      .map((el) => el.textContent)
+    const items = screen.getAllByTestId("for").map((el) => el.textContent)
     expect(items).toStrictEqual(["One", "Three", "Two"])
   })
 
-  test("For renders correctly with combined options", async () => {
-    await render(
+  test("renders correctly with combined options", () => {
+    render(
       <For
         each={["One", "Two", "Three", "Four"]}
         filter={(item) => item !== "Two"}
@@ -139,9 +123,8 @@ describe("<For />", () => {
         )}
       </For>,
     )
-    const items = page
-      .getByTestId("for-combined-item")
-      .elements()
+    const items = screen
+      .getAllByTestId("for-combined-item")
       .map((el) => el.textContent)
     expect(items).toStrictEqual(["One", "Four"])
   })


### PR DESCRIPTION
Closes #7202

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/for` according to the rule introduced in #7139.

## Current behavior (updates)

One `*.test.browser.tsx` file lived under `packages/react/src/components/for/`:

- `for.test.browser.tsx` — 11 tests. The `For` component is pure logic (it iterates an array and renders children) and never reads the DOM, handles events, uses observers, manipulates focus, or calls a browser API. Every assertion is either an `a11y` axe pass, a render-then-text-content read, or a metadata read.

The `sets displayName correctly` test did not contribute to coverage (pure metadata read on `For.name`, no rendering).

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md). Because nothing in `For` requires a real browser, every remaining test moved to jsdom and the browser file was deleted.

**jsdom (`#test`)**

- `for.test.tsx` — 10 tests
  - passes a11y checks
  - renders fallback when array is empty
  - renders fallback when array is undefined
  - passes index to children
  - renders correctly with filter
  - renders correctly with limit
  - renders correctly with offset
  - renders correctly with reverse
  - renders correctly with sort
  - renders correctly with combined options

**browser (`#test/browser`)**

- `for.test.browser.tsx` is removed because no browser-only assertion remained.

Removed tests that did not contribute to coverage:

- `sets displayName correctly` (no rendering, pure metadata read on `For.name`)

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/for/` — 10 tests pass
- `pnpm react test:browser --run src/components/for/` — no test files found (every test is jsdom-friendly and the browser file was deleted)
- `pnpm react lint` — passes (no `#test` ↔ `#test/browser` boundary violations)

Coverage on `packages/react/src/components/for/` (combined = covered in either project):

| Metric     | Baseline (chromium) | Final (jsdom) | Delta |
| ---------- | ------------------- | ------------- | ----- |
| Statements | 90.9% (10/11)       | 90.9% (10/11) | 0     |
| Branches   | 80.95% (17/21)      | 80.95% (17/21)| 0     |
| Functions  | 100% (1/1)          | 100% (1/1)    | 0     |
| Lines      | 100% (9/9)          | 100% (9/9)    | 0     |

Uncovered lines (60, 68 — `return fallback || null` paths) are unchanged from baseline.

Sub-issue of #7141.