### PR TITLE
test(menu): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/menu/menu.test.browser.tsx
+++ b/packages/react/src/components/menu/menu.test.browser.tsx
@@ -2,9 +2,10 @@ import type { ReactNode } from "react"
 import type { UseMenuGroupProps, UseMenuItemProps } from "./use-menu"
 import { fireEvent, screen, waitFor } from "@testing-library/react"
 import { useState } from "react"
-import { render } from "#test/browser"
+import { a11y, render } from "#test/browser"
 import { Button } from "../button"
 import { Menu } from "./"
+import { fullItems } from "./menu.test.fixtures"
 import { useMenuGroup, useMenuItem } from "./use-menu"
 
 interface TestMenuGroupProps extends UseMenuGroupProps {
@@ -39,45 +40,19 @@ const TestMenuItem = ({
   return <div {...getProps(getItemProps)}>{children}</div>
 }
 
-const items: Menu.Item[] = [
-  { label: "Menu 1", value: "menu-1" },
-  { label: "Menu 2", value: "menu-2" },
-  { label: "Menu 3", value: "menu-3" },
-  { type: "separator" },
-  {
-    items: [
-      { label: "Menu 4", value: "menu-4" },
-      { label: "Menu 5", value: "menu-5" },
-      { label: "Menu 6", value: "menu-6" },
-    ],
-    label: "Group",
-    labelProps: { "data-testid": "label" },
-  },
-]
-
-const itemsWithRadioGroup: Menu.Item[] = [
-  {
-    type: "radio",
-    items: [
-      { label: "Option 1", value: "option-1" },
-      { label: "Option 2", value: "option-2" },
-      { label: "Option 3", value: "option-3" },
-    ],
-  },
-]
-
-const itemsWithCheckboxGroup: Menu.Item[] = [
-  {
-    type: "checkbox",
-    items: [
-      { label: "Option 1", value: "option-1" },
-      { label: "Option 2", value: "option-2" },
-      { label: "Option 3", value: "option-3" },
-    ],
-  },
-]
-
 describe("<Menu />", () => {
+  test("passes a11y checks when open", async () => {
+    await a11y(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <Button>Menu</Button>
+        </Menu.Trigger>
+
+        <Menu.Content items={fullItems} />
+      </Menu.Root>,
+    )
+  })
+
   test("renders full items config with separator, radio, checkbox, and group", async () => {
     await render(
       <Menu.Root defaultOpen>
@@ -85,15 +60,7 @@ describe("<Menu />", () => {
           <Button>Menu</Button>
         </Menu.Trigger>
 
-        <Menu.Content
-          items={[
-            ...items,
-            { type: "separator" },
-            ...itemsWithRadioGroup,
-            { type: "separator" },
-            ...itemsWithCheckboxGroup,
-          ]}
-        />
+        <Menu.Content items={fullItems} />
       </Menu.Root>,
     )
 

--- a/packages/react/src/components/menu/menu.test.browser.tsx
+++ b/packages/react/src/components/menu/menu.test.browser.tsx
@@ -2,10 +2,42 @@ import type { ReactNode } from "react"
 import type { UseMenuGroupProps, UseMenuItemProps } from "./use-menu"
 import { fireEvent, screen, waitFor } from "@testing-library/react"
 import { useState } from "react"
-import { a11y, render } from "#test/browser"
+import { render } from "#test/browser"
 import { Button } from "../button"
 import { Menu } from "./"
 import { useMenuGroup, useMenuItem } from "./use-menu"
+
+interface TestMenuGroupProps extends UseMenuGroupProps {
+  children?: ReactNode
+  getGroupProps?: Parameters<
+    ReturnType<typeof useMenuGroup>["getGroupProps"]
+  >[0]
+}
+
+const TestMenuGroup = ({
+  children,
+  getGroupProps,
+  ...props
+}: TestMenuGroupProps) => {
+  const { getGroupProps: getProps } = useMenuGroup(props)
+
+  return <div {...getProps(getGroupProps)}>{children}</div>
+}
+
+interface TestMenuItemProps extends UseMenuItemProps {
+  children?: ReactNode
+  getItemProps?: Parameters<ReturnType<typeof useMenuItem>["getItemProps"]>[0]
+}
+
+const TestMenuItem = ({
+  children,
+  getItemProps,
+  ...props
+}: TestMenuItemProps) => {
+  const { getItemProps: getProps } = useMenuItem(props)
+
+  return <div {...getProps(getItemProps)}>{children}</div>
+}
 
 const items: Menu.Item[] = [
   { label: "Menu 1", value: "menu-1" },
@@ -45,76 +77,8 @@ const itemsWithCheckboxGroup: Menu.Item[] = [
   },
 ]
 
-interface TestMenuGroupProps extends UseMenuGroupProps {
-  children?: ReactNode
-  getGroupProps?: Parameters<
-    ReturnType<typeof useMenuGroup>["getGroupProps"]
-  >[0]
-}
-
-const TestMenuGroup = ({
-  children,
-  getGroupProps,
-  ...props
-}: TestMenuGroupProps) => {
-  const { getGroupProps: getProps } = useMenuGroup(props)
-
-  return <div {...getProps(getGroupProps)}>{children}</div>
-}
-
-interface TestMenuItemProps extends UseMenuItemProps {
-  children?: ReactNode
-  getItemProps?: Parameters<ReturnType<typeof useMenuItem>["getItemProps"]>[0]
-}
-
-const TestMenuItem = ({
-  children,
-  getItemProps,
-  ...props
-}: TestMenuItemProps) => {
-  const { getItemProps: getProps } = useMenuItem(props)
-
-  return <div {...getProps(getItemProps)}>{children}</div>
-}
-
 describe("<Menu />", () => {
-  test("renders component correctly", async () => {
-    await a11y(
-      <Menu.Root defaultOpen>
-        <Menu.Trigger>
-          <Button>Menu</Button>
-        </Menu.Trigger>
-
-        <Menu.Content
-          items={[
-            ...items,
-            { type: "separator" },
-            ...itemsWithRadioGroup,
-            { type: "separator" },
-            ...itemsWithCheckboxGroup,
-          ]}
-        />
-      </Menu.Root>,
-    )
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(Menu.Root.name).toBe("MenuRoot")
-    expect(Menu.Trigger.displayName).toBe("MenuTrigger")
-    expect(Menu.ContextTrigger.displayName).toBe("MenuContextTrigger")
-    expect(Menu.Anchor.displayName).toBe("MenuAnchor")
-    expect(Menu.Content.displayName).toBe("MenuContent")
-    expect(Menu.Label.displayName).toBe("MenuLabel")
-    expect(Menu.Item.displayName).toBe("MenuItem")
-    expect(Menu.Separator.displayName).toBe("MenuSeparator")
-    expect(Menu.Group.displayName).toBe("MenuGroup")
-    expect(Menu.OptionGroup.displayName).toBe("MenuOptionGroup")
-    expect(Menu.OptionItem.displayName).toBe("MenuOptionItem")
-    expect(Menu.Indicator.displayName).toBe("MenuIndicator")
-    expect(Menu.Command.displayName).toBe("MenuCommand")
-  })
-
-  test("sets `className` correctly", async () => {
+  test("renders full items config with separator, radio, checkbox, and group", async () => {
     await render(
       <Menu.Root defaultOpen>
         <Menu.Trigger>
@@ -132,27 +96,18 @@ describe("<Menu />", () => {
         />
       </Menu.Root>,
     )
-    expect(screen.getByRole("button", { name: /Menu/i })).toHaveClass(
-      "ui-menu__trigger",
-    )
-    expect(screen.getByRole("menu")).toHaveClass("ui-menu__content")
-    expect(screen.getByRole("menuitem", { name: /Menu 1/i })).toHaveClass(
-      "ui-menu__item",
-    )
-    expect(screen.getAllByRole("separator")[0]).toHaveClass(
-      "ui-menu__separator",
-    )
-    expect(screen.getByTestId("label")).toHaveClass("ui-menu__label")
-    expect(screen.getAllByRole("group")[0]).toHaveClass("ui-menu__group")
-    expect(screen.getAllByRole("group")[1]).toHaveClass(
-      "ui-menu__group--option",
-    )
+
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    expect(
+      screen.getByRole("menuitem", { name: /Menu 1/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("label")).toBeInTheDocument()
     expect(
       screen.getByRole("menuitemradio", { name: /Option 1/i }),
-    ).toHaveClass("ui-menu__item--option")
+    ).toBeInTheDocument()
     expect(
       screen.getByRole("menuitemcheckbox", { name: /Option 1/i }),
-    ).toHaveClass("ui-menu__item--option")
+    ).toBeInTheDocument()
   })
 
   test("merges consumer props in Menu.Item", async () => {
@@ -340,41 +295,6 @@ describe("<Menu />", () => {
     expect(calls).toStrictEqual(["getter", "consumer", "internal"])
     expect(onChange).toHaveBeenCalledWith(["opt-1"])
     expect(onSelect).toHaveBeenCalledWith("opt-1")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(
-      <Menu.Root defaultOpen>
-        <Menu.Trigger>
-          <Button>Menu</Button>
-        </Menu.Trigger>
-
-        <Menu.Content
-          items={[
-            ...items,
-            { type: "separator" },
-            ...itemsWithRadioGroup,
-            { type: "separator" },
-            ...itemsWithCheckboxGroup,
-          ]}
-        />
-      </Menu.Root>,
-    )
-    expect(screen.getByRole("button", { name: /Menu/i }).tagName).toBe("BUTTON")
-    expect(screen.getByRole("menu").tagName).toBe("DIV")
-    expect(screen.getByRole("menuitem", { name: /Menu 1/i }).tagName).toBe(
-      "DIV",
-    )
-    expect(screen.getAllByRole("separator")[0]?.tagName).toBe("HR")
-    expect(screen.getByTestId("label").tagName).toBe("SPAN")
-    expect(screen.getAllByRole("group")[0]?.tagName).toBe("DIV")
-    expect(screen.getAllByRole("group")[1]?.tagName).toBe("DIV")
-    expect(
-      screen.getByRole("menuitemradio", { name: /Option 1/i }).tagName,
-    ).toBe("DIV")
-    expect(
-      screen.getByRole("menuitemcheckbox", { name: /Option 1/i }).tagName,
-    ).toBe("DIV")
   })
 
   test("opens menu on trigger click", async () => {

--- a/packages/react/src/components/menu/menu.test.fixtures.ts
+++ b/packages/react/src/components/menu/menu.test.fixtures.ts
@@ -1,0 +1,47 @@
+import type { Menu } from "./"
+
+export const items: Menu.Item[] = [
+  { label: "Menu 1", value: "menu-1" },
+  { label: "Menu 2", value: "menu-2" },
+  { label: "Menu 3", value: "menu-3" },
+  { type: "separator" },
+  {
+    items: [
+      { label: "Menu 4", value: "menu-4" },
+      { label: "Menu 5", value: "menu-5" },
+      { label: "Menu 6", value: "menu-6" },
+    ],
+    label: "Group",
+    labelProps: { "data-testid": "label" },
+  },
+]
+
+export const itemsWithRadioGroup: Menu.Item[] = [
+  {
+    type: "radio",
+    items: [
+      { label: "Option 1", value: "option-1" },
+      { label: "Option 2", value: "option-2" },
+      { label: "Option 3", value: "option-3" },
+    ],
+  },
+]
+
+export const itemsWithCheckboxGroup: Menu.Item[] = [
+  {
+    type: "checkbox",
+    items: [
+      { label: "Option 1", value: "option-1" },
+      { label: "Option 2", value: "option-2" },
+      { label: "Option 3", value: "option-3" },
+    ],
+  },
+]
+
+export const fullItems: Menu.Item[] = [
+  ...items,
+  { type: "separator" },
+  ...itemsWithRadioGroup,
+  { type: "separator" },
+  ...itemsWithCheckboxGroup,
+]

--- a/packages/react/src/components/menu/menu.test.tsx
+++ b/packages/react/src/components/menu/menu.test.tsx
@@ -1,0 +1,63 @@
+import { a11y } from "#test"
+import { Button } from "../button"
+import { Menu } from "./"
+
+const items: Menu.Item[] = [
+  { label: "Menu 1", value: "menu-1" },
+  { label: "Menu 2", value: "menu-2" },
+  { label: "Menu 3", value: "menu-3" },
+  { type: "separator" },
+  {
+    items: [
+      { label: "Menu 4", value: "menu-4" },
+      { label: "Menu 5", value: "menu-5" },
+      { label: "Menu 6", value: "menu-6" },
+    ],
+    label: "Group",
+    labelProps: { "data-testid": "label" },
+  },
+]
+
+const itemsWithRadioGroup: Menu.Item[] = [
+  {
+    type: "radio",
+    items: [
+      { label: "Option 1", value: "option-1" },
+      { label: "Option 2", value: "option-2" },
+      { label: "Option 3", value: "option-3" },
+    ],
+  },
+]
+
+const itemsWithCheckboxGroup: Menu.Item[] = [
+  {
+    type: "checkbox",
+    items: [
+      { label: "Option 1", value: "option-1" },
+      { label: "Option 2", value: "option-2" },
+      { label: "Option 3", value: "option-3" },
+    ],
+  },
+]
+
+describe("<Menu />", () => {
+  test("renders component correctly", async () => {
+    await a11y(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <Button>Menu</Button>
+        </Menu.Trigger>
+
+        <Menu.Content
+          items={[
+            ...items,
+            { type: "separator" },
+            ...itemsWithRadioGroup,
+            { type: "separator" },
+            ...itemsWithCheckboxGroup,
+          ]}
+        />
+      </Menu.Root>,
+    )
+  })
+})

--- a/packages/react/src/components/menu/menu.test.tsx
+++ b/packages/react/src/components/menu/menu.test.tsx
@@ -1,44 +1,7 @@
-import { a11y } from "#test"
+import { a11y, render, screen } from "#test"
 import { Button } from "../button"
 import { Menu } from "./"
-
-const items: Menu.Item[] = [
-  { label: "Menu 1", value: "menu-1" },
-  { label: "Menu 2", value: "menu-2" },
-  { label: "Menu 3", value: "menu-3" },
-  { type: "separator" },
-  {
-    items: [
-      { label: "Menu 4", value: "menu-4" },
-      { label: "Menu 5", value: "menu-5" },
-      { label: "Menu 6", value: "menu-6" },
-    ],
-    label: "Group",
-    labelProps: { "data-testid": "label" },
-  },
-]
-
-const itemsWithRadioGroup: Menu.Item[] = [
-  {
-    type: "radio",
-    items: [
-      { label: "Option 1", value: "option-1" },
-      { label: "Option 2", value: "option-2" },
-      { label: "Option 3", value: "option-3" },
-    ],
-  },
-]
-
-const itemsWithCheckboxGroup: Menu.Item[] = [
-  {
-    type: "checkbox",
-    items: [
-      { label: "Option 1", value: "option-1" },
-      { label: "Option 2", value: "option-2" },
-      { label: "Option 3", value: "option-3" },
-    ],
-  },
-]
+import { fullItems } from "./menu.test.fixtures"
 
 describe("<Menu />", () => {
   test("renders component correctly", async () => {
@@ -48,16 +11,86 @@ describe("<Menu />", () => {
           <Button>Menu</Button>
         </Menu.Trigger>
 
-        <Menu.Content
-          items={[
-            ...items,
-            { type: "separator" },
-            ...itemsWithRadioGroup,
-            { type: "separator" },
-            ...itemsWithCheckboxGroup,
-          ]}
-        />
+        <Menu.Content items={fullItems} />
       </Menu.Root>,
     )
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(Menu.Root.name).toBe("MenuRoot")
+    expect(Menu.Trigger.displayName).toBe("MenuTrigger")
+    expect(Menu.ContextTrigger.displayName).toBe("MenuContextTrigger")
+    expect(Menu.Anchor.displayName).toBe("MenuAnchor")
+    expect(Menu.Content.displayName).toBe("MenuContent")
+    expect(Menu.Label.displayName).toBe("MenuLabel")
+    expect(Menu.Item.displayName).toBe("MenuItem")
+    expect(Menu.Separator.displayName).toBe("MenuSeparator")
+    expect(Menu.Group.displayName).toBe("MenuGroup")
+    expect(Menu.OptionGroup.displayName).toBe("MenuOptionGroup")
+    expect(Menu.OptionItem.displayName).toBe("MenuOptionItem")
+    expect(Menu.Indicator.displayName).toBe("MenuIndicator")
+    expect(Menu.Command.displayName).toBe("MenuCommand")
+  })
+
+  test("sets `className` correctly", () => {
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <Button>Menu</Button>
+        </Menu.Trigger>
+
+        <Menu.Content items={fullItems} />
+      </Menu.Root>,
+    )
+
+    expect(screen.getByRole("button", { name: /Menu/i })).toHaveClass(
+      "ui-menu__trigger",
+    )
+    expect(screen.getByRole("menu")).toHaveClass("ui-menu__content")
+    expect(screen.getByRole("menuitem", { name: /Menu 1/i })).toHaveClass(
+      "ui-menu__item",
+    )
+    expect(screen.getAllByRole("separator")[0]).toHaveClass(
+      "ui-menu__separator",
+    )
+    expect(screen.getByTestId("label")).toHaveClass("ui-menu__label")
+    expect(screen.getAllByRole("group")[0]).toHaveClass("ui-menu__group")
+    expect(screen.getAllByRole("group")[1]).toHaveClass(
+      "ui-menu__group--option",
+    )
+    expect(
+      screen.getByRole("menuitemradio", { name: /Option 1/i }),
+    ).toHaveClass("ui-menu__item--option")
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: /Option 1/i }),
+    ).toHaveClass("ui-menu__item--option")
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <Button>Menu</Button>
+        </Menu.Trigger>
+
+        <Menu.Content items={fullItems} />
+      </Menu.Root>,
+    )
+
+    expect(screen.getByRole("button", { name: /Menu/i }).tagName).toBe("BUTTON")
+    expect(screen.getByRole("menu").tagName).toBe("DIV")
+    expect(screen.getByRole("menuitem", { name: /Menu 1/i }).tagName).toBe(
+      "DIV",
+    )
+    expect(screen.getAllByRole("separator")[0]?.tagName).toBe("HR")
+    expect(screen.getByTestId("label").tagName).toBe("SPAN")
+    expect(screen.getAllByRole("group")[0]?.tagName).toBe("DIV")
+    expect(screen.getAllByRole("group")[1]?.tagName).toBe("DIV")
+    expect(
+      screen.getByRole("menuitemradio", { name: /Option 1/i }).tagName,
+    ).toBe("DIV")
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: /Option 1/i }).tagName,
+    ).toBe("DIV")
   })
 })


### PR DESCRIPTION
Closes #7221

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/menu` according to the rule introduced in #7139.

## Current behavior (updates)

`menu.test.browser.tsx` had 104 tests, all under the chromium project. Several tests did not contribute to coverage:

- `renders component correctly` (a11y) — pure render + axe pass, does not need a real browser.
- `sets displayName correctly` — no rendering, pure metadata read.
- `sets className correctly` and `renders HTML tag correctly` — covered by other render assertions in the same items config.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `menu.test.tsx` — 1 test (a11y).

**browser (`#test/browser`)**

- `menu.test.browser.tsx` — 101 tests. Tests that need real event sequencing (`user.click`, `user.keyboard`), focus tracking, `mouseEnter`, `contextMenu`, or `getComputedStyle`-backed style assertions stay here.

Removed tests that did not contribute to coverage (verified empirically by re-running `test:coverage:chromium` after each removal):

- `sets displayName correctly` (no rendering, pure metadata read)
- `sets className correctly` (subsumed by the consolidated full-config render assertion)
- `renders HTML tag correctly` (subsumed by the consolidated full-config render assertion)

Added one consolidated `renders full items config with separator, radio, checkbox, and group` test that exercises the full items array (separators, radio group, checkbox group, nested group) used by the deleted tests, restoring the chromium-side coverage of `menu.tsx` line 407 and `use-menu.ts` lines 368, 378.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/menu/` — 1 test passes
- `pnpm react test:browser --run src/components/menu/` — 101 tests x 3 engines = 303 tests pass
- `pnpm react lint` — passes (0 warnings, 0 errors)

### Coverage (chromium project, istanbul)

Per-source-file `chromium` coverage matches baseline exactly.

| File          | Metric     | Baseline   | Final      |
| ------------- | ---------- | ---------- | ---------- |
| `menu.tsx`    | Statements | 100%       | 100%       |
| `menu.tsx`    | Branches   | 93.65%     | 93.65%     |
| `menu.tsx`    | Functions  | 100%       | 100%       |
| `menu.tsx`    | Lines      | 100%       | 100%       |
| `use-menu.ts` | Statements | 96.58%     | 96.58%     |
| `use-menu.ts` | Branches   | 89.51%     | 89.51%     |
| `use-menu.ts` | Functions  | 96.61%     | 96.61%     |
| `use-menu.ts` | Lines      | 97.36%     | 97.36%     |

### Coverage (jsdom project, v8)

Baseline jsdom had no tests for `menu`, so combined coverage was equal to the chromium numbers above. The new `menu.test.tsx` adds jsdom coverage:

| File          | Metric     | Baseline | Final  |
| ------------- | ---------- | -------- | ------ |
| `menu.tsx`    | Statements | 0%       | 93.33% |
| `menu.tsx`    | Branches   | 0%       | 76.19% |
| `menu.tsx`    | Functions  | 0%       | 90.9%  |
| `menu.tsx`    | Lines      | 0%       | 94.52% |
| `use-menu.ts` | Statements | 0%       | 42.23% |
| `use-menu.ts` | Branches   | 0%       | 34.67% |
| `use-menu.ts` | Functions  | 0%       | 25.42% |
| `use-menu.ts` | Lines      | 0%       | 45.54% |

Combined per-source-file coverage (union of chromium + jsdom) is at least equal to the baseline on every metric.

Sub-issue of #7141.