### PR TITLE
test(number-input): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/number-input/number-input.test.browser.tsx
+++ b/packages/react/src/components/number-input/number-input.test.browser.tsx
@@ -1,77 +1,8 @@
-import { a11y, page, render } from "#test/browser"
+import { page, render } from "#test/browser"
 import { NumberInput } from "."
-import { Group } from "../group"
 
 describe("<NumberInput />", () => {
-  test("renders component correctly", async () => {
-    await a11y(<NumberInput aria-label="Input number" />)
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(NumberInput.displayName).toBe("NumberInputRoot")
-  })
-
-  test("should merge groupItemProps and rootProps without overwriting style", async () => {
-    await render(
-      <Group>
-        <NumberInput
-          aria-label="Input number"
-          rootProps={{ style: { marginRight: "3px" } }}
-        />
-      </Group>,
-    )
-
-    const input = page.getByRole("spinbutton")
-    const root = input.element().closest(".ui-group")
-
-    expect(root).not.toBeNull()
-    expect(root).toHaveStyle({ marginRight: "3px" })
-    expect(root).toHaveAttribute(
-      "style",
-      expect.stringContaining("--group-count: 1"),
-    )
-    expect(root).toHaveAttribute(
-      "style",
-      expect.stringContaining("--group-index: 0"),
-    )
-  })
-
-  test("render input with props", async () => {
-    await render(
-      <NumberInput size="md" variant="outline" placeholder="Enter a number" />,
-    )
-
-    const numberInput = page
-      .getByRole("spinbutton")
-      .and(page.getByPlaceholder("Enter a number"))
-    await expect.element(numberInput).toBeVisible()
-  })
-
-  test("should render input with default value", async () => {
-    await render(<NumberInput defaultValue={20} max={30} min={5} step={5} />)
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toHaveValue("20")
-    await expect.element(numberInput).toHaveProperty("step", "5")
-    await expect.element(numberInput).toHaveProperty("min", "5")
-    await expect.element(numberInput).toHaveProperty("max", "30")
-  })
-
-  test("should disable the input", async () => {
-    await render(<NumberInput disabled />)
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toBeDisabled()
-  })
-
-  test("should render input with precision", async () => {
-    await render(<NumberInput defaultValue={10} precision={2} step={0.2} />)
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toHaveValue("10.00")
-  })
-
-  test("should clamp value on blur if value exceeds max value", async () => {
+  test("clamps value on blur if value exceeds max value", async () => {
     const { user } = await render(<NumberInput defaultValue={35} max={30} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -83,7 +14,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("30")
   })
 
-  test("should clamp value on blur if value is below min value", async () => {
+  test("clamps value on blur if value is below min value", async () => {
     const { user } = await render(<NumberInput defaultValue={-5} min={0} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -95,7 +26,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("0")
   })
 
-  test("should clear value on blur if value starts with E or e", async () => {
+  test("clears value on blur if value starts with E or e", async () => {
     const { user } = await render(<NumberInput />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -106,7 +37,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("")
   })
 
-  test("should not clamp value on blur when clampValueOnBlur is false", async () => {
+  test("does not clamp value on blur when clampValueOnBlur is false", async () => {
     const { user } = await render(
       <NumberInput clampValueOnBlur={false} keepWithinRange={false} max={10} />,
     )
@@ -119,7 +50,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("50")
   })
 
-  test("should disable keep within range", async () => {
+  test("disables keep within range", async () => {
     const { user } = await render(
       <NumberInput defaultValue={15} keepWithinRange={false} max={30} />,
     )
@@ -132,28 +63,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("35")
   })
 
-  test("should render an invalid input", async () => {
-    await render(<NumberInput invalid />)
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toBeInvalid()
-  })
-
-  test("should render a custom stepper input", async () => {
-    await render(
-      <NumberInput
-        decrementProps={{ children: "-", px: "xs" }}
-        incrementProps={{ children: "+", px: "xs" }}
-      />,
-    )
-
-    const plusButton = page.getByText(/\+/i)
-    const minusButton = page.getByText(/-/i)
-    await expect.element(plusButton).toBeVisible()
-    await expect.element(minusButton).toBeVisible()
-  })
-
-  test("should correctly reflect value changes with keyboard operations", async () => {
+  test("reflects value changes with keyboard operations", async () => {
     const { user } = await render(
       <NumberInput defaultValue={10} max={30} min={0} />,
     )
@@ -176,7 +86,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("30")
   })
 
-  test("should correctly reflect value changes based on step with keyboard operations", async () => {
+  test("reflects value changes based on step with keyboard operations", async () => {
     const { user } = await render(<NumberInput defaultValue={10} step={5} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -191,18 +101,14 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should correctly reflect value changes with stepper elements", async () => {
+  test("reflects value changes with stepper elements", async () => {
     const { user } = await render(
       <NumberInput defaultValue={10} max={30} min={0} />,
     )
 
     const numberInput = page.getByRole("spinbutton")
-    const incrementStepper = page.getByRole("button", {
-      name: "Increase",
-    })
-    const decrementStepper = page.getByRole("button", {
-      name: "Decrease",
-    })
+    const incrementStepper = page.getByRole("button", { name: "Increase" })
+    const decrementStepper = page.getByRole("button", { name: "Decrease" })
 
     await expect.element(numberInput).toHaveValue("10")
 
@@ -213,7 +119,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should change value on wheel when focused and allowMouseWheel is true", async () => {
+  test("changes value on wheel when focused and allowMouseWheel is true", async () => {
     const { user } = await render(
       <NumberInput allowMouseWheel defaultValue={10} />,
     )
@@ -234,7 +140,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should prevent invalid character input via keyboard", async () => {
+  test("prevents invalid character input via keyboard", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -252,7 +158,7 @@ describe("<NumberInput />", () => {
     expect(preventDefaultSpy).toHaveBeenCalledWith()
   })
 
-  test("should allow valid numeric characters via keyboard", async () => {
+  test("allows valid numeric characters via keyboard", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -270,7 +176,7 @@ describe("<NumberInput />", () => {
     expect(preventDefaultSpy).not.toHaveBeenCalled()
   })
 
-  test("should not change value when disabled and increment/decrement buttons are clicked", async () => {
+  test("does not change value when disabled and increment/decrement buttons are clicked", async () => {
     await render(<NumberInput defaultValue={10} disabled />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -294,7 +200,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should not change value when readOnly and work with controlled value", async () => {
+  test("does not change value when readOnly and works with controlled value", async () => {
     const { user } = await render(<NumberInput defaultValue={10} readOnly />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -310,7 +216,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should not focus input on change when focusInputOnChange is false", async () => {
+  test("does not focus input on change when focusInputOnChange is false", async () => {
     await render(<NumberInput defaultValue={10} focusInputOnChange={false} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -328,34 +234,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("11")
   })
 
-  test("should use custom format and parse functions", async () => {
-    await render(
-      <NumberInput
-        defaultValue={10}
-        format={(val) => `$${val}`}
-        parse={(val) => val.replace("$", "")}
-      />,
-    )
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toHaveValue("$10")
-  })
-
-  test("should use getAriaValueText for aria-valuetext", async () => {
-    await render(
-      <NumberInput
-        defaultValue={10}
-        getAriaValueText={(val) => `${val} items`}
-      />,
-    )
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect
-      .element(numberInput)
-      .toHaveAttribute("aria-valuetext", "10 items")
-  })
-
-  test("should use custom isValidCharacter function", async () => {
+  test("uses custom isValidCharacter function", async () => {
     await render(
       <NumberInput
         defaultValue={10}
@@ -378,7 +257,7 @@ describe("<NumberInput />", () => {
     expect(preventDefaultSpy).toHaveBeenCalledWith()
   })
 
-  test("should increment value continuously on long press of increment button", async () => {
+  test("increments value continuously on long press of increment button", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -410,7 +289,7 @@ describe("<NumberInput />", () => {
       .dispatchEvent(new PointerEvent("pointerup", { bubbles: true }))
   })
 
-  test("should decrement value continuously on long press of decrement button", async () => {
+  test("decrements value continuously on long press of decrement button", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -442,7 +321,7 @@ describe("<NumberInput />", () => {
       .dispatchEvent(new PointerEvent("pointerup", { bubbles: true }))
   })
 
-  test("should stop spinning on pointer leave", async () => {
+  test("stops spinning on pointer leave", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -476,7 +355,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue(valueAfterLeave)
   })
 
-  test("should not change value on wheel when input is not focused", async () => {
+  test("does not change value on wheel when input is not focused", async () => {
     await render(<NumberInput allowMouseWheel defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -488,7 +367,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should not change value on wheel when allowMouseWheel is false", async () => {
+  test("does not change value on wheel when allowMouseWheel is false", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -502,7 +381,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("10")
   })
 
-  test("should apply step ratio with shift key on wheel", async () => {
+  test("applies step ratio with shift key on wheel", async () => {
     await render(<NumberInput allowMouseWheel defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -519,7 +398,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("20")
   })
 
-  test("should apply step ratio with shift key on keyboard", async () => {
+  test("applies step ratio with shift key on keyboard", async () => {
     await render(<NumberInput defaultValue={10} step={1} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -536,7 +415,7 @@ describe("<NumberInput />", () => {
     await expect.element(numberInput).toHaveValue("20")
   })
 
-  test("should not prevent keydown when modifier keys are pressed", async () => {
+  test("does not prevent keydown when modifier keys are pressed", async () => {
     await render(<NumberInput defaultValue={10} />)
 
     const numberInput = page.getByRole("spinbutton")
@@ -553,58 +432,5 @@ describe("<NumberInput />", () => {
     numberInput.element().dispatchEvent(event)
 
     expect(preventDefaultSpy).not.toHaveBeenCalled()
-  })
-
-  test("should handle controlled value changes", async () => {
-    const onChange = vi.fn()
-    const { rerender } = await render(
-      <NumberInput value={10} onChange={onChange} />,
-    )
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toHaveValue("10")
-
-    await rerender(<NumberInput value={20} onChange={onChange} />)
-    await expect.element(numberInput).toHaveValue("20")
-  })
-
-  test("should combine multiple props and render all custom props correctly", async () => {
-    await render(
-      <NumberInput
-        className="custom-class"
-        colorScheme="primary"
-        aria-describedby="helper-text"
-        aria-label="Custom label"
-        defaultValue={15}
-        disabled={false}
-        max={100}
-        min={0}
-        placeholder="Enter number"
-        readOnly={false}
-        step={5}
-        controlProps={{ "data-testid": "control" }}
-        decrementProps={{ "data-testid": "decrement" }}
-        elementProps={{ "data-testid": "element" }}
-        incrementProps={{ "data-testid": "increment" }}
-        rootProps={{ "data-testid": "root" }}
-      />,
-    )
-
-    const numberInput = page.getByRole("spinbutton")
-    await expect.element(numberInput).toHaveValue("15")
-    await expect.element(numberInput).toHaveProperty("step", "5")
-    await expect.element(numberInput).toHaveProperty("min", "0")
-    await expect.element(numberInput).toHaveProperty("max", "100")
-    await expect
-      .element(numberInput)
-      .toHaveAttribute("aria-label", "Custom label")
-    await expect
-      .element(numberInput)
-      .toHaveAttribute("aria-describedby", "helper-text")
-    await expect.element(page.getByTestId("root")).toBeVisible()
-    await expect.element(page.getByTestId("element")).toBeVisible()
-    await expect.element(page.getByTestId("control")).toBeVisible()
-    await expect.element(page.getByTestId("increment")).toBeVisible()
-    await expect.element(page.getByTestId("decrement")).toBeVisible()
   })
 })

--- a/packages/react/src/components/number-input/number-input.test.tsx
+++ b/packages/react/src/components/number-input/number-input.test.tsx
@@ -13,7 +13,7 @@ describe("<NumberInput />", () => {
     await a11y(<NumberInput aria-label="Input number" />)
   })
 
-  test("should merge groupItemProps and rootProps without overwriting style", () => {
+  test("merges groupItemProps and rootProps without overwriting style", () => {
     render(
       <Group>
         <NumberInput

--- a/packages/react/src/components/number-input/number-input.test.tsx
+++ b/packages/react/src/components/number-input/number-input.test.tsx
@@ -1,10 +1,166 @@
 import type { PropsWithChildren } from "react"
 import { createElement } from "react"
-import { renderHook } from "#test"
+import { a11y, render, renderHook, screen } from "#test"
+import { NumberInput } from "."
 import { noop } from "../../utils"
 import { FieldContext } from "../field/field"
+import { Group } from "../group"
 import { useNumberCounter } from "./use-number-counter"
 import { useNumberInput } from "./use-number-input"
+
+describe("<NumberInput />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<NumberInput aria-label="Input number" />)
+  })
+
+  test("should merge groupItemProps and rootProps without overwriting style", () => {
+    render(
+      <Group>
+        <NumberInput
+          aria-label="Input number"
+          rootProps={{ style: { marginRight: "3px" } }}
+        />
+      </Group>,
+    )
+
+    const input = screen.getByRole("spinbutton")
+    const root = input.closest(".ui-group")
+
+    expect(root).not.toBeNull()
+    expect(root).toHaveStyle({ marginRight: "3px" })
+    expect(root).toHaveAttribute(
+      "style",
+      expect.stringContaining("--group-count: 1"),
+    )
+    expect(root).toHaveAttribute(
+      "style",
+      expect.stringContaining("--group-index: 0"),
+    )
+  })
+
+  test("renders input with props", () => {
+    render(
+      <NumberInput size="md" variant="outline" placeholder="Enter a number" />,
+    )
+
+    expect(screen.getByRole("spinbutton")).toHaveAttribute(
+      "placeholder",
+      "Enter a number",
+    )
+  })
+
+  test("renders input with default value, min, max, and step", () => {
+    render(<NumberInput defaultValue={20} max={30} min={5} step={5} />)
+
+    const input = screen.getByRole("spinbutton")
+    expect(input).toHaveValue("20")
+    expect(input).toHaveProperty("step", "5")
+    expect(input).toHaveProperty("min", "5")
+    expect(input).toHaveProperty("max", "30")
+  })
+
+  test("disables the input when disabled is true", () => {
+    render(<NumberInput disabled />)
+
+    expect(screen.getByRole("spinbutton")).toBeDisabled()
+  })
+
+  test("renders input with precision", () => {
+    render(<NumberInput defaultValue={10} precision={2} step={0.2} />)
+
+    expect(screen.getByRole("spinbutton")).toHaveValue("10.00")
+  })
+
+  test("renders an invalid input", () => {
+    render(<NumberInput invalid />)
+
+    expect(screen.getByRole("spinbutton")).toBeInvalid()
+  })
+
+  test("renders a custom stepper input", () => {
+    render(
+      <NumberInput
+        decrementProps={{ children: "-", px: "xs" }}
+        incrementProps={{ children: "+", px: "xs" }}
+      />,
+    )
+
+    expect(screen.getByText(/\+/i)).toBeInTheDocument()
+    expect(screen.getByText(/-/i)).toBeInTheDocument()
+  })
+
+  test("uses custom format and parse functions", () => {
+    render(
+      <NumberInput
+        defaultValue={10}
+        format={(val) => `$${val}`}
+        parse={(val) => val.replace("$", "")}
+      />,
+    )
+
+    expect(screen.getByRole("spinbutton")).toHaveValue("$10")
+  })
+
+  test("uses getAriaValueText for aria-valuetext", () => {
+    render(
+      <NumberInput
+        defaultValue={10}
+        getAriaValueText={(val) => `${val} items`}
+      />,
+    )
+
+    expect(screen.getByRole("spinbutton")).toHaveAttribute(
+      "aria-valuetext",
+      "10 items",
+    )
+  })
+
+  test("reflects controlled value changes", () => {
+    const onChange = vi.fn()
+    const { rerender } = render(<NumberInput value={10} onChange={onChange} />)
+
+    expect(screen.getByRole("spinbutton")).toHaveValue("10")
+
+    rerender(<NumberInput value={20} onChange={onChange} />)
+    expect(screen.getByRole("spinbutton")).toHaveValue("20")
+  })
+
+  test("combines multiple props and renders all custom props correctly", () => {
+    render(
+      <NumberInput
+        className="custom-class"
+        colorScheme="primary"
+        aria-describedby="helper-text"
+        aria-label="Custom label"
+        defaultValue={15}
+        disabled={false}
+        max={100}
+        min={0}
+        placeholder="Enter number"
+        readOnly={false}
+        step={5}
+        controlProps={{ "data-testid": "control" }}
+        decrementProps={{ "data-testid": "decrement" }}
+        elementProps={{ "data-testid": "element" }}
+        incrementProps={{ "data-testid": "increment" }}
+        rootProps={{ "data-testid": "root" }}
+      />,
+    )
+
+    const input = screen.getByRole("spinbutton")
+    expect(input).toHaveValue("15")
+    expect(input).toHaveProperty("step", "5")
+    expect(input).toHaveProperty("min", "0")
+    expect(input).toHaveProperty("max", "100")
+    expect(input).toHaveAttribute("aria-label", "Custom label")
+    expect(input).toHaveAttribute("aria-describedby", "helper-text")
+    expect(screen.getByTestId("root")).toBeInTheDocument()
+    expect(screen.getByTestId("element")).toBeInTheDocument()
+    expect(screen.getByTestId("control")).toBeInTheDocument()
+    expect(screen.getByTestId("increment")).toBeInTheDocument()
+    expect(screen.getByTestId("decrement")).toBeInTheDocument()
+  })
+})
 
 describe("number-input mergeProps", () => {
   test("useNumberCounter getButtonProps merges style and chains pointer handlers", () => {


### PR DESCRIPTION
Closes #7229

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/number-input` according to the rule introduced in #7139.

## Current behavior (updates)

Two test files lived under `packages/react/src/components/number-input/`:

- `number-input.test.browser.tsx` — 36 tests. Many were pure render + attribute assertions (`displayName`, `placeholder`, `aria-valuetext`, controlled `value` rerender, multi-prop combine) that did not need a real browser.
- `use-number-mergeprops.test.ts` — 3 jsdom tests that lived in a sibling file instead of the component test file.

`displayName` and other metadata-only reads did not contribute to combined coverage on any source file.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md). `a11y` was moved to jsdom (the assertion is a pure render + axe pass). The sibling `use-number-mergeprops.test.ts` was merged into the component test file under a `number-input mergeProps` describe block.

**jsdom (`#test`) — `number-input.test.tsx`** — 15 tests

- `<NumberInput />`: a11y, groupItemProps merge, props render, default value/min/max/step, disabled, precision, invalid, custom stepper, custom format/parse, getAriaValueText, controlled value rerender, multi-prop combine
- `number-input mergeProps`: 3 hook tests merged from the deleted `use-number-mergeprops.test.ts`

**browser (`#test/browser`) — `number-input.test.browser.tsx`** — 23 tests (× 3 engines)

Tests that exercise focus, real keyboard / pointer / wheel sequences, and the spinner observer:

- blur clamping (max, min, leading E/e, `clampValueOnBlur={false}`, `keepWithinRange={false}`)
- keyboard arrows (`ArrowUp`/`ArrowDown`/`Home`/`End`, step, shift ratio, modifier keys)
- stepper clicks (basic, disabled, `focusInputOnChange={false}`)
- readOnly + keyboard
- wheel (focused/unfocused, `allowMouseWheel={false}`, shift ratio)
- long-press increment/decrement and `pointerleave` stop
- `isValidCharacter` keydown gate (default + custom)

Removed because they did not contribute to combined coverage:

- `sets displayName correctly` — pure metadata read

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/number-input/` — 15 tests pass
- `pnpm react test:browser --run src/components/number-input/` — 23 tests × 3 engines = 69 pass
- `pnpm react lint` — passes

Per-source-file combined coverage (covered if hit in either project) on `packages/react/src/components/number-input/`:

| File | Baseline (lines) | Final (lines) |
| --- | --- | --- |
| `number-input.tsx` | 15/16 (93.75%) | 16/16 (100.00%) |
| `use-number-counter.ts` | 24/24 (100.00%) | 24/24 (100.00%) |
| `use-number-input.ts` | 90/93 (96.77%) | 90/93 (96.77%) |
| `use-spinner.ts` | 30/30 (100.00%) | 30/30 (100.00%) |

No source line that was covered in baseline becomes uncovered in the final run.

Sub-issue of #7141.