### PR TITLE
test(portal): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/portal/portal.test.tsx
+++ b/packages/react/src/components/portal/portal.test.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react"
-import { a11y, page, render } from "#test/browser"
+import { a11y, render, screen } from "#test"
 import { Portal } from "./portal"
 
 describe("<Portal />", () => {
@@ -7,11 +7,7 @@ describe("<Portal />", () => {
     await a11y(<Portal>Hello</Portal>)
   })
 
-  test("sets `displayName` correctly", () => {
-    expect(Portal.name).toBe("Portal")
-  })
-
-  test("Portal with containerRef renders correctly", async () => {
+  test("Portal with containerRef renders correctly", () => {
     const TestContainer = () => {
       const ref = useRef<HTMLDivElement>(null)
 
@@ -24,12 +20,12 @@ describe("<Portal />", () => {
       )
     }
 
-    await render(<TestContainer />)
+    render(<TestContainer />)
 
-    await expect.element(page.getByText("order2order3")).toBeInTheDocument()
+    expect(screen.getByText("order2order3")).toBeInTheDocument()
   })
 
-  test("Nested Portal with containerRef renders correctly", async () => {
+  test("Nested Portal with containerRef renders correctly", () => {
     const TestContainer = () => {
       const ref = useRef<HTMLDivElement>(null)
 
@@ -44,13 +40,13 @@ describe("<Portal />", () => {
       )
     }
 
-    await render(<TestContainer />)
+    render(<TestContainer />)
 
-    await expect.element(page.getByText("order1order2")).toBeInTheDocument()
-    await expect.element(page.getByText("order3")).toBeInTheDocument()
+    expect(screen.getByText("order1order2")).toBeInTheDocument()
+    expect(screen.getByText("order3")).toBeInTheDocument()
   })
 
-  test("Portal with disabled renders correctly", async () => {
+  test("Portal with disabled renders correctly", () => {
     const TestContainer = () => {
       const ref = useRef<HTMLDivElement>(null)
 
@@ -64,10 +60,8 @@ describe("<Portal />", () => {
       )
     }
 
-    await render(<TestContainer />)
+    render(<TestContainer />)
 
-    await expect
-      .element(page.getByText("order1"))
-      .not.toHaveTextContent("order1order2")
+    expect(screen.getByText("order1")).not.toHaveTextContent("order1order2")
   })
 })


### PR DESCRIPTION
Closes #7235

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/portal` according to the rule introduced in #7139.

## Current behavior (updates)

One `*.test.browser.tsx` file lived under `packages/react/src/components/portal/`:

- `portal.test.browser.tsx` — 5 tests. Only `a11y` and the four behavior tests (`containerRef`, nested portal, `disabled`, plus a `displayName` metadata read). None of the assertions depend on real-DOM reads, event sequencing, observers, focus, or browser APIs — `Portal` only uses `useState`/`useEffect` and `react-dom`'s `createPortal`, which is fully supported under jsdom.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md). Per the rule, `a11y(...)` defaults to jsdom because `Portal` does not read the real DOM.

**jsdom (`#test`)**

- `portal.test.tsx` — 4 tests (a11y, containerRef, nested containerRef, disabled)

**browser (`#test/browser`)**

- `portal.test.browser.tsx` is removed because no browser-only assertion remained.

Removed tests that did not contribute to coverage:

- `sets displayName correctly` (no rendering, pure metadata read)

## Coverage

Per-source-file combined coverage on `packages/react/src/components/portal/` is unchanged.

| Project  | File         | % Stmts        | % Branch     | % Funcs    | % Lines      |
| -------- | ------------ | -------------- | ------------ | ---------- | ------------ |
| Baseline (chromium / istanbul) | `portal.tsx` | 94.11 (16/17) | 87.5 (7/8) | 100 (5/5) | 100 (14/14) |
| Final (jsdom / v8)             | `portal.tsx` | 94.44 (17/18) | 87.5 (7/8) | 100 (5/5) | 100 (15/15) |

The slight statement-count delta (17 vs 18) is a v8/istanbul instrumentation difference. The single uncovered branch (line 13, `isShadowRoot`) is identical in both reports.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/portal/` — 4 tests pass
- `pnpm react test:browser --run src/components/portal/` — no test files (browser file removed)
- `pnpm react lint` — passes
- `pnpm react test:coverage:jsdom --coverage.include='src/components/portal/**' --coverage.reporter=text src/components/portal/` — 94.44% stmts / 87.5% branches / 100% funcs / 100% lines

Sub-issue of #7141.