### PR TITLE
test(resizable): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/resizable/resizable.test.browser.tsx
+++ b/packages/react/src/components/resizable/resizable.test.browser.tsx
@@ -1,95 +1,7 @@
 import type { ResizableRootControl } from "./"
 import { useRef } from "react"
-import { a11y, page, render } from "#test/browser"
-import { GripVerticalIcon } from "../icon"
+import { page, render } from "#test/browser"
 import { Resizable } from "./"
-
-describe("<Resizable />", () => {
-  test("renders component correctly", async () => {
-    await a11y(
-      <Resizable.Root>
-        <Resizable.Item>One</Resizable.Item>
-        <Resizable.Trigger />
-
-        <Resizable.Item>Two</Resizable.Item>
-      </Resizable.Root>,
-    )
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(Resizable.Root.displayName).toBe("ResizableRoot")
-    expect(Resizable.Item.displayName).toBe("ResizableItem")
-    expect(Resizable.Trigger.displayName).toBe("ResizableTrigger")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(
-      <Resizable.Root id="root">
-        <Resizable.Item id="item">One</Resizable.Item>
-
-        <Resizable.Trigger id="trigger" />
-
-        <Resizable.Item>Two</Resizable.Item>
-      </Resizable.Root>,
-    )
-    await expect
-      .element(page.getByTestId("root"))
-      .toHaveClass("ui-resizable__root")
-    await expect
-      .element(page.getByTestId("item").getByText("One"))
-      .toHaveClass("ui-resizable__item")
-    await expect
-      .element(page.getByTestId("trigger"))
-      .toHaveClass("ui-resizable__trigger")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(
-      <Resizable.Root id="root">
-        <Resizable.Item id="item">One</Resizable.Item>
-
-        <Resizable.Trigger id="trigger" />
-
-        <Resizable.Item>Two</Resizable.Item>
-      </Resizable.Root>,
-    )
-    expect(page.getByTestId("root").element().tagName).toBe("DIV")
-    expect(page.getByTestId("item").element().firstElementChild?.tagName).toBe(
-      "DIV",
-    )
-    expect(page.getByTestId("trigger").element().tagName).toBe("DIV")
-  })
-
-  test.todo("The default size of the left panel should be 30 and 70", async () => {
-    await render(
-      <Resizable.Root>
-        <Resizable.Item
-          id="left-item"
-          data-testid="left-item"
-          defaultSize="30%"
-        >
-          One
-        </Resizable.Item>
-
-        <Resizable.Trigger />
-
-        <Resizable.Item
-          id="right-item"
-          data-testid="right-item"
-          defaultSize="70%"
-        >
-          Two
-        </Resizable.Item>
-      </Resizable.Root>,
-    )
-    expect(page.getByTestId("left-item").element()).toHaveStyle({
-      flex: "30 1 0px",
-    })
-    expect(page.getByTestId("right-item").element()).toHaveStyle({
-      flex: "70 1 0px",
-    })
-  })
-})
 
 describe("<ResizableTrigger />", () => {
   test("handles double-click to equalize panel sizes", async () => {
@@ -107,7 +19,9 @@ describe("<ResizableTrigger />", () => {
                 controlRef.current.setLayout = setLayoutMock
               }
             }}
-          />
+          >
+            mock
+          </button>
 
           <Resizable.Root controlRef={controlRef}>
             <Resizable.Item>One</Resizable.Item>
@@ -120,32 +34,10 @@ describe("<ResizableTrigger />", () => {
       )
     }
 
-    await render(<Wrapper />)
-    ;(page.getByTestId("mock-set-layout").element() as HTMLElement).click()
-
-    const trigger = page.getByTestId("trigger").element()
-
-    trigger.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }))
+    const { user } = await render(<Wrapper />)
+    await user.click(page.getByTestId("mock-set-layout"))
+    await user.dblClick(page.getByTestId("trigger"))
 
     expect(setLayoutMock).toHaveBeenCalledWith(expect.objectContaining({}))
-  })
-})
-
-describe("<ResizableTriggerIcon />", () => {
-  test("icon renders correctly", async () => {
-    await render(
-      <Resizable.Root>
-        <Resizable.Item>One</Resizable.Item>
-
-        <Resizable.Trigger
-          id="trigger"
-          icon={<GripVerticalIcon data-testid="icon" />}
-        />
-
-        <Resizable.Item>Two</Resizable.Item>
-      </Resizable.Root>,
-    )
-    await expect.element(page.getByTestId("trigger")).toBeInTheDocument()
-    await expect.element(page.getByTestId("icon")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/components/resizable/resizable.test.tsx
+++ b/packages/react/src/components/resizable/resizable.test.tsx
@@ -13,6 +13,49 @@ describe("<Resizable />", () => {
       </Resizable.Root>,
     )
   })
+
+  test("sets `displayName` correctly", () => {
+    expect(Resizable.Root.displayName).toBe("ResizableRoot")
+    expect(Resizable.Item.displayName).toBe("ResizableItem")
+    expect(Resizable.Trigger.displayName).toBe("ResizableTrigger")
+  })
+
+  test("sets `className` correctly", () => {
+    render(
+      <Resizable.Root id="root">
+        <Resizable.Item id="item">One</Resizable.Item>
+
+        <Resizable.Trigger id="trigger" />
+
+        <Resizable.Item>Two</Resizable.Item>
+      </Resizable.Root>,
+    )
+
+    const item = screen.getByText("One").closest(".ui-resizable__item")
+
+    expect(screen.getByTestId("root")).toHaveClass("ui-resizable__root")
+    expect(item).toBeInTheDocument()
+    expect(item).toHaveClass("ui-resizable__item")
+    expect(screen.getByTestId("trigger")).toHaveClass("ui-resizable__trigger")
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(
+      <Resizable.Root id="root">
+        <Resizable.Item id="item">One</Resizable.Item>
+
+        <Resizable.Trigger id="trigger" />
+
+        <Resizable.Item>Two</Resizable.Item>
+      </Resizable.Root>,
+    )
+
+    const item = screen.getByText("One").closest(".ui-resizable__item")
+
+    expect(screen.getByTestId("root").tagName).toBe("DIV")
+    expect(item?.tagName).toBe("DIV")
+    expect(screen.getByTestId("trigger").tagName).toBe("DIV")
+  })
 })
 
 describe("<ResizableTriggerIcon />", () => {

--- a/packages/react/src/components/resizable/resizable.test.tsx
+++ b/packages/react/src/components/resizable/resizable.test.tsx
@@ -1,0 +1,35 @@
+import { a11y, render, screen } from "#test"
+import { GripVerticalIcon } from "../icon"
+import { Resizable } from "./"
+
+describe("<Resizable />", () => {
+  test("renders component correctly", async () => {
+    await a11y(
+      <Resizable.Root>
+        <Resizable.Item>One</Resizable.Item>
+        <Resizable.Trigger />
+
+        <Resizable.Item>Two</Resizable.Item>
+      </Resizable.Root>,
+    )
+  })
+})
+
+describe("<ResizableTriggerIcon />", () => {
+  test("icon renders correctly", () => {
+    render(
+      <Resizable.Root>
+        <Resizable.Item>One</Resizable.Item>
+
+        <Resizable.Trigger
+          id="trigger"
+          icon={<GripVerticalIcon data-testid="icon" />}
+        />
+
+        <Resizable.Item>Two</Resizable.Item>
+      </Resizable.Root>,
+    )
+    expect(screen.getByTestId("trigger")).toBeInTheDocument()
+    expect(screen.getByTestId("icon")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #7242

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/resizable` according to the rule introduced in #7139.

## Current behavior (updates)

A single `*.test.browser.tsx` file lived under `packages/react/src/components/resizable/`:

- `resizable.test.browser.tsx` — 6 tests + 1 `test.todo`. Only the double-click handler test depends on real layout measurement; everything else is jsdom-friendly.

Several of these tests did not contribute to coverage (pure metadata reads such as `Resizable.Root.displayName`, repeated render assertions covered by sibling cases).

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `resizable.test.tsx` — 2 tests
  - `renders component correctly` (a11y)
  - `icon renders correctly`

**browser (`#test/browser`)**

- `resizable.test.browser.tsx` — 1 test
  - `handles double-click to equalize panel sizes` — kept in browser because the handler depends on `getLayout()` reading registered panel sizes from real DOM measurements; in jsdom the layout is empty and the inner `Object.fromEntries(Object.keys(layout).map(...))` branch never executes.
  - Switched the interaction from direct DOM dispatch (`element.click()` / `dispatchEvent(new MouseEvent("dblclick"))`) to `user.click` / `user.dblClick` to match the [Browser Testing Rules](.agents/rules/browser-testing.md).

Removed tests that did not contribute to coverage (verified empirically by removing each and re-running coverage):

- `sets displayName correctly` — pure metadata read, no rendering. No effect on coverage.
- `sets className correctly` — same render path as `icon renders correctly`. No effect on coverage.
- `renders HTML tag correctly` — same render path as `sets className correctly`. No effect on coverage.
- `The default size of the left panel should be 30 and 70` — already a `test.todo` with no executing body.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/resizable/` — 2 tests pass
- `pnpm react test:browser --run src/components/resizable/` — 1 test x 3 engines pass
- `pnpm react lint` — passes

### Coverage

Coverage commands:

```sh
pnpm react test:coverage:jsdom --coverage.include='src/components/resizable/**' --coverage.reporter=text src/components/resizable/
pnpm react test:coverage:chromium --coverage.include='src/components/resizable/**' --coverage.reporter=text src/components/resizable/
```

Combined per-source-file coverage (lines covered in either project):

| File | Metric | Baseline | Final (combined) |
| --- | --- | --- | --- |
| `resizable.style.ts` | Stmts/Branch/Funcs/Lines | 1/1, 0/0, 0/0, 1/1 | 1/1, 0/0, 0/0, 1/1 |
| `resizable.tsx` | Stmts/Branch/Funcs/Lines | 14/14, 2/2, 4/4, 14/14 | 15/15 (jsdom) / 14/14 (chromium), 2/2, 4/4, 100% lines |
| `use-resizable.ts` | Lines | 31/31 | 31/31 (jsdom misses 145–157, chromium misses 186; union covers all 31) |
| `use-resizable.ts` | Branches | 8/12 | 9/12 (jsdom alone) — at least baseline |
| `use-resizable.ts` | Funcs | 9/9 | 9/9 (chromium covers `onDoubleClick` callback + inner `Object.keys` map; jsdom covers `getIconProps` callback) |
| `use-resizable.ts` | Stmts | 31/32 | at least baseline (chromium 30/32 + jsdom covers the icon path stmt that chromium misses) |

Sub-issue of #7141.