### PR TITLE
test(simple-grid): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/simple-grid/simple-grid.test.browser.tsx
+++ b/packages/react/src/components/simple-grid/simple-grid.test.browser.tsx
@@ -1,4 +1,4 @@
-import { a11y, page, render } from "#test/browser"
+import { page, render } from "#test/browser"
 import { SimpleGrid } from "./simple-grid"
 
 const getDeclaredGridTemplateColumns = () => {
@@ -33,26 +33,6 @@ const getComputedGridTemplateColumns = () =>
   getComputedStyle(page.getByText("SimpleGrid").element()).gridTemplateColumns
 
 describe("<SimpleGrid />", () => {
-  test("renders component correctly", async () => {
-    await a11y(<SimpleGrid>GridSimple</SimpleGrid>)
-  })
-
-  test("sets `displayName` correctly", () => {
-    expect(SimpleGrid.displayName).toBe("SimpleGrid")
-  })
-
-  test("sets `className` correctly", async () => {
-    await render(<SimpleGrid>SimpleGrid</SimpleGrid>)
-    await expect
-      .element(page.getByText("SimpleGrid"))
-      .toHaveClass("ui-simple-grid")
-  })
-
-  test("renders HTML tag correctly", async () => {
-    await render(<SimpleGrid>SimpleGrid</SimpleGrid>)
-    expect(page.getByText("SimpleGrid").element().tagName).toBe("DIV")
-  })
-
   test("applies `minChildWidth` correctly", async () => {
     await render(<SimpleGrid minChildWidth="200px">SimpleGrid</SimpleGrid>)
     const gridTemplateColumns = getDeclaredGridTemplateColumns()
@@ -85,35 +65,5 @@ describe("<SimpleGrid />", () => {
     await render(<SimpleGrid columns={3}>SimpleGrid</SimpleGrid>)
     const gridTemplateColumns = getDeclaredGridTemplateColumns().trim()
     expect(gridTemplateColumns).toMatch(/^repeat\(3,\s*minmax\(0px,\s*1fr\)\)$/)
-  })
-
-  test("returns undefined for null value in `minChildWidth` responsive array", async () => {
-    await render(
-      // @ts-expect-error testing null handling in responsive array
-      <SimpleGrid minChildWidth={[null, "200px"]}>SimpleGrid</SimpleGrid>,
-    )
-    await expect.element(page.getByText("SimpleGrid")).toBeInTheDocument()
-  })
-
-  test("returns undefined for undefined value in `minChildWidth` responsive object", async () => {
-    await render(
-      <SimpleGrid minChildWidth={{ base: undefined, md: "200px" }}>
-        SimpleGrid
-      </SimpleGrid>,
-    )
-    await expect.element(page.getByText("SimpleGrid")).toBeInTheDocument()
-  })
-
-  test("returns undefined for null value in `columns` responsive array", async () => {
-    // @ts-expect-error - testing null handling in responsive array
-    await render(<SimpleGrid columns={[null, 3]}>SimpleGrid</SimpleGrid>)
-    await expect.element(page.getByText("SimpleGrid")).toBeInTheDocument()
-  })
-
-  test("returns undefined for undefined value in `columns` responsive object", async () => {
-    await render(
-      <SimpleGrid columns={{ base: undefined, md: 3 }}>SimpleGrid</SimpleGrid>,
-    )
-    await expect.element(page.getByText("SimpleGrid")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/components/simple-grid/simple-grid.test.tsx
+++ b/packages/react/src/components/simple-grid/simple-grid.test.tsx
@@ -1,0 +1,52 @@
+import { a11y, render, screen } from "#test"
+import { SimpleGrid } from "./simple-grid"
+
+describe("<SimpleGrid />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<SimpleGrid>SimpleGrid</SimpleGrid>)
+  })
+
+  test("sets `displayName` correctly", () => {
+    expect(SimpleGrid.displayName).toBe("SimpleGrid")
+  })
+
+  test("sets `className` correctly", () => {
+    render(<SimpleGrid>SimpleGrid</SimpleGrid>)
+    expect(screen.getByText("SimpleGrid")).toHaveClass("ui-simple-grid")
+  })
+
+  test("renders HTML tag correctly", () => {
+    render(<SimpleGrid>SimpleGrid</SimpleGrid>)
+    expect(screen.getByText("SimpleGrid").tagName).toBe("DIV")
+  })
+
+  test("returns undefined for null value in `minChildWidth` responsive array", () => {
+    render(
+      // @ts-expect-error testing null handling in responsive array
+      <SimpleGrid minChildWidth={[null, "200px"]}>SimpleGrid</SimpleGrid>,
+    )
+    expect(screen.getByText("SimpleGrid")).toBeInTheDocument()
+  })
+
+  test("returns undefined for undefined value in `minChildWidth` responsive object", () => {
+    render(
+      <SimpleGrid minChildWidth={{ base: undefined, md: "200px" }}>
+        SimpleGrid
+      </SimpleGrid>,
+    )
+    expect(screen.getByText("SimpleGrid")).toBeInTheDocument()
+  })
+
+  test("returns undefined for null value in `columns` responsive array", () => {
+    // @ts-expect-error - testing null handling in responsive array
+    render(<SimpleGrid columns={[null, 3]}>SimpleGrid</SimpleGrid>)
+    expect(screen.getByText("SimpleGrid")).toBeInTheDocument()
+  })
+
+  test("returns undefined for undefined value in `columns` responsive object", () => {
+    render(
+      <SimpleGrid columns={{ base: undefined, md: 3 }}>SimpleGrid</SimpleGrid>,
+    )
+    expect(screen.getByText("SimpleGrid")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #7251

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/simple-grid` according to the rule introduced in #7139.

## Current behavior (updates)

`packages/react/src/components/simple-grid/simple-grid.test.browser.tsx` held 12 tests, but only the four `gridTemplateColumns` assertions actually need a real browser (they read declared CSS rules and resolved `getComputedStyle`). The other eight tests were either pure metadata reads or render assertions that work under jsdom.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)** — new `simple-grid.test.tsx` (8 tests)

- a11y check
- `displayName`
- `className`
- `tagName`
- `minChildWidth` null in responsive array
- `minChildWidth` undefined in responsive object
- `columns` null in responsive array
- `columns` undefined in responsive object

**browser (`#test/browser`)** — `simple-grid.test.browser.tsx` (4 tests)

- `applies minChildWidth correctly` (reads declared `gridTemplateColumns`)
- `applies minChildWidth with number value correctly` (reads declared + resolved `gridTemplateColumns`)
- `applies minChildWidth takes precedence over columns` (reads declared `gridTemplateColumns`)
- `applies columns correctly` (reads declared `gridTemplateColumns`)

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/simple-grid/` — 8 tests pass
- `pnpm react test:browser --run src/components/simple-grid/` — 4 tests x 3 engines pass
- `pnpm react lint` — 0 warnings, 0 errors

Coverage on `packages/react/src/components/simple-grid/`:

| Project  | Stmts    | Branch   | Funcs    | Lines    |
| -------- | -------- | -------- | -------- | -------- |
| jsdom    | 100%     | 100%     | 100%     | 100%     |
| chromium | 100%     | 66.66%   | 100%     | 100%     |
| Combined | **100%** | **100%** | **100%** | **100%** |

Baseline (browser-only): 100% / 100% / 100% / 100%. Combined coverage matches baseline.

Sub-issue of #7141.