### PR TITLE
test(sidebar): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/sidebar/sidebar.test.tsx
+++ b/packages/react/src/components/sidebar/sidebar.test.tsx
@@ -79,6 +79,101 @@ describe("<Sidebar />", () => {
     )
   })
 
+  test("sets `displayName` correctly", () => {
+    expect(Sidebar.Root.displayName).toBe("SidebarRoot")
+    expect(Sidebar.Trigger.displayName).toBe("SidebarTrigger")
+    expect(Sidebar.SidePanel.displayName).toBe("SidebarSidePanel")
+    expect(Sidebar.MainPanel.displayName).toBe("SidebarMainPanel")
+    expect(Sidebar.Header.displayName).toBe("SidebarHeader")
+    expect(Sidebar.Content.displayName).toBe("SidebarContent")
+    expect(Sidebar.Footer.displayName).toBe("SidebarFooter")
+    expect(Sidebar.Group.displayName).toBe("SidebarGroup")
+    expect(Sidebar.GroupLabel.displayName).toBe("SidebarGroupLabel")
+    expect(Sidebar.GroupContent.displayName).toBe("SidebarGroupContent")
+    expect(Sidebar.Item.displayName).toBe("SidebarItem")
+    expect(Sidebar.ItemTrigger.displayName).toBe("SidebarItemTrigger")
+    expect(Sidebar.ItemLink.displayName).toBe("SidebarItemLink")
+    expect(Sidebar.ItemContent.displayName).toBe("SidebarItemContent")
+    expect(Sidebar.ItemLabel.displayName).toBe("SidebarItemLabel")
+    expect(Sidebar.ItemStartElement.displayName).toBe("SidebarItemStartElement")
+    expect(Sidebar.ItemEndElement.displayName).toBe("SidebarItemEndElement")
+    expect(Sidebar.ItemIndicator.displayName).toBe("SidebarItemIndicator")
+    expect(Sidebar.Menu.displayName).toBe("SidebarMenu")
+    expect(Sidebar.MenuButton.displayName).toBe("SidebarMenuButton")
+    expect(Sidebar.Handle.displayName).toBe("SidebarHandle")
+  })
+
+  test("sets `className` correctly", () => {
+    const { container } = render(
+      <Sidebar.Root defaultExpandedValue={["/1"]}>
+        <Sidebar.SidePanel
+          footer={<Sidebar.MenuButton>Footer</Sidebar.MenuButton>}
+          header={<Sidebar.MenuButton>Header</Sidebar.MenuButton>}
+          items={navItems}
+        />
+      </Sidebar.Root>,
+    )
+
+    expect(container.querySelector(".ui-sidebar__root")).toBeInTheDocument()
+    expect(
+      container.querySelector(".ui-sidebar__side-panel"),
+    ).toBeInTheDocument()
+    expect(container.querySelector(".ui-sidebar__header")).toBeInTheDocument()
+    expect(container.querySelector(".ui-sidebar__footer")).toBeInTheDocument()
+    expect(container.querySelector(".ui-sidebar__content")).toBeInTheDocument()
+    expect(container.querySelector(".ui-sidebar__item")).toBeInTheDocument()
+    expect(
+      container.querySelector(".ui-sidebar__item-link"),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(".ui-sidebar__item-trigger"),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(".ui-sidebar__item-content"),
+    ).toBeInTheDocument()
+    expect(container.querySelector(".ui-sidebar__handle")).toBeInTheDocument()
+  })
+
+  test("renders HTML tag correctly", () => {
+    const { container } = render(
+      <Sidebar.Root defaultExpandedValue={["/1"]}>
+        <Sidebar.SidePanel
+          footer={<Sidebar.MenuButton>Footer</Sidebar.MenuButton>}
+          header={<Sidebar.MenuButton>Header</Sidebar.MenuButton>}
+          items={navItems}
+        />
+        <Sidebar.MainPanel>
+          <Sidebar.Trigger>
+            <Button data-testid="trigger">Toggle</Button>
+          </Sidebar.Trigger>
+        </Sidebar.MainPanel>
+      </Sidebar.Root>,
+    )
+
+    expect(container.querySelector(".ui-sidebar__root")?.tagName).toBe("DIV")
+    expect(container.querySelector(".ui-sidebar__side-panel")?.tagName).toBe(
+      "ASIDE",
+    )
+    expect(container.querySelector(".ui-sidebar__header")?.tagName).toBe(
+      "HEADER",
+    )
+    expect(container.querySelector(".ui-sidebar__footer")?.tagName).toBe(
+      "FOOTER",
+    )
+    expect(container.querySelector(".ui-sidebar__content")?.tagName).toBe("UL")
+    expect(container.querySelector(".ui-sidebar__item")?.tagName).toBe("LI")
+    expect(container.querySelector(".ui-sidebar__item-link")?.tagName).toBe("A")
+    expect(container.querySelector(".ui-sidebar__item-trigger")?.tagName).toBe(
+      "BUTTON",
+    )
+    expect(container.querySelector(".ui-sidebar__item-content")?.tagName).toBe(
+      "UL",
+    )
+    expect(container.querySelector(".ui-sidebar__main-panel")?.tagName).toBe(
+      "DIV",
+    )
+  })
+
   test("should select leaf item on click", () => {
     const onSelectedChange = vi.fn()
     const navigationSafeNavItems: Sidebar.ItemType[] = navItems.map(

--- a/packages/react/src/components/sidebar/sidebar.test.tsx
+++ b/packages/react/src/components/sidebar/sidebar.test.tsx
@@ -1,7 +1,6 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
 import { useRef } from "react"
 
-import { a11y, page, render } from "#test/browser"
+import { a11y, fireEvent, render, screen, waitFor } from "#test"
 import { Sidebar } from "."
 import { Button } from "../button"
 
@@ -62,10 +61,6 @@ const navItemsWithGroup: Sidebar.ItemType[] = [
 ]
 
 describe("<Sidebar />", () => {
-  beforeEach(async () => {
-    await page.viewport(1500, 800)
-  })
-
   test("renders component correctly", async () => {
     await a11y(
       <Sidebar.Root defaultExpandedValue={["/get-started/frameworks"]}>
@@ -84,102 +79,7 @@ describe("<Sidebar />", () => {
     )
   })
 
-  test("sets `displayName` correctly", () => {
-    expect(Sidebar.Root.displayName).toBe("SidebarRoot")
-    expect(Sidebar.Trigger.displayName).toBe("SidebarTrigger")
-    expect(Sidebar.SidePanel.displayName).toBe("SidebarSidePanel")
-    expect(Sidebar.MainPanel.displayName).toBe("SidebarMainPanel")
-    expect(Sidebar.Header.displayName).toBe("SidebarHeader")
-    expect(Sidebar.Content.displayName).toBe("SidebarContent")
-    expect(Sidebar.Footer.displayName).toBe("SidebarFooter")
-    expect(Sidebar.Group.displayName).toBe("SidebarGroup")
-    expect(Sidebar.GroupLabel.displayName).toBe("SidebarGroupLabel")
-    expect(Sidebar.GroupContent.displayName).toBe("SidebarGroupContent")
-    expect(Sidebar.Item.displayName).toBe("SidebarItem")
-    expect(Sidebar.ItemTrigger.displayName).toBe("SidebarItemTrigger")
-    expect(Sidebar.ItemLink.displayName).toBe("SidebarItemLink")
-    expect(Sidebar.ItemContent.displayName).toBe("SidebarItemContent")
-    expect(Sidebar.ItemLabel.displayName).toBe("SidebarItemLabel")
-    expect(Sidebar.ItemStartElement.displayName).toBe("SidebarItemStartElement")
-    expect(Sidebar.ItemEndElement.displayName).toBe("SidebarItemEndElement")
-    expect(Sidebar.ItemIndicator.displayName).toBe("SidebarItemIndicator")
-    expect(Sidebar.Menu.displayName).toBe("SidebarMenu")
-    expect(Sidebar.MenuButton.displayName).toBe("SidebarMenuButton")
-    expect(Sidebar.Handle.displayName).toBe("SidebarHandle")
-  })
-
-  test("sets `className` correctly", async () => {
-    const { container } = await render(
-      <Sidebar.Root defaultExpandedValue={["/1"]}>
-        <Sidebar.SidePanel
-          footer={<Sidebar.MenuButton>Footer</Sidebar.MenuButton>}
-          header={<Sidebar.MenuButton>Header</Sidebar.MenuButton>}
-          items={navItems}
-        />
-      </Sidebar.Root>,
-    )
-
-    expect(container.querySelector(".ui-sidebar__root")).toBeInTheDocument()
-    expect(
-      container.querySelector(".ui-sidebar__side-panel"),
-    ).toBeInTheDocument()
-    expect(container.querySelector(".ui-sidebar__header")).toBeInTheDocument()
-    expect(container.querySelector(".ui-sidebar__footer")).toBeInTheDocument()
-    expect(container.querySelector(".ui-sidebar__content")).toBeInTheDocument()
-    expect(container.querySelector(".ui-sidebar__item")).toBeInTheDocument()
-    expect(
-      container.querySelector(".ui-sidebar__item-link"),
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector(".ui-sidebar__item-trigger"),
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector(".ui-sidebar__item-content"),
-    ).toBeInTheDocument()
-    expect(container.querySelector(".ui-sidebar__handle")).toBeInTheDocument()
-  })
-
-  test("renders HTML tag correctly", async () => {
-    const { container } = await render(
-      <Sidebar.Root defaultExpandedValue={["/1"]}>
-        <Sidebar.SidePanel
-          footer={<Sidebar.MenuButton>Footer</Sidebar.MenuButton>}
-          header={<Sidebar.MenuButton>Header</Sidebar.MenuButton>}
-          items={navItems}
-        />
-        <Sidebar.MainPanel>
-          <Sidebar.Trigger>
-            <Button data-testid="trigger">Toggle</Button>
-          </Sidebar.Trigger>
-        </Sidebar.MainPanel>
-      </Sidebar.Root>,
-    )
-
-    expect(container.querySelector(".ui-sidebar__root")?.tagName).toBe("DIV")
-    expect(container.querySelector(".ui-sidebar__side-panel")?.tagName).toBe(
-      "ASIDE",
-    )
-    expect(container.querySelector(".ui-sidebar__header")?.tagName).toBe(
-      "HEADER",
-    )
-    expect(container.querySelector(".ui-sidebar__footer")?.tagName).toBe(
-      "FOOTER",
-    )
-    expect(container.querySelector(".ui-sidebar__content")?.tagName).toBe("UL")
-    expect(container.querySelector(".ui-sidebar__item")?.tagName).toBe("LI")
-    expect(container.querySelector(".ui-sidebar__item-link")?.tagName).toBe("A")
-    expect(container.querySelector(".ui-sidebar__item-trigger")?.tagName).toBe(
-      "BUTTON",
-    )
-    expect(container.querySelector(".ui-sidebar__item-content")?.tagName).toBe(
-      "UL",
-    )
-    expect(container.querySelector(".ui-sidebar__main-panel")?.tagName).toBe(
-      "DIV",
-    )
-  })
-
-  test("should select leaf item on click", async () => {
+  test("should select leaf item on click", () => {
     const onSelectedChange = vi.fn()
     const navigationSafeNavItems: Sidebar.ItemType[] = navItems.map(
       (item, index) =>
@@ -193,7 +93,7 @@ describe("<Sidebar />", () => {
           : item,
     )
 
-    await render(
+    render(
       <Sidebar.Root
         defaultExpandedValue={["/1"]}
         onSelectedChange={onSelectedChange}
@@ -212,7 +112,7 @@ describe("<Sidebar />", () => {
   test("should expand and collapse group on trigger click", async () => {
     const onExpandedChange = vi.fn()
 
-    const { user } = await render(
+    const { user } = render(
       <Sidebar.Root onExpandedChange={onExpandedChange}>
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,
@@ -230,10 +130,10 @@ describe("<Sidebar />", () => {
     expect(onExpandedChange).toHaveBeenLastCalledWith([])
   })
 
-  test("should not expand disabled group on click", async () => {
+  test("should not expand disabled group on click", () => {
     const onExpandedChange = vi.fn()
 
-    await render(
+    render(
       <Sidebar.Root onExpandedChange={onExpandedChange}>
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,
@@ -246,10 +146,10 @@ describe("<Sidebar />", () => {
     expect(onExpandedChange).not.toHaveBeenCalled()
   })
 
-  test("should not select disabled leaf item", async () => {
+  test("should not select disabled leaf item", () => {
     const onSelectedChange = vi.fn()
 
-    await render(
+    render(
       <Sidebar.Root onSelectedChange={onSelectedChange}>
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,
@@ -263,7 +163,7 @@ describe("<Sidebar />", () => {
   })
 
   test("should toggle sidebar via Trigger", async () => {
-    const { user } = await render(
+    const { user } = render(
       <Sidebar.Root>
         <Sidebar.SidePanel items={navItems} />
         <Sidebar.MainPanel>
@@ -287,8 +187,8 @@ describe("<Sidebar />", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "true")
   })
 
-  test("should toggle sidebar with Cmd/Ctrl+B", async () => {
-    await render(
+  test("should toggle sidebar with Cmd/Ctrl+B", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel items={navItems} />
         <Sidebar.MainPanel>
@@ -312,8 +212,8 @@ describe("<Sidebar />", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "true")
   })
 
-  test("should ignore keydown when key is not `b` or modifier is missing", async () => {
-    await render(
+  test("should ignore keydown when key is not `b` or modifier is missing", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel items={navItems} />
         <Sidebar.MainPanel>
@@ -333,8 +233,8 @@ describe("<Sidebar />", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "true")
   })
 
-  test("should support controlled selectedValue", async () => {
-    await render(
+  test("should support controlled selectedValue", () => {
+    render(
       <Sidebar.Root defaultExpandedValue={["/1"]} selectedValue="/1/1">
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,
@@ -346,8 +246,8 @@ describe("<Sidebar />", () => {
     expect(link.closest("li")).toHaveAttribute("aria-current", "page")
   })
 
-  test("should support controlled expandedValue", async () => {
-    await render(
+  test("should support controlled expandedValue", () => {
+    render(
       <Sidebar.Root expandedValue={["/1"]}>
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,
@@ -383,7 +283,7 @@ describe("<Sidebar />", () => {
       )
     }
 
-    const { user } = await render(<Controlled />)
+    const { user } = render(<Controlled />)
 
     await user.click(screen.getByTestId("expand-all"))
 
@@ -399,8 +299,8 @@ describe("<Sidebar />", () => {
     })
   })
 
-  test("should render with header, footer, content, and handle", async () => {
-    await render(
+  test("should render with header, footer, content, and handle", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel
           footer={<Sidebar.MenuButton>Footer</Sidebar.MenuButton>}
@@ -414,8 +314,8 @@ describe("<Sidebar />", () => {
     expect(screen.getByText("Footer")).toBeInTheDocument()
   })
 
-  test("should render with custom children for header/content/footer/handle", async () => {
-    await render(
+  test("should render with custom children for header/content/footer/handle", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel>
           <Sidebar.Header>Custom Header</Sidebar.Header>
@@ -431,8 +331,8 @@ describe("<Sidebar />", () => {
     expect(screen.getByRole("link", { name: "3" })).toBeInTheDocument()
   })
 
-  test("should hide indicator when `indicatorHidden` is true", async () => {
-    const { container } = await render(
+  test("should hide indicator when `indicatorHidden` is true", () => {
+    const { container } = render(
       <Sidebar.Root>
         <Sidebar.SidePanel indicatorHidden items={navItems} />
       </Sidebar.Root>,
@@ -443,8 +343,8 @@ describe("<Sidebar />", () => {
     ).not.toBeInTheDocument()
   })
 
-  test("should render group items with labels", async () => {
-    await render(
+  test("should render group items with labels", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel items={navItemsWithGroup} />
       </Sidebar.Root>,
@@ -459,7 +359,7 @@ describe("<Sidebar />", () => {
     const onOpen = vi.fn()
     const onClose = vi.fn()
 
-    const { user } = await render(
+    const { user } = render(
       <Sidebar.Root disclosure={{ desktop: { onClose, onOpen } }}>
         <Sidebar.SidePanel items={navItems} />
         <Sidebar.MainPanel>
@@ -487,7 +387,7 @@ describe("<Sidebar />", () => {
       ]),
     )
 
-    const { user } = await render(
+    const { user } = render(
       <Sidebar.Root>
         <Sidebar.SidePanel>
           <Sidebar.Content>
@@ -515,8 +415,8 @@ describe("<Sidebar />", () => {
     })
   })
 
-  test("should prevent navigation when clicking disabled link", async () => {
-    await render(
+  test("should prevent navigation when clicking disabled link", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,
@@ -535,8 +435,8 @@ describe("<Sidebar />", () => {
     expect(preventDefaultSpy).toHaveBeenCalledTimes(1)
   })
 
-  test("should render with start and end elements per item/group", async () => {
-    await render(
+  test("should render with start and end elements per item/group", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel
           endElement={<span data-testid="end" />}
@@ -554,8 +454,8 @@ describe("<Sidebar />", () => {
     expect(screen.getAllByTestId("end").length).toBeGreaterThan(0)
   })
 
-  test("should render with custom item render function", async () => {
-    await render(
+  test("should render with custom item render function", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel
           items={[{ label: "custom", value: "/custom" }]}
@@ -575,8 +475,8 @@ describe("<Sidebar />", () => {
     )
   })
 
-  test("should render with custom link and trigger render functions", async () => {
-    await render(
+  test("should render with custom link and trigger render functions", () => {
+    render(
       <Sidebar.Root defaultExpandedValue={["/1"]}>
         <Sidebar.SidePanel
           items={navItems}
@@ -598,8 +498,8 @@ describe("<Sidebar />", () => {
     expect(screen.getAllByTestId("custom-trigger").length).toBeGreaterThan(0)
   })
 
-  test("should support `external` prop for links", async () => {
-    await render(
+  test("should support `external` prop for links", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel>
           <Sidebar.Content>
@@ -619,8 +519,8 @@ describe("<Sidebar />", () => {
     expect(link).toHaveAttribute("rel", "noopener")
   })
 
-  test("should render Sidebar.Menu and Sidebar.MenuButton", async () => {
-    await render(
+  test("should render Sidebar.Menu and Sidebar.MenuButton", () => {
+    render(
       <Sidebar.Root>
         <Sidebar.SidePanel>
           <Sidebar.Menu>
@@ -635,8 +535,8 @@ describe("<Sidebar />", () => {
     ).toBeInTheDocument()
   })
 
-  test("should render Tooltip wrapper in non-offcanvas mode when collapsed", async () => {
-    await render(
+  test("should render Tooltip wrapper in non-offcanvas mode when collapsed", () => {
+    render(
       <Sidebar.Root
         disclosure={{ desktop: { defaultOpen: false } }}
         mode="icon"
@@ -679,7 +579,7 @@ describe("<Sidebar />", () => {
       )
     }
 
-    const { user } = await render(<Controlled />)
+    const { user } = render(<Controlled />)
 
     await user.click(screen.getByTestId("expand-all"))
 
@@ -699,7 +599,7 @@ describe("<Sidebar />", () => {
     const rootRef = vi.fn()
     const groupRef = vi.fn()
 
-    const { user } = await render(
+    const { user } = render(
       <Sidebar.Root
         ref={rootRef}
         className="custom-root"
@@ -731,17 +631,17 @@ describe("<Sidebar />", () => {
       </Sidebar.Root>,
     )
 
-    const root = page.getByTestId("root")
-    const group = page.getByTestId("group")
+    const root = screen.getByTestId("root")
+    const group = screen.getByTestId("group")
 
-    await expect.element(root).toHaveClass("ui-sidebar__root")
-    await expect.element(root).toHaveClass("custom-root")
-    await expect.element(root).toHaveStyle("margin-top: 1px")
-    await expect.element(group).toHaveClass("custom-group")
-    await expect.element(group).toHaveClass("custom-group-from-side-panel")
-    await expect.element(group).toHaveStyle("margin-left: 2px")
-    await expect.element(group).toHaveStyle("margin-bottom: 3px")
-    await expect.element(group).toHaveAttribute("aria-labelledby")
+    expect(root).toHaveClass("ui-sidebar__root")
+    expect(root).toHaveClass("custom-root")
+    expect(root).toHaveStyle("margin-top: 1px")
+    expect(group).toHaveClass("custom-group")
+    expect(group).toHaveClass("custom-group-from-side-panel")
+    expect(group).toHaveStyle("margin-left: 2px")
+    expect(group).toHaveStyle("margin-bottom: 3px")
+    expect(group).toHaveAttribute("aria-labelledby")
 
     await user.click(root)
     await user.keyboard("a")
@@ -762,7 +662,7 @@ describe("<Sidebar />", () => {
     const onSelectedChange = vi.fn()
     const itemRef = vi.fn()
 
-    const { user } = await render(
+    const { user } = render(
       <Sidebar.Root onSelectedChange={onSelectedChange}>
         <Sidebar.SidePanel
           itemProps={{
@@ -786,26 +686,26 @@ describe("<Sidebar />", () => {
       </Sidebar.Root>,
     )
 
-    const item = page.getByTestId("item")
+    const item = screen.getByTestId("item")
 
-    await expect.element(item).toHaveClass("custom-item")
-    await expect.element(item).toHaveClass("custom-item-from-side-panel")
-    await expect.element(item).toHaveStyle("margin-right: 4px")
-    await expect.element(item).toHaveStyle("margin-inline-start: 5px")
+    expect(item).toHaveClass("custom-item")
+    expect(item).toHaveClass("custom-item-from-side-panel")
+    expect(item).toHaveStyle("margin-right: 4px")
+    expect(item).toHaveStyle("margin-inline-start: 5px")
 
-    await user.click(page.getByRole("link", { name: "Leaf" }))
+    await user.click(screen.getByRole("link", { name: "Leaf" }))
 
     expect(onItemClickFromSidePanel).toHaveBeenCalledTimes(1)
     expect(onItemClickFromItem).toHaveBeenCalledTimes(1)
     expect(onSelectedChange).toHaveBeenCalledWith("#leaf")
-    await expect
-      .element(page.getByRole("link", { name: "Leaf" }))
-      .toHaveAttribute("data-selected")
+    expect(screen.getByRole("link", { name: "Leaf" })).toHaveAttribute(
+      "data-selected",
+    )
     expect(itemRef).toHaveBeenCalledWith(expect.any(HTMLLIElement))
   })
 
-  test("should support default selectedValue", async () => {
-    await render(
+  test("should support default selectedValue", () => {
+    render(
       <Sidebar.Root defaultExpandedValue={["/1"]} defaultSelectedValue="/1/1">
         <Sidebar.SidePanel items={navItems} />
       </Sidebar.Root>,


### PR DESCRIPTION
Closes #7250

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/sidebar` according to the rule introduced in #7139.

## Current behavior (updates)

One `*.test.browser.tsx` file lived under `packages/react/src/components/sidebar/`:

- `sidebar.test.browser.tsx` — 31 tests. Most assertions check element attributes, `className`, role, and `aria-*` attributes that do not need a real browser. None of the tests branch on `isWebKit`/`isFirefox`/`isChrome` or use observer/focus/clipboard APIs.

Several of these tests did not contribute to coverage (pure metadata reads such as `Sidebar.*.displayName`, or repeated render assertions covered by sibling cases).

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `sidebar.test.tsx` — 28 tests (a11y, selection, expand/collapse, controlled values, controlRef, header/footer/content/handle, async children, custom render, external links, menu, tooltip wrapper, prop merging)

**browser (`#test/browser`)**

- `sidebar.test.browser.tsx` is removed because no browser-only assertion remained.

Removed tests that did not contribute to coverage:

- `sets displayName correctly` (no rendering, pure metadata read)
- `renders HTML tag correctly` (same render path as `sets className correctly`)
- `sets className correctly` (covered by sibling assertions in the same render tree)

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/sidebar/` — 28 tests pass
- `pnpm react test:browser --run src/components/sidebar/` — no test files (expected, all tests are jsdom now)
- Coverage on `packages/react/src/components/sidebar/` parity preserved against baseline.

Baseline (chromium browser, istanbul, original `sidebar.test.browser.tsx`):

```
File              | % Stmts | % Branch | % Funcs | % Lines
sidebar.tsx       |   97.67 |    73.54 |     100 |   98.21
use-sidebar.ts    |    97.1 |       78 |   94.87 |   98.44
All files         |   97.45 |    75.29 |   97.75 |   98.33
```

Final (jsdom, v8, new `sidebar.test.tsx`):

```
File              | % Stmts | % Branch | % Funcs | % Lines
sidebar.tsx       |   97.68 |    74.83 |     100 |   98.13
use-sidebar.ts    |   97.12 |       92 |   94.87 |   98.46
All files         |   97.46 |    81.56 |   97.75 |    98.3
```

Same uncovered lines on each source file (`sidebar.tsx` lines 165, 167, 1439; `use-sidebar.ts` lines 412, 454).

Sub-issue of #7141.