### PR TITLE
test(visually-hidden): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/components/visually-hidden/visually-hidden.test.browser.tsx
+++ b/packages/react/src/components/visually-hidden/visually-hidden.test.browser.tsx
@@ -1,9 +1,0 @@
-import { page, render } from "#test/browser"
-import { VisuallyHidden } from "./"
-
-describe("<VisuallyHidden />", () => {
-  test("renders component correctly", async () => {
-    await render(<VisuallyHidden>Test</VisuallyHidden>)
-    expect(page.getByText("Test").element().textContent).toBe("Test")
-  })
-})

--- a/packages/react/src/components/visually-hidden/visually-hidden.test.tsx
+++ b/packages/react/src/components/visually-hidden/visually-hidden.test.tsx
@@ -1,0 +1,8 @@
+import { a11y } from "#test"
+import { VisuallyHidden } from "./"
+
+describe("<VisuallyHidden />", () => {
+  test("renders component correctly", async () => {
+    await a11y(<VisuallyHidden>Test</VisuallyHidden>)
+  })
+})

--- a/packages/react/src/components/visually-hidden/visually-hidden.test.tsx
+++ b/packages/react/src/components/visually-hidden/visually-hidden.test.tsx
@@ -1,8 +1,11 @@
-import { a11y } from "#test"
+import { a11y, render, screen } from "#test"
 import { VisuallyHidden } from "./"
 
 describe("<VisuallyHidden />", () => {
   test("renders component correctly", async () => {
+    render(<VisuallyHidden>Test</VisuallyHidden>)
+
+    expect(screen.getByText("Test")).toBeInTheDocument()
     await a11y(<VisuallyHidden>Test</VisuallyHidden>)
   })
 })


### PR DESCRIPTION
Closes #7273

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/components/visually-hidden` according to the rule introduced in #7139.

## Current behavior (updates)

A single `*.test.browser.tsx` file lived under `packages/react/src/components/visually-hidden/`:

- `visually-hidden.test.browser.tsx` — 1 test (`renders component correctly`) that called `render(<VisuallyHidden>Test</VisuallyHidden>)` and asserted on `page.getByText("Test").element().textContent`.

The assertion is a pure render + text content read. It does not need a real browser engine: there is no computed-style read, no event handling, no observer, no focus assertion, and no browser-only API. The five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md) routes this test to jsdom.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `visually-hidden.test.tsx` — 1 test (`a11y`)

**browser (`#test/browser`)**

- `visually-hidden.test.browser.tsx` is removed because no browser-only assertion remained.

Removed tests that did not contribute to coverage:

- None. The single existing browser test was relocated to jsdom and rewritten as `a11y(<VisuallyHidden>Test</VisuallyHidden>)`. `a11y` renders the component, so the same code paths in `visually-hidden.tsx` and `visually-hidden.style.ts` stay covered, and axe additionally checks the ARIA contract.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/components/visually-hidden/` — 1 test passes
- `pnpm react test:browser --run src/components/visually-hidden/` — no test files (every test is jsdom-friendly; the browser file was deleted)
- `pnpm react lint` passes

Coverage on `packages/react/src/components/visually-hidden/`:

| Project  | Metric     | Baseline    | Final       |
| -------- | ---------- | ----------- | ----------- |
| jsdom    | Statements | 0% (0/4)    | 100% (4/4)  |
| jsdom    | Branches   | 100% (0/0)  | 100% (0/0)  |
| jsdom    | Functions  | 100% (0/0)  | 100% (0/0)  |
| jsdom    | Lines      | 0% (0/4)    | 100% (4/4)  |
| chromium | Statements | 100% (3/3)  | n/a (no test files) |
| chromium | Branches   | 100% (0/0)  | n/a         |
| chromium | Functions  | 100% (0/0)  | n/a         |
| chromium | Lines      | 100% (3/3)  | n/a         |

Combined per-source-file coverage (covered in either project) is unchanged at 100% statements / 100% branches / 100% functions / 100% lines. `visually-hidden.tsx` and `visually-hidden.style.ts` both remain fully covered.

Sub-issue of #7141.