### PR TITLE
test(core): recategorize and clean up browser tests in core/components

### DIFF
--- a/packages/react/src/core/components/props.test.tsx
+++ b/packages/react/src/core/components/props.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "#test/browser"
+import { renderHook } from "#test"
 import {
   chainProps,
   createShouldForwardProp,
@@ -108,7 +108,7 @@ describe("mergeProps", () => {
 describe("chainProps", () => {
   test("returns identity function when no props", () => {
     const chain = chainProps()()
-    expect(chain({ a: 1 } as any)).toStrictEqual({ a: 1 })
+    expect(chain({ a: 1 })).toStrictEqual({ a: 1 })
   })
 
   test("merges single props object", () => {
@@ -194,8 +194,8 @@ describe("extractProps", () => {
 })
 
 describe("useSplitProps", () => {
-  test("splits props based on keys", async () => {
-    const { result } = await renderHook(() =>
+  test("splits props based on keys", () => {
+    const { result } = renderHook(() =>
       useSplitProps({ id: "test", color: "red", fontSize: "16px" }, [
         "color",
         "fontSize",
@@ -208,8 +208,8 @@ describe("useSplitProps", () => {
 })
 
 describe("useExtractProps", () => {
-  test("extracts props via hook", async () => {
-    const { result } = await renderHook(() =>
+  test("extracts props via hook", () => {
+    const { result } = renderHook(() =>
       useExtractProps({ color: "red", fontSize: "16px" }, ["color"]),
     )
     expect(result.current).toStrictEqual({ color: "red" })


### PR DESCRIPTION
Closes #7275

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/core/components` according to the rule introduced in #7139.

## Current behavior (updates)

One `*.test.browser.tsx` file lived under `packages/react/src/core/components/`:

- `props.test.browser.tsx` — 25 tests across 7 describe blocks (`createShouldForwardProp`, `mergeProps`, `chainProps`, `isEqualProps`, `extractProps`, `useSplitProps`, `useExtractProps`).

Each assertion is a pure JS/object comparison (`toStrictEqual`, `toBeTruthy`, `toHaveBeenCalledWith`). Two cases use `renderHook` to exercise `useSplitProps` / `useExtractProps`, but neither hook touches the DOM, drives events, observes layout, manages focus, or uses a browser-only API.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md). Nothing in the file required a real browser engine, so the entire file moves to jsdom.

**jsdom (`#test`)**

- `props.test.tsx` — 25 tests (3 `createShouldForwardProp`, 9 `mergeProps`, 5 `chainProps`, 3 `isEqualProps`, 3 `extractProps`, 1 `useSplitProps`, 1 `useExtractProps`)

**browser (`#test/browser`)**

- `props.test.browser.tsx` is removed because no browser-only assertion remained.

Removed tests that did not contribute to coverage:

- None. Re-categorization alone preserved or improved combined coverage on every source file, so no test was pruned.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/core/components/` — 25 tests pass
- `pnpm react test:browser --run src/core/components/` — no test files (acceptable; nothing required a real browser)
- `pnpm react lint` — 0 warnings, 0 errors

Coverage on `packages/react/src/core/components/` (per-source-file, combined jsdom-or-browser, baseline vs final):

| File | Baseline (chromium) | Final (jsdom) |
| --- | --- | --- |
| `props.ts` | 94.11% / 86.95% / 100% / 96.55% | 94.11% / 88.40% / 100% / 96.55% |
| `create-component.tsx` | 64.7% / 48.38% / 66.66% / 66.08% | 65% / 51.61% / 66.66% / 66.37% |
| `use-component-style.ts` | 39.57% / 34.83% / 36.58% / 43.11% | 39.89% / 38.06% / 36.58% / 44.24% |
| `utils.ts` | 100% / 80% / 100% / 100% | 100% / 80% / 100% / 100% |

(Stmts / Branch / Funcs / Lines.) Every source file meets or exceeds baseline.

Sub-issue of #7141.