### PR TITLE
test(core): recategorize and clean up browser tests in core/css

### DIFF
--- a/packages/react/src/core/css/animation.test.ts
+++ b/packages/react/src/core/css/animation.test.ts
@@ -1,5 +1,5 @@
 import type { UsageTheme } from "../system"
-import { system } from "#test/browser"
+import { system } from "#test"
 import { animation, keyframes } from "./animation"
 
 const createMockOptions = () => ({

--- a/packages/react/src/core/css/at-rule.test.ts
+++ b/packages/react/src/core/css/at-rule.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { generateAtRule } from "./at-rule"
 
 describe("atRule", () => {

--- a/packages/react/src/core/css/calc.test.ts
+++ b/packages/react/src/core/css/calc.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { generateCalc } from "./calc"
 
 describe("generateCalc", () => {

--- a/packages/react/src/core/css/color-mix.test.ts
+++ b/packages/react/src/core/css/color-mix.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { colorMix } from "./color-mix"
 
 describe("colorMix", () => {

--- a/packages/react/src/core/css/color-scheme.test.ts
+++ b/packages/react/src/core/css/color-scheme.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { colorScheme } from "./color-scheme"
 
 describe("colorScheme", () => {

--- a/packages/react/src/core/css/config.test.ts
+++ b/packages/react/src/core/css/config.test.ts
@@ -1,5 +1,5 @@
 import type { Dict } from "../../utils"
-import { system } from "#test/browser"
+import { system } from "#test"
 import { transforms } from "./config"
 
 describe("bgClip", () => {

--- a/packages/react/src/core/css/css.test.ts
+++ b/packages/react/src/core/css/css.test.ts
@@ -1,4 +1,4 @@
-import { styledTheme, system } from "#test/browser"
+import { styledTheme, system } from "#test"
 import { getCondition } from "./conditions"
 import { css } from "./css"
 

--- a/packages/react/src/core/css/display.test.ts
+++ b/packages/react/src/core/css/display.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { visuallyHiddenAttributes } from "../../utils"
 import { display } from "./display"
 

--- a/packages/react/src/core/css/filter.test.ts
+++ b/packages/react/src/core/css/filter.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { generateFilter } from "./filter"
 
 describe("generateFilter", () => {

--- a/packages/react/src/core/css/focus-ring.test.ts
+++ b/packages/react/src/core/css/focus-ring.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { focusRingStyle, generateFocusRing } from "./focus-ring"
 
 describe("generateFocusRing", () => {

--- a/packages/react/src/core/css/function.test.ts
+++ b/packages/react/src/core/css/function.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { generateFunction } from "./function"
 
 describe("function", () => {

--- a/packages/react/src/core/css/gradient.test.ts
+++ b/packages/react/src/core/css/gradient.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { gradient } from "./gradient"
 
 describe("gradient", () => {

--- a/packages/react/src/core/css/grid.test.ts
+++ b/packages/react/src/core/css/grid.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { grid } from "./grid"
 
 describe("grid", () => {

--- a/packages/react/src/core/css/style.test.ts
+++ b/packages/react/src/core/css/style.test.ts
@@ -1,5 +1,5 @@
 import type { UsageTheme } from "../system"
-import { system } from "#test/browser"
+import { system } from "#test"
 import { generateStyle } from "./style"
 
 describe("generateStyle", () => {

--- a/packages/react/src/core/css/transform.test.ts
+++ b/packages/react/src/core/css/transform.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { transform } from "./transform"
 
 describe("transform", () => {

--- a/packages/react/src/core/css/transition.test.ts
+++ b/packages/react/src/core/css/transition.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import { generateTransition } from "./transition"
 
 describe("generateTransition", () => {

--- a/packages/react/src/core/css/use-inject-vars.test.ts
+++ b/packages/react/src/core/css/use-inject-vars.test.ts
@@ -1,10 +1,10 @@
-import { renderHook } from "#test/browser"
+import { renderHook } from "#test"
 import { useInjectVarsIntoCss, useInjectVarsIntoProps } from "./use-inject-vars"
 
 describe("useInjectVarsIntoCss", () => {
-  test("injects values into css", async () => {
+  test("injects values into css", () => {
     const css = { opacity: "1" }
-    const { result } = await renderHook(() =>
+    const { result } = renderHook(() =>
       useInjectVarsIntoCss(css, { opacity: "opacity" }),
     )
     expect(result.current).toStrictEqual({ "--opacity": "1" })
@@ -12,9 +12,9 @@ describe("useInjectVarsIntoCss", () => {
 })
 
 describe("useInjectVarsIntoProps", () => {
-  test("injects values into props", async () => {
+  test("injects values into props", () => {
     const props = { opacity: "1" }
-    const { result } = await renderHook(() =>
+    const { result } = renderHook(() =>
       useInjectVarsIntoProps(props, { opacity: "opacity" }),
     )
     expect(result.current).toStrictEqual({ "--opacity": "1" })

--- a/packages/react/src/core/css/utils.test.ts
+++ b/packages/react/src/core/css/utils.test.ts
@@ -1,4 +1,4 @@
-import { system } from "#test/browser"
+import { system } from "#test"
 import {
   analyzeCSSValue,
   getCSSFunction,


### PR DESCRIPTION
Closes #7276

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/core/css` according to the rule introduced in #7139.

## Current behavior (updates)

Nineteen `*.test.browser.{ts,tsx}` files lived under `packages/react/src/core/css/`. All but `use-css.test.browser.tsx` only exercised pure transform/utility functions — no DOM read, no events, no observers, no focus, no browser-only API. The whole folder was running on chromium/firefox/webkit even though the assertions are environment-agnostic.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `animation.test.ts` — pure CSS transform output.
- `at-rule.test.ts` — pure media/container/supports rule generation.
- `calc.test.ts` — pure CSS math transform.
- `color-mix.test.ts` — pure color-mix string generation.
- `color-scheme.test.ts` — pure object generation.
- `config.test.ts` — pure transform table.
- `css.test.ts` — pure style-object resolution against the system.
- `display.test.ts` — pure object output.
- `filter.test.ts` — pure transform output.
- `focus-ring.test.ts` — pure transform output.
- `function.test.ts` — pure transform output.
- `gradient.test.ts` — pure string output.
- `grid.test.ts` — pure string output.
- `style.test.ts` — pure object output.
- `transform.test.ts` — pure object output.
- `transition.test.ts` — pure object output.
- `use-inject-vars.test.ts` — `renderHook` of two `useMemo` hooks; no DOM read.
- `utils.test.ts` — pure helpers.

**browser (`#test/browser`)**

- `use-css.test.browser.tsx` — kept in browser. The single test renders a component, applies an emotion-generated class, and asserts `getComputedStyle` via `toHaveStyle({ fontSize: ... })`. That requires the full stylesheet pipeline that browser mode provides.

Removed tests: none. Re-categorization-only PR — every test was preserved and the import was switched from `#test/browser` to `#test`. `use-inject-vars.test.ts` also dropped two no-op `await`s on the now-synchronous `renderHook` from `#test`.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/core/css/` — 18 files / 188 tests pass.
- `pnpm react test:browser --run src/core/css/` — 1 file / 3 tests pass (one per engine).
- `pnpm react lint` — clean.

Coverage on `packages/react/src/core/css/` (combined = max of jsdom and chromium per source file):

| File | Baseline (chromium) stmt/branch/func/line | Final combined stmt/branch/func/line |
| --- | --- | --- |
| animation.ts | 100 / 82.75 / 100 / 100 | 100 / 93.1 / 100 / 100 |
| at-rule.ts | 100 / 91.66 / 100 / 100 | 100 / 91.66 / 100 / 100 |
| calc.ts | 98.07 / 97.05 / 100 / 100 | 98.07 / 97.05 / 100 / 100 |
| color-mix.ts | 93.75 / 83.78 / 100 / 98.07 | 93.75 / 83.78 / 100 / 98.07 |
| color-scheme.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| conditions.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| config.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| css.ts | 96.63 / 93.75 / 100 / 97.32 | 96.63 / 95 / 100 / 97.32 |
| display.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| filter.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| focus-ring.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| function.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| gradient.ts | 96.77 / 94.11 / 100 / 100 | 96.77 / 97.05 / 100 / 100 |
| grid.ts | 95.83 / 95 / 100 / 100 | 95.83 / 95 / 100 / 100 |
| merge-css.ts | 50 / 100 / 0 / 50 | 50 / 100 / 0 / 50 |
| style.ts | 100 / 73.33 / 100 / 100 | 100 / 80 / 100 / 100 |
| styles.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| token.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| transform.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| transition.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| use-css.ts | 100 / 0 / 100 / 100 | 100 / 0 / 100 / 100 |
| use-inject-vars.ts | 100 / 100 / 100 / 100 | 100 / 100 / 100 / 100 |
| utils.ts | 98.59 / 96.22 / 100 / 100 | 98.59 / 96.22 / 100 / 100 |

Every file matches or exceeds baseline. Several branch numbers improved because v8 (jsdom) reports finer-grained branches than the istanbul instrumentation chromium uses.

Sub-issue of #7141.