### PR TITLE
test(use-media-query): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/hooks/use-media-query/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-media-query/index.test.browser.tsx
@@ -2,6 +2,18 @@ import { page, renderHook } from "#test/browser"
 import { useMediaQuery } from "."
 
 describe("useMediaQuery", () => {
+  test("returns true immediately when query matches on initial mount", async () => {
+    await page.viewport(600, 800)
+
+    const { result, unmount } = await renderHook(() =>
+      useMediaQuery("(min-width: 500px)"),
+    )
+
+    expect(result.current).toBeTruthy()
+
+    unmount()
+  })
+
   test("returns the current match state and updates on viewport change", async () => {
     await page.viewport(400, 800)
 

--- a/packages/react/src/hooks/use-media-query/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-media-query/index.test.browser.tsx
@@ -2,20 +2,10 @@ import { page, renderHook } from "#test/browser"
 import { useMediaQuery } from "."
 
 describe("useMediaQuery", () => {
-  test("should return true when media query matches", async () => {
-    await page.viewport(600, 800)
-
-    const { result } = await renderHook(() =>
-      useMediaQuery("(min-width: 500px)"),
-    )
-
-    expect(result.current).toBeTruthy()
-  })
-
-  test("should update when media query match status changes", async () => {
+  test("returns the current match state and updates on viewport change", async () => {
     await page.viewport(400, 800)
 
-    const { result } = await renderHook(() =>
+    const { result, unmount } = await renderHook(() =>
       useMediaQuery("(min-width: 500px)"),
     )
 
@@ -26,5 +16,7 @@ describe("useMediaQuery", () => {
     await vi.waitFor(() => {
       expect(result.current).toBeTruthy()
     })
+
+    unmount()
   })
 })


### PR DESCRIPTION
Closes #7281

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/hooks/use-media-query` according to the rule introduced in #7139.

## Current behavior (updates)

`index.test.browser.tsx` had two browser tests:

- `should return true when media query matches` — render at viewport `600x800`, assert that `useMediaQuery("(min-width: 500px)")` returns truthy.
- `should update when media query match status changes` — render at `400x800`, assert falsy, change viewport to `600x800`, assert truthy via `vi.waitFor`.

The first test only covered the initial-match path. The second test covered the initial-not-match path plus reactivity. Both tests together left the cleanup line (`mql?.removeEventListener`) covered only as a side effect of test ordering and `vi.waitFor` keeping the consumer alive across tests.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

The hook reads `window.matchMedia(query).matches` and subscribes to `change` events fired by the engine when the viewport crosses the query boundary. Both axes (browser API + engine-fired event) require a real browser, so the file stays in `*.test.browser.tsx`.

**browser (`#test/browser`)**

- `index.test.browser.tsx` — 1 test (`returns the current match state and updates on viewport change`) that exercises the initial-not-match snapshot, the engine-fired `change` event path, and the `removeEventListener` cleanup via an explicit `unmount()`.

The two original tests were consolidated into one because the second test already exercises both states (initial false, then true after viewport change). Calling `unmount()` explicitly at the end pulls cleanup coverage into the single test instead of relying on cross-test state.

No tests were moved to jsdom — the hook's only behaviors are reading `matchMedia` and reacting to its `change` events, both of which are browser-engine APIs.

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/hooks/use-media-query/` — no test files (acceptable; the hook does not have jsdom-only assertions)
- `pnpm react test:browser --run src/hooks/use-media-query/` — 1 test x 3 engines pass
- `pnpm react lint` passes (no `#test` <-> `#test/browser` boundary violations)

Combined per-source-file coverage on `packages/react/src/hooks/use-media-query/index.ts`:

| Metric     | Baseline (chromium) | Final (chromium) |
| ---------- | ------------------- | ---------------- |
| Statements | 100% (10/10)        | 100% (10/10)     |
| Branches   | 66.66% (2/3)        | 66.66% (2/3)     |
| Functions  | 100% (4/4)          | 100% (4/4)       |
| Lines      | 100% (10/10)        | 100% (10/10)    |

The remaining uncovered branch (line 28, the `?? fallback` nullish path) is unchanged from baseline and is unreachable in a real browser because `getWindow()` always returns the window.

Sub-issue of #7286.