### PR TITLE
test(use-timeout): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/hooks/use-timeout/index.test.ts
+++ b/packages/react/src/hooks/use-timeout/index.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "#test/browser"
+import { renderHook } from "#test"
 import { useTimeout } from "."
 
 describe("useTimeout", () => {
@@ -10,10 +10,10 @@ describe("useTimeout", () => {
     vi.useRealTimers()
   })
 
-  test("should call the callback after the specified delay", async () => {
+  test("should call the callback after the specified delay", () => {
     const callback = vi.fn()
 
-    await renderHook(() => useTimeout(callback, 50))
+    renderHook(() => useTimeout(callback, 50))
 
     expect(callback).not.toHaveBeenCalled()
 
@@ -22,20 +22,20 @@ describe("useTimeout", () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  test("should not call the callback when delay is null", async () => {
+  test("should not call the callback when delay is null", () => {
     const callback = vi.fn()
 
-    await renderHook(() => useTimeout(callback, null))
+    renderHook(() => useTimeout(callback, null))
 
     vi.advanceTimersByTime(50)
 
     expect(callback).not.toHaveBeenCalled()
   })
 
-  test("should clear timeout on unmount", async () => {
+  test("should clear timeout on unmount", () => {
     const callback = vi.fn()
 
-    const { unmount } = await renderHook(() => useTimeout(callback, 50))
+    const { unmount } = renderHook(() => useTimeout(callback, 50))
 
     unmount()
 
@@ -44,17 +44,17 @@ describe("useTimeout", () => {
     expect(callback).not.toHaveBeenCalled()
   })
 
-  test("should restart timeout when delay changes", async () => {
+  test("should restart timeout when delay changes", () => {
     const callback = vi.fn()
 
-    const { rerender } = await renderHook(
-      (props) => useTimeout(callback, props?.delay ?? null),
+    const { rerender } = renderHook(
+      ({ delay }: { delay: null | number }) => useTimeout(callback, delay),
       { initialProps: { delay: 5000 } },
     )
 
     expect(callback).not.toHaveBeenCalled()
 
-    await rerender({ delay: 50 })
+    rerender({ delay: 50 })
 
     vi.advanceTimersByTime(50)
 


### PR DESCRIPTION
Closes #7284

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize the browser tests in `packages/react/src/hooks/use-timeout` according to the rule introduced in #7139.

## Current behavior (updates)

`packages/react/src/hooks/use-timeout/index.test.browser.ts` contained 4 tests, all of which exercise pure hook logic with `renderHook` and fake timers. None of them read the DOM, dispatch real events, depend on observers, depend on focus, or use browser-only APIs.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `index.test.ts` — 4 tests (delay fires, null delay no-ops, unmount clears, delay change restarts)

**browser (`#test/browser`)**

- None. `index.test.browser.ts` is removed because no browser-only assertion remains.

No tests were dropped — recategorizing the entire set into jsdom preserves every existing assertion.

## Coverage

`packages/react/src/hooks/use-timeout/index.ts`:

| Project          | Stmts        | Branch    | Funcs      | Lines       |
| ---------------- | ------------ | --------- | ---------- | ----------- |
| Baseline jsdom   | 0% (0/10)    | 0% (0/2)  | 0% (0/3)   | 0% (0/9)    |
| Baseline chromium| 100% (9/9)   | 100% (2/2)| 100% (3/3) | 100% (8/8)  |
| Baseline combined| 100%         | 100%      | 100%       | 100%        |
| Final jsdom      | 100% (10/10) | 100% (2/2)| 100% (3/3) | 100% (9/9)  |
| Final chromium   | n/a (no files)| n/a      | n/a        | n/a         |
| Final combined   | 100%         | 100%      | 100%       | 100%        |

Combined coverage is preserved (>= baseline).

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/hooks/use-timeout/` — 4 tests pass
- `pnpm react test:browser --run src/hooks/use-timeout/` — no test files (acceptable per acceptance criteria)
- Pre-commit lint/format/typecheck pass

Sub-issue of #7286.