### PR TITLE
test(use-resize-observer): recategorize and clean up browser tests

### DIFF
--- a/packages/react/src/hooks/use-resize-observer/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-resize-observer/index.test.browser.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react"
 import { page, render } from "#test/browser"
-import { useResizeObserver } from "./"
+import { useElementSize, useResizeObserver } from "./"
 
 describe("useResizeObserver", () => {
   const ButtonWithSize: FC = () => {
@@ -18,5 +18,24 @@ describe("useResizeObserver", () => {
 
     const button = page.getByRole("button")
     await expect.element(button).toHaveTextContent("400 x 320")
+  })
+})
+
+describe("useElementSize", () => {
+  const ButtonWithSize: FC = () => {
+    const { ref, height, width } = useElementSize()
+
+    return (
+      <button ref={ref} style={{ blockSize: 200, inlineSize: 150 }}>
+        {width} x {height}
+      </button>
+    )
+  }
+
+  test("returns width and height correctly", async () => {
+    await render(<ButtonWithSize />)
+
+    const button = page.getByRole("button")
+    await expect.element(button).toHaveTextContent("150 x 200")
   })
 })

--- a/packages/react/src/hooks/use-resize-observer/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-resize-observer/index.test.browser.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react"
 import { page, render } from "#test/browser"
-import { useElementSize, useResizeObserver } from "./"
+import { useResizeObserver } from "./"
 
 describe("useResizeObserver", () => {
   const ButtonWithSize: FC = () => {
@@ -18,24 +18,5 @@ describe("useResizeObserver", () => {
 
     const button = page.getByRole("button")
     await expect.element(button).toHaveTextContent("400 x 320")
-  })
-})
-
-describe("useElementSize", () => {
-  const ButtonWithSize: FC = () => {
-    const { ref, height, width } = useElementSize()
-
-    return (
-      <button ref={ref} style={{ blockSize: 200, inlineSize: 150 }}>
-        {width} x {height}
-      </button>
-    )
-  }
-
-  test("returns width and height correctly", async () => {
-    await render(<ButtonWithSize />)
-
-    const button = page.getByRole("button")
-    await expect.element(button).toHaveTextContent("150 x 200")
   })
 })

--- a/packages/react/src/hooks/use-resize-observer/index.test.tsx
+++ b/packages/react/src/hooks/use-resize-observer/index.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from "#test"
+import { useElementSize, useResizeObserver } from "./"
+
+describe("useResizeObserver", () => {
+  test("returns default rect on initial render", () => {
+    const { result } = renderHook(() => useResizeObserver())
+    const [, rect] = result.current
+
+    expect(rect).toStrictEqual({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    })
+  })
+})
+
+describe("useElementSize", () => {
+  test("returns zero width and height on initial render", () => {
+    const { result } = renderHook(() => useElementSize())
+
+    expect(result.current.width).toBe(0)
+    expect(result.current.height).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #7283

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Recategorize, prune, and consolidate the browser tests in `packages/react/src/hooks/use-resize-observer` according to the rule introduced in #7139.

## Current behavior (updates)

`packages/react/src/hooks/use-resize-observer/index.test.browser.tsx` had 2 tests, both rendering a button and reading the `ResizeObserver` `contentRect`. The `useElementSize` test was a thin wrapper assertion that did not exercise any observer behaviour beyond what `useResizeObserver` already validates. There was no jsdom test file, so the default-rect initial-render path was not covered by either project.

## New behavior

Each test was re-categorized using the five-axis checklist in [`test-categorization.md`](.agents/rules/test-categorization.md).

**jsdom (`#test`)**

- `index.test.tsx` (new) — 2 tests
  - `useResizeObserver` returns the default rect on initial render
  - `useElementSize` returns zero width and height on initial render

  These cover pure-render paths (default state, hook composition) that do not need a real browser. They exercise `useElementSize` so combined coverage of lines 57-59 is preserved without a browser test.

**browser (`#test/browser`)**

- `index.test.browser.tsx` — 1 test
  - `useResizeObserver` returns the `contentRect` value correctly via `ResizeObserver`

  Kept because the assertion depends on the real `ResizeObserver` callback firing with the actual `contentRect` — jsdom cannot drive this path.

Removed:

- `useElementSize` "returns width and height correctly" browser test — empirically verified that combined coverage does not drop after removal (see numbers below). `useElementSize` is a thin wrapper around `useResizeObserver`; the observer code path it exercised is identical to the one validated by the kept `useResizeObserver` browser test.

## Coverage

Per source file (`src/hooks/use-resize-observer/index.ts`), combined across both projects:

| Metric     | Baseline (before) | Final (after) |
| ---------- | ----------------- | ------------- |
| Statements | 24/26 (92.30%)    | 26/27 (96.30%) |
| Branches   | 5/10 (50%)        | 6/10 (60%)    |
| Functions  | 7/7 (100%)        | 7/7 (100%)    |
| Lines      | 21/21 (100%)      | 22/22 (100%)  |

Combined coverage is at least equal to baseline on every metric (and improves on statements and branches because the new jsdom tests exercise the `createdDom() === false` early-return path that the browser project cannot hit).

## Is this a breaking change (Yes/No):

No. Test-only change. Public API unchanged.

## Additional Information

Verified locally:

- `pnpm react test:jsdom --run src/hooks/use-resize-observer/` — 2 tests pass
- `pnpm react test:browser --run src/hooks/use-resize-observer/` — 1 test x 3 engines pass
- `pnpm react lint` — 0 warnings, 0 errors

Sub-issue of #7286.