### PR TITLE
test(checkbox): simplify indeterminate input assertion

### DIFF
--- a/packages/react/src/components/checkbox/checkbox.test.tsx
+++ b/packages/react/src/components/checkbox/checkbox.test.tsx
@@ -18,12 +18,11 @@ describe("<Checkbox />", () => {
   test("sets `aria-checked` to mixed and native `indeterminate` when indeterminate", () => {
     render(<Checkbox indeterminate>checkbox</Checkbox>)
 
-    const input = screen.getByRole("checkbox")
+    const input = screen.getByRole("checkbox") as HTMLInputElement
 
     expect(input).toHaveAttribute("aria-checked", "mixed")
     expect(input).toBeInstanceOf(HTMLInputElement)
-    if (input instanceof HTMLInputElement)
-      expect(input.indeterminate).toBeTruthy()
+    expect(input.indeterminate).toBeTruthy()
   })
 
   test("forwards `aria-controls` to the input element", () => {


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

- Simplifies the Checkbox indeterminate test by typing the queried checkbox input before asserting the native `indeterminate` property.

## Current behavior (updates)

- The test first queried a checkbox, asserted it was an `HTMLInputElement`, and then guarded the native `indeterminate` assertion with an `instanceof` branch.

## New behavior

- The test casts the queried checkbox to `HTMLInputElement` once and asserts the ARIA and native indeterminate states directly.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Tests: `pnpm react test:jsdom --run src/components/checkbox/checkbox.test.tsx`
- Follow-up: no follow-up identified.
