### PR TITLE
fix(forge): remove local debug fallback from dependabot script

### DIFF
--- a/packages/forge/src/pr/dependabot/index.ts
+++ b/packages/forge/src/pr/dependabot/index.ts
@@ -35,8 +35,7 @@ if (!prNumber) {
 }
 
 const updatedDependencies = JSON.parse(
-  process.env.UPDATED_DEPENDENCIES_JSON ||
-    '[{"dependencyName": "lucide-react"}]',
+  process.env.UPDATED_DEPENDENCIES_JSON || "[]",
 ) as UpdatedDependency[]
 
 if (updatedDependencies.length === 0) {


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Removes a leftover local-debug fallback in `packages/forge/src/pr/dependabot/index.ts` where `UPDATED_DEPENDENCIES_JSON` defaulted to a hardcoded `lucide-react` payload. This default was used during local verification and should not have been committed.

## Current behavior (updates)

When `UPDATED_DEPENDENCIES_JSON` is unset, the script falls back to `[{"dependencyName": "lucide-react"}]`, which triggers `gen:icons` and writes a changeset even when Dependabot did not update any dependency.

## New behavior

When `UPDATED_DEPENDENCIES_JSON` is unset, the script falls back to `[]` and exits early with `No updated dependencies found.`, matching the intended CI behavior.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Internal `@yamada-ui/forge` package only; no impact on published packages.