### PR TITLE
ci(release): isolate npm publish permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
-  publish:
-    name: Publish
+  release:
+    name: Release
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -103,7 +103,7 @@ jobs:
 
   post_release:
     name: Post release
-    needs: publish
+    needs: release
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -118,21 +118,21 @@ jobs:
         uses: ./.github/composite-actions/install
 
       - name: Update issue templates
-        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.release.outputs.published == 'true'
         run: |
           pnpm forge issue:template
           git add ./.github/ISSUE_TEMPLATE
           git diff --staged --exit-code || git commit -m 'ci(changesets): update issue templates'
 
       - name: Generate registries
-        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.release.outputs.published == 'true'
         run: |
           pnpm react gen:registries
           git add ./www/public/registry
           git diff --staged --exit-code || git commit -m 'ci(changesets): update registries'
 
       - name: Generate @dev registries
-        if: github.ref_name == 'main' && needs.publish.outputs.published != 'true'
+        if: github.ref_name == 'main' && needs.release.outputs.published != 'true'
         run: |
           pnpm react gen:registries --tag dev
           git add ./www/public/registry
@@ -146,7 +146,7 @@ jobs:
           git diff --staged --exit-code || git commit -m 'ci(changesets): update next registries'
 
       - name: Update www
-        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.release.outputs.published == 'true'
         run: |
           pnpm react gen:styles -p
           git add ./www/data
@@ -170,9 +170,9 @@ jobs:
         run: git push
 
       - name: Update next branch
-        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.release.outputs.published == 'true'
         run: |
-          PUBLISHED_VERSION=$(echo '${{ needs.publish.outputs.published_packages }}' | jq -r '.[] | select(.name == "@yamada-ui/react") | .version')
+          PUBLISHED_VERSION=$(echo '${{ needs.release.outputs.published_packages }}' | jq -r '.[] | select(.name == "@yamada-ui/react") | .version')
 
           if [ -z "$PUBLISHED_VERSION" ]; then
             exit 0
@@ -210,7 +210,7 @@ jobs:
           done
 
       - name: Notification release
-        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.release.outputs.published == 'true'
         run: |
           pnpm react notification:release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,7 @@ on:
       - v*
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,9 +47,16 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
-  release:
-    name: Release
+  publish:
+    name: Publish
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      published_packages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -96,22 +101,38 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  post_release:
+    name: Post release
+    needs: publish
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Install
+        uses: ./.github/composite-actions/install
+
       - name: Update issue templates
-        if: github.ref_name == 'main' && steps.changesets.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
         run: |
           pnpm forge issue:template
           git add ./.github/ISSUE_TEMPLATE
           git diff --staged --exit-code || git commit -m 'ci(changesets): update issue templates'
 
       - name: Generate registries
-        if: github.ref_name == 'main' && steps.changesets.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
         run: |
           pnpm react gen:registries
           git add ./www/public/registry
           git diff --staged --exit-code || git commit -m 'ci(changesets): update registries'
 
       - name: Generate @dev registries
-        if: github.ref_name == 'main' && steps.changesets.outputs.published != 'true'
+        if: github.ref_name == 'main' && needs.publish.outputs.published != 'true'
         run: |
           pnpm react gen:registries --tag dev
           git add ./www/public/registry
@@ -125,7 +146,7 @@ jobs:
           git diff --staged --exit-code || git commit -m 'ci(changesets): update next registries'
 
       - name: Update www
-        if: github.ref_name == 'main' && steps.changesets.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
         run: |
           pnpm react gen:styles -p
           git add ./www/data
@@ -149,9 +170,9 @@ jobs:
         run: git push
 
       - name: Update next branch
-        if: github.ref_name == 'main' && steps.changesets.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
         run: |
-          PUBLISHED_VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | select(.name == "@yamada-ui/react") | .version')
+          PUBLISHED_VERSION=$(echo '${{ needs.publish.outputs.published_packages }}' | jq -r '.[] | select(.name == "@yamada-ui/react") | .version')
 
           if [ -z "$PUBLISHED_VERSION" ]; then
             exit 0
@@ -189,7 +210,7 @@ jobs:
           done
 
       - name: Notification release
-        if: github.ref_name == 'main' && steps.changesets.outputs.published == 'true'
+        if: github.ref_name == 'main' && needs.publish.outputs.published == 'true'
         run: |
           pnpm react notification:release
         env:


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Summary
- Split the `release` job into `publish` + `post_release` to confine `id-token: write` to the publish job only
- `post_release` runs with only `contents: write`
- Top-level permissions reduced to `contents: read`

## Motivation
`id-token: write` is required for npm OIDC provenance but unnecessary for registry generation, git push, and notifications.
The single-job design exposed the OIDC token to steps that didn't need it.
This change applies the principle of least privilege by isolating permissions per job.

## Is this a breaking change (Yes/No):
No

## Test plan
- [ ] Workflow runs successfully on `v*` branch push
- [ ] Changesets PR creation works on `main`
- [ ] npm publish with provenance succeeds on `main`
- [ ] Post-release steps (registry gen, git push, notifications) complete