### PR TITLE
test(use-event-listener): migrate tests to browser mode

### DIFF
--- a/packages/react/src/hooks/use-event-listener/index.test.browser.ts
+++ b/packages/react/src/hooks/use-event-listener/index.test.browser.ts
@@ -1,12 +1,12 @@
-import { renderHook } from "#test"
-import { useEventListener, useEventListeners } from "./"
+import { renderHook } from "#test/browser"
+import { useEventListener, useEventListeners } from "./index"
 
 describe("useEventListener", () => {
-  test("Adds event listener to target element", () => {
+  test("Adds event listener to target element", async () => {
     const target = document.createElement("div")
     const handler = vi.fn()
 
-    renderHook(() => useEventListener(target, "click", handler))
+    await renderHook(() => useEventListener(target, "click", handler))
 
     const clickEvent = new MouseEvent("click")
     target.dispatchEvent(clickEvent)
@@ -14,11 +14,11 @@ describe("useEventListener", () => {
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
-  test("Removes event listener when unmounted", () => {
+  test("Removes event listener when unmounted", async () => {
     const target = document.createElement("div")
     const handler = vi.fn()
 
-    const { unmount } = renderHook(() =>
+    const { unmount } = await renderHook(() =>
       useEventListener(target, "click", handler),
     )
     unmount()
@@ -29,11 +29,11 @@ describe("useEventListener", () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
-  test("Removes event listener using returned cleanup function", () => {
+  test("Removes event listener using returned cleanup function", async () => {
     const target = document.createElement("div")
     const handler = vi.fn()
 
-    const { result } = renderHook(() =>
+    const { result } = await renderHook(() =>
       useEventListener(target, "click", handler),
     )
     const cleanup = result.current
@@ -48,8 +48,8 @@ describe("useEventListener", () => {
 })
 
 describe("useEventListeners", () => {
-  test("Adds and removes event listeners to multiple elements", () => {
-    const { result } = renderHook(() => useEventListeners())
+  test("Adds and removes event listeners to multiple elements", async () => {
+    const { result } = await renderHook(() => useEventListeners())
     const { add, remove } = result.current
 
     const target1 = document.createElement("button")

--- a/packages/react/src/hooks/use-event-listener/index.test.browser.ts
+++ b/packages/react/src/hooks/use-event-listener/index.test.browser.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "#test/browser"
-import { useEventListener, useEventListeners } from "./index"
+import { useEventListener, useEventListeners } from "./"
 
 describe("useEventListener", () => {
   test("Adds event listener to target element", async () => {


### PR DESCRIPTION
Closes #7512

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `use-event-listener` tests to Vitest Browser Mode.

## Current behavior (updates)

`index.test.ts` was a jsdom test importing from `#test`.

## New behavior

- Renamed to `index.test.browser.ts`
- Switched to `#test/browser`
- Updated `renderHook` usage to async (`await renderHook(...)`) for browser-mode runtime
- Kept event dispatch assertions on real DOM targets

Coverage check (folder-scoped, before/after on same command):
- Command: `NODE_OPTIONS='--localstorage-file=/tmp/yamada-ui-localstorage.json' pnpm -C packages/react exec vitest run --project=jsdom --project=browser:chromium --project=browser:firefox --project=browser:webkit --coverage --coverage.provider=istanbul --run src/hooks/use-event-listener/`
- `use-event-listener` statements coverage: `92.59% -> 88.89%` (delta `-3.70%`, within ±5%)

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified targeted browser tests:
- `pnpm react test:browser --run src/hooks/use-event-listener/`
