### PR TITLE
test(use-online): migrate interaction tests to browser mode

### DIFF
--- a/packages/react/src/hooks/use-online/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-online/index.test.browser.tsx
@@ -1,0 +1,59 @@
+import type { FC } from "react"
+import { page, render } from "#test/browser"
+import { useOnline } from "./"
+
+const Component: FC<{ getServerSnapshot?: () => boolean }> = ({
+  getServerSnapshot,
+}) => {
+  const online = useOnline(getServerSnapshot)
+
+  return <p data-testid="status">{String(online)}</p>
+}
+
+describe("useOnline", () => {
+  const onLineSpy = vi.spyOn(window.navigator, "onLine", "get")
+
+  afterEach(() => {
+    onLineSpy.mockReset()
+  })
+
+  test("returns true when the browser is online", async () => {
+    onLineSpy.mockReturnValue(true)
+
+    await render(<Component />, { withProvider: false })
+
+    await expect.element(page.getByTestId("status")).toHaveTextContent("true")
+  })
+
+  test("returns false when the browser is offline", async () => {
+    onLineSpy.mockReturnValue(false)
+
+    await render(<Component />, { withProvider: false })
+
+    await expect.element(page.getByTestId("status")).toHaveTextContent("false")
+  })
+
+  test("updates when the browser goes offline", async () => {
+    onLineSpy.mockReturnValue(true)
+
+    await render(<Component />, { withProvider: false })
+    await expect.element(page.getByTestId("status")).toHaveTextContent("true")
+
+    onLineSpy.mockReturnValue(false)
+    window.dispatchEvent(new Event("offline"))
+
+    await expect.element(page.getByTestId("status")).toHaveTextContent("false")
+  })
+
+  test("updates when the browser goes online", async () => {
+    onLineSpy.mockReturnValue(false)
+
+    await render(<Component />, { withProvider: false })
+    await expect.element(page.getByTestId("status")).toHaveTextContent("false")
+
+    onLineSpy.mockReturnValue(true)
+    window.dispatchEvent(new Event("online"))
+
+    await expect.element(page.getByTestId("status")).toHaveTextContent("true")
+  })
+})

--- a/packages/react/src/hooks/use-online/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-online/index.test.browser.tsx
@@ -56,4 +56,32 @@ describe("useOnline", () => {
 
     await expect.element(page.getByTestId("status")).toHaveTextContent("true")
   })
+
+  test("removes online and offline listeners with the same callback on unmount", async () => {
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener")
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener")
+
+    const { unmount } = await render(<Component />, { withProvider: false })
+    const onlineCallback = addEventListenerSpy.mock.calls.find(
+      ([event]) => event === "online",
+    )?.[1]
+    const offlineCallback = addEventListenerSpy.mock.calls.find(
+      ([event]) => event === "offline",
+    )?.[1]
+
+    expect(onlineCallback).toBeDefined()
+    expect(offlineCallback).toBeDefined()
+    expect(onlineCallback).toBe(offlineCallback)
+
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "online",
+      onlineCallback,
+    )
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "offline",
+      offlineCallback,
+    )
+  })
 })

--- a/packages/react/src/hooks/use-online/index.test.tsx
+++ b/packages/react/src/hooks/use-online/index.test.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react"
 import { renderToString } from "react-dom/server"
-import { act, render } from "#test"
 import { useOnline } from "./"
 
 const Component: FC<{ getServerSnapshot?: () => boolean }> = ({
@@ -11,79 +10,7 @@ const Component: FC<{ getServerSnapshot?: () => boolean }> = ({
   return <p data-testid="status">{String(online)}</p>
 }
 
-describe("useOnline", () => {
-  const onLineSpy = vi.spyOn(window.navigator, "onLine", "get")
-
-  afterEach(() => {
-    onLineSpy.mockReset()
-  })
-
-  test("returns true when the browser is online", () => {
-    onLineSpy.mockReturnValue(true)
-
-    const { getByTestId } = render(<Component />)
-
-    expect(getByTestId("status").textContent).toBe("true")
-  })
-
-  test("returns false when the browser is offline", () => {
-    onLineSpy.mockReturnValue(false)
-
-    const { getByTestId } = render(<Component />)
-
-    expect(getByTestId("status").textContent).toBe("false")
-  })
-
-  test("updates when the browser goes offline", () => {
-    onLineSpy.mockReturnValue(true)
-
-    const { getByTestId } = render(<Component />)
-
-    expect(getByTestId("status").textContent).toBe("true")
-
-    act(() => {
-      onLineSpy.mockReturnValue(false)
-      window.dispatchEvent(new Event("offline"))
-    })
-
-    expect(getByTestId("status").textContent).toBe("false")
-  })
-
-  test("updates when the browser goes online", () => {
-    onLineSpy.mockReturnValue(false)
-
-    const { getByTestId } = render(<Component />)
-
-    expect(getByTestId("status").textContent).toBe("false")
-
-    act(() => {
-      onLineSpy.mockReturnValue(true)
-      window.dispatchEvent(new Event("online"))
-    })
-
-    expect(getByTestId("status").textContent).toBe("true")
-  })
-
-  test("removes event listeners on unmount", () => {
-    const addSpy = vi.spyOn(window, "addEventListener")
-    const removeSpy = vi.spyOn(window, "removeEventListener")
-
-    onLineSpy.mockReturnValue(true)
-
-    const { unmount } = render(<Component />)
-
-    expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function))
-    expect(addSpy).toHaveBeenCalledWith("offline", expect.any(Function))
-
-    unmount()
-
-    expect(removeSpy).toHaveBeenCalledWith("online", expect.any(Function))
-    expect(removeSpy).toHaveBeenCalledWith("offline", expect.any(Function))
-
-    addSpy.mockRestore()
-    removeSpy.mockRestore()
-  })
-
+describe("useOnline SSR", () => {
   test("uses default getServerSnapshot during SSR", () => {
     const html = renderToString(<Component />)
 


### PR DESCRIPTION
## Summary
- move browser interaction assertions for `use-online` into `index.test.browser.tsx`
- keep SSR `renderToString` behavior checks in `index.test.tsx`
- align test environment split with browser/jsdom categorization

## Coverage check (folder scoped)
- before (`origin/main`): `use-online/index.ts` statements `100.00% (9/9)`
- after (this branch): `use-online/index.ts` statements `100.00% (9/9)`
- delta: `0.00%` (within ±5% threshold)

### Commands
```bash
NODE_OPTIONS='--localstorage-file=/tmp/yamada-ui-localstorage.json' \
  pnpm -C packages/react exec vitest run \
  --project=jsdom \
  --project=browser:chromium \
  --project=browser:firefox \
  --project=browser:webkit \
  --coverage --coverage.provider=istanbul \
  --run src/hooks/use-online/
```

Closes #7517
