### PR TITLE
test(use-async-callback): migrate tests to browser mode

### DIFF
--- a/packages/react/src/hooks/use-async-callback/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-async-callback/index.test.browser.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react"
 import { page, render, renderHook } from "#test/browser"
 import { useAsyncCallback } from "."
-import { wait } from "../../utils"
 
 describe("useAsyncCallback", () => {
   test("should handle callback correctly", async () => {
@@ -19,9 +18,13 @@ describe("useAsyncCallback", () => {
   })
 
   test("should handle callback with processing", async () => {
-    const mockCallback = vi.fn(async () => {
-      await wait(100)
-    })
+    let resolveCallback: (() => void) | undefined
+    const mockCallback = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve
+        }),
+    )
     const { result } = await renderHook(() =>
       useAsyncCallback(mockCallback, []),
     )
@@ -47,7 +50,10 @@ describe("useAsyncCallback", () => {
     expect(result.current[0]).toBeTruthy()
     await expect.element(button).toBeDisabled()
 
-    await wait(100)
+    resolveCallback?.()
+    await vi.waitFor(() => {
+      expect(result.current[0]).toBeFalsy()
+    })
     rerender(<Component />)
 
     expect(result.current[0]).toBeFalsy()
@@ -56,9 +62,13 @@ describe("useAsyncCallback", () => {
   })
 
   test("should handle callback without processing", async () => {
-    const mockCallback = vi.fn(async () => {
-      await wait(100)
-    })
+    let resolveCallback: (() => void) | undefined
+    const mockCallback = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve
+        }),
+    )
     const { result } = await renderHook(() =>
       useAsyncCallback(mockCallback, [], { processing: false }),
     )
@@ -84,7 +94,10 @@ describe("useAsyncCallback", () => {
     expect(result.current[0]).toBeFalsy()
     await expect.element(button).not.toBeDisabled()
 
-    await wait(100)
+    resolveCallback?.()
+    await vi.waitFor(() => {
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+    })
     rerender(<Component />)
 
     expect(result.current[0]).toBeFalsy()
@@ -132,9 +145,13 @@ describe("useAsyncCallback", () => {
   })
 
   test.todo("should handle callback with loading", async () => {
-    const mockCallback = vi.fn(async () => {
-      await wait(100)
-    })
+    let resolveCallback: (() => void) | undefined
+    const mockCallback = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve
+        }),
+    )
     const { result } = await renderHook(() =>
       useAsyncCallback(mockCallback, [], { loading: "page" }),
     )
@@ -162,7 +179,10 @@ describe("useAsyncCallback", () => {
     expect(document.querySelector("[data-loading]")).toBeInTheDocument()
     await expect.element(button).toBeDisabled()
 
-    await wait(500)
+    resolveCallback?.()
+    await vi.waitFor(() => {
+      expect(result.current[0]).toBeFalsy()
+    })
     rerender(<Component />)
 
     expect(result.current[0]).toBeFalsy()

--- a/packages/react/src/hooks/use-async-callback/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-async-callback/index.test.browser.tsx
@@ -1,15 +1,19 @@
 import type { FC } from "react"
-import { vi } from "vitest"
-import { render, renderHook, screen, waitFor } from "#test"
+import { page, render, renderHook } from "#test/browser"
 import { useAsyncCallback } from "."
 import { wait } from "../../utils"
 
 describe("useAsyncCallback", () => {
   test("should handle callback correctly", async () => {
     const mockCallback = vi.fn((value: number) => value * 2)
-    const { result } = renderHook(() => useAsyncCallback(mockCallback, []))
+    const { result } = await renderHook(() =>
+      useAsyncCallback(mockCallback, []),
+    )
+
     expect(result.current[0]).toBeFalsy()
+
     const value = await result.current[1](5)
+
     expect(value).toBe(10)
     expect(mockCallback).toHaveBeenLastCalledWith(5)
   })
@@ -18,7 +22,9 @@ describe("useAsyncCallback", () => {
     const mockCallback = vi.fn(async () => {
       await wait(100)
     })
-    const { result } = renderHook(() => useAsyncCallback(mockCallback, []))
+    const { result } = await renderHook(() =>
+      useAsyncCallback(mockCallback, []),
+    )
     const Component: FC = () => {
       return (
         <button
@@ -29,18 +35,23 @@ describe("useAsyncCallback", () => {
         </button>
       )
     }
-    const { rerender, user } = render(<Component />)
-    const el = screen.getByText("Button")
+    const { rerender, user } = await render(<Component />)
+    const button = page.getByRole("button", { name: "Button" })
+
     expect(result.current[0]).toBeFalsy()
-    expect(el).not.toBeDisabled()
-    await user.click(el)
+    await expect.element(button).not.toBeDisabled()
+
+    await user.click(button)
     rerender(<Component />)
+
     expect(result.current[0]).toBeTruthy()
-    expect(el).toBeDisabled()
+    await expect.element(button).toBeDisabled()
+
     await wait(100)
     rerender(<Component />)
+
     expect(result.current[0]).toBeFalsy()
-    expect(el).not.toBeDisabled()
+    await expect.element(button).not.toBeDisabled()
     expect(mockCallback).toHaveBeenLastCalledWith()
   })
 
@@ -48,7 +59,7 @@ describe("useAsyncCallback", () => {
     const mockCallback = vi.fn(async () => {
       await wait(100)
     })
-    const { result } = renderHook(() =>
+    const { result } = await renderHook(() =>
       useAsyncCallback(mockCallback, [], { processing: false }),
     )
     const Component: FC = () => {
@@ -61,50 +72,62 @@ describe("useAsyncCallback", () => {
         </button>
       )
     }
-    const { rerender, user } = render(<Component />)
-    const el = screen.getByText("Button")
+    const { rerender, user } = await render(<Component />)
+    const button = page.getByRole("button", { name: "Button" })
+
     expect(result.current[0]).toBeFalsy()
-    expect(el).not.toBeDisabled()
-    await user.click(el)
+    await expect.element(button).not.toBeDisabled()
+
+    await user.click(button)
     rerender(<Component />)
+
     expect(result.current[0]).toBeFalsy()
-    expect(el).not.toBeDisabled()
+    await expect.element(button).not.toBeDisabled()
+
     await wait(100)
     rerender(<Component />)
+
     expect(result.current[0]).toBeFalsy()
-    expect(el).not.toBeDisabled()
+    await expect.element(button).not.toBeDisabled()
     expect(mockCallback).toHaveBeenLastCalledWith()
   })
 
-  test("should return stable callback reference when inline function is passed with empty deps", () => {
-    const { rerender, result } = renderHook(() =>
+  test("should return stable callback reference when inline function is passed with empty deps", async () => {
+    const { rerender, result } = await renderHook(() =>
       useAsyncCallback(() => "result", []),
     )
     const first = result.current[1]
-    rerender()
+
+    await rerender()
+
     expect(result.current[1]).toBe(first)
   })
 
-  test("should update callback reference when deps change", () => {
+  test("should update callback reference when deps change", async () => {
     let dep = 1
-    const { rerender, result } = renderHook(() =>
+    const { rerender, result } = await renderHook(() =>
       useAsyncCallback(() => dep, [dep]),
     )
     const first = result.current[1]
+
     dep = 2
-    rerender()
+    await rerender()
+
     expect(result.current[1]).not.toBe(first)
   })
 
   test("should call the latest callback even when reference is stable", async () => {
     let value = 1
-    const { rerender, result } = renderHook(() =>
+    const { rerender, result } = await renderHook(() =>
       useAsyncCallback(() => value, []),
     )
     const stableCallback = result.current[1]
+
     value = 42
-    rerender()
+    await rerender()
+
     const returned = await stableCallback()
+
     expect(returned).toBe(42)
   })
 
@@ -112,7 +135,7 @@ describe("useAsyncCallback", () => {
     const mockCallback = vi.fn(async () => {
       await wait(100)
     })
-    const { result } = renderHook(() =>
+    const { result } = await renderHook(() =>
       useAsyncCallback(mockCallback, [], { loading: "page" }),
     )
     const Component: FC = () => {
@@ -125,23 +148,26 @@ describe("useAsyncCallback", () => {
         </button>
       )
     }
-    const { rerender, user } = render(<Component />)
-    const el = screen.getByText("Button")
+    const { rerender, user } = await render(<Component />)
+    const button = page.getByRole("button", { name: "Button" })
+
     expect(result.current[0]).toBeFalsy()
     expect(document.querySelector("[data-loading]")).not.toBeInTheDocument()
-    expect(el).not.toBeDisabled()
-    await user.click(el)
+    await expect.element(button).not.toBeDisabled()
+
+    await user.click(button)
     rerender(<Component />)
+
     expect(result.current[0]).toBeTruthy()
     expect(document.querySelector("[data-loading]")).toBeInTheDocument()
-    expect(el).toBeDisabled()
+    await expect.element(button).toBeDisabled()
+
     await wait(500)
     rerender(<Component />)
+
     expect(result.current[0]).toBeFalsy()
-    await waitFor(() => {
-      expect(document.querySelector("[data-loading]")).not.toBeInTheDocument()
-    })
-    expect(el).not.toBeDisabled()
+    expect(document.querySelector("[data-loading]")).not.toBeInTheDocument()
+    await expect.element(button).not.toBeDisabled()
     expect(mockCallback).toHaveBeenLastCalledWith()
   })
 })


### PR DESCRIPTION
## Summary
- migrate `use-async-callback` tests to Vitest Browser Mode by renaming to `index.test.browser.tsx`
- switch test helpers from `#test` to `#test/browser` and adapt queries to `page` locator usage
- keep existing assertions and test intent while updating async rerender handling in browser mode

## Coverage check (folder scoped)
- before (`origin/main`): `use-async-callback/index.ts` statements `89.47% (17/19)`
- after (this branch): `use-async-callback/index.ts` statements `89.47% (17/19)`
- delta: `0.00%` (within ±5% threshold)

### Commands
```bash
NODE_OPTIONS='--localstorage-file=/tmp/yamada-ui-localstorage.json' \
  pnpm -C packages/react exec vitest run \
  --project=jsdom \
  --project=browser:chromium \
  --project=browser:firefox \
  --project=browser:webkit \
  --coverage --coverage.provider=istanbul \
  --run src/hooks/use-async-callback/
```

Closes #7507
