### PR TITLE
test(use-controllable-state): split jsdom and browser cases

### DIFF
--- a/packages/react/src/hooks/use-controllable-state/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-controllable-state/index.test.browser.tsx
@@ -17,19 +17,12 @@ describe("useControllableEventState", () => {
         onChange,
       })
 
-      return (
-        <input
-          type="text"
-          data-testid="input"
-          value={value}
-          onChange={setValue}
-        />
-      )
+      return <input type="text" value={value} onChange={setValue} />
     }
 
     const { user } = await render(<Component />)
 
-    await user.fill(page.getByTestId("input"), "hello")
+    await user.fill(page.getByRole("textbox"), "hello")
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const ev = onChange.mock.calls[0]![0] as ChangeEvent<HTMLInputElement>
@@ -45,21 +38,14 @@ describe("useControllableEventState", () => {
         defaultValue: "initial",
       })
 
-      return (
-        <input
-          type="text"
-          data-testid="input"
-          value={value}
-          onChange={setValue}
-        />
-      )
+      return <input type="text" value={value} onChange={setValue} />
     }
 
     const { user } = await render(<Component />)
 
-    await user.fill(page.getByTestId("input"), "updated")
+    await user.fill(page.getByRole("textbox"), "updated")
 
-    await expect.element(page.getByTestId("input")).toHaveValue("updated")
+    await expect.element(page.getByRole("textbox")).toHaveValue("updated")
   })
 })
 
@@ -70,20 +56,16 @@ describe("useControllableState", () => {
         defaultValue: "initial",
       })
 
-      return (
-        <button data-testid="btn" onClick={() => setValue("updated")}>
-          {value}
-        </button>
-      )
+      return <button onClick={() => setValue("updated")}>{value}</button>
     }
 
     const { user } = await render(<Component />)
 
-    await expect.element(page.getByTestId("btn")).toHaveTextContent("initial")
+    await expect.element(page.getByRole("button")).toHaveTextContent("initial")
 
-    await user.click(page.getByTestId("btn"))
+    await user.click(page.getByRole("button"))
 
-    await expect.element(page.getByTestId("btn")).toHaveTextContent("updated")
+    await expect.element(page.getByRole("button")).toHaveTextContent("updated")
   })
 
   test("works in controlled mode", async () => {
@@ -99,22 +81,18 @@ describe("useControllableState", () => {
         },
       })
 
-      return (
-        <button data-testid="btn" onClick={() => setState("new")}>
-          {state}
-        </button>
-      )
+      return <button onClick={() => setState("new")}>{state}</button>
     }
 
     const { user } = await render(<Component />)
 
     await expect
-      .element(page.getByTestId("btn"))
+      .element(page.getByRole("button"))
       .toHaveTextContent("controlled")
 
-    await user.click(page.getByTestId("btn"))
+    await user.click(page.getByRole("button"))
 
     expect(onChange).toHaveBeenCalledWith("new")
-    await expect.element(page.getByTestId("btn")).toHaveTextContent("new")
+    await expect.element(page.getByRole("button")).toHaveTextContent("new")
   })
 })

--- a/packages/react/src/hooks/use-controllable-state/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-controllable-state/index.test.browser.tsx
@@ -1,0 +1,120 @@
+import type { ChangeEvent, FC } from "react"
+import { useState } from "react"
+import { vi } from "vitest"
+import { page, render } from "#test/browser"
+import { useControllableEventState, useControllableState } from "./"
+
+describe("useControllableEventState", () => {
+  test("reads ev.target.value for non-boolean inputs", async () => {
+    const onChange = vi.fn()
+
+    const Component: FC = () => {
+      const [value, setValue] = useControllableEventState<
+        string,
+        HTMLInputElement
+      >({
+        defaultValue: "",
+        onChange,
+      })
+
+      return (
+        <input
+          type="text"
+          data-testid="input"
+          value={value}
+          onChange={setValue}
+        />
+      )
+    }
+
+    const { user } = await render(<Component />)
+
+    await user.fill(page.getByTestId("input"), "hello")
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const ev = onChange.mock.calls[0]![0] as ChangeEvent<HTMLInputElement>
+    expect(ev.target.value).toBe("hello")
+  })
+
+  test("updates defaultValue in uncontrolled mode", async () => {
+    const Component: FC = () => {
+      const [value, setValue] = useControllableEventState<
+        string,
+        HTMLInputElement
+      >({
+        defaultValue: "initial",
+      })
+
+      return (
+        <input
+          type="text"
+          data-testid="input"
+          value={value}
+          onChange={setValue}
+        />
+      )
+    }
+
+    const { user } = await render(<Component />)
+
+    await user.fill(page.getByTestId("input"), "updated")
+
+    await expect.element(page.getByTestId("input")).toHaveValue("updated")
+  })
+})
+
+describe("useControllableState", () => {
+  test("works in uncontrolled mode with defaultValue", async () => {
+    const Component: FC = () => {
+      const [value, setValue] = useControllableState<string>({
+        defaultValue: "initial",
+      })
+
+      return (
+        <button data-testid="btn" onClick={() => setValue("updated")}>
+          {value}
+        </button>
+      )
+    }
+
+    const { user } = await render(<Component />)
+
+    await expect.element(page.getByTestId("btn")).toHaveTextContent("initial")
+
+    await user.click(page.getByTestId("btn"))
+
+    await expect.element(page.getByTestId("btn")).toHaveTextContent("updated")
+  })
+
+  test("works in controlled mode", async () => {
+    const onChange = vi.fn()
+
+    const Component: FC = () => {
+      const [value, setValue] = useState("controlled")
+      const [state, setState] = useControllableState<string>({
+        value,
+        onChange: (v) => {
+          onChange(v)
+          setValue(v)
+        },
+      })
+
+      return (
+        <button data-testid="btn" onClick={() => setState("new")}>
+          {state}
+        </button>
+      )
+    }
+
+    const { user } = await render(<Component />)
+
+    await expect
+      .element(page.getByTestId("btn"))
+      .toHaveTextContent("controlled")
+
+    await user.click(page.getByTestId("btn"))
+
+    expect(onChange).toHaveBeenCalledWith("new")
+    await expect.element(page.getByTestId("btn")).toHaveTextContent("new")
+  })
+})

--- a/packages/react/src/hooks/use-controllable-state/index.test.tsx
+++ b/packages/react/src/hooks/use-controllable-state/index.test.tsx
@@ -1,128 +1,48 @@
-import type { ChangeEvent, FC } from "react"
-import { useState } from "react"
-import { vi } from "vitest"
-import { act, fireEvent, render, screen } from "#test"
+import { renderHook } from "#test"
 import { useControllableEventState, useControllableState } from "./"
 
 describe("useControllableEventState", () => {
-  test("reads ev.target.value for non-boolean inputs", () => {
-    const onChange = vi.fn()
+  test("returns defaultValue in uncontrolled mode", () => {
+    const { result } = renderHook(() =>
+      useControllableEventState<string, HTMLInputElement>({
+        defaultValue: "initial",
+      }),
+    )
 
-    const Component: FC = () => {
-      const [value, setValue] = useControllableEventState<
-        string,
-        HTMLInputElement
-      >({
-        defaultValue: "",
-        onChange,
-      })
-
-      return (
-        <input
-          type="text"
-          data-testid="input"
-          value={value}
-          onChange={setValue}
-        />
-      )
-    }
-
-    render(<Component />)
-
-    act(() => {
-      fireEvent.change(screen.getByTestId("input"), {
-        target: { value: "hello" },
-      })
-    })
-
-    expect(onChange).toHaveBeenCalledTimes(1)
-    const ev = onChange.mock.calls[0]![0] as ChangeEvent<HTMLInputElement>
-    expect(ev.target.value).toBe("hello")
+    expect(result.current[0]).toBe("initial")
   })
 
-  test("updates defaultValue in uncontrolled mode", () => {
-    const Component: FC = () => {
-      const [value, setValue] = useControllableEventState<
-        string,
-        HTMLInputElement
-      >({
+  test("prioritizes value over defaultValue in controlled mode", () => {
+    const { result } = renderHook(() =>
+      useControllableEventState<string, HTMLInputElement>({
         defaultValue: "initial",
-      })
+        value: "controlled",
+      }),
+    )
 
-      return (
-        <input
-          type="text"
-          data-testid="input"
-          value={value}
-          onChange={setValue}
-        />
-      )
-    }
-
-    render(<Component />)
-
-    act(() => {
-      fireEvent.change(screen.getByTestId("input"), {
-        target: { value: "updated" },
-      })
-    })
-
-    expect(screen.getByTestId("input")).toHaveValue("updated")
+    expect(result.current[0]).toBe("controlled")
   })
 })
 
 describe("useControllableState", () => {
-  test("works in uncontrolled mode with defaultValue", () => {
-    const Component: FC = () => {
-      const [value, setValue] = useControllableState<string>({
+  test("returns defaultValue in uncontrolled mode", () => {
+    const { result } = renderHook(() =>
+      useControllableState<string>({
         defaultValue: "initial",
-      })
+      }),
+    )
 
-      return (
-        <button data-testid="btn" onClick={() => setValue("updated")}>
-          {value}
-        </button>
-      )
-    }
-
-    render(<Component />)
-    expect(screen.getByTestId("btn")).toHaveTextContent("initial")
-
-    act(() => {
-      fireEvent.click(screen.getByTestId("btn"))
-    })
-
-    expect(screen.getByTestId("btn")).toHaveTextContent("updated")
+    expect(result.current[0]).toBe("initial")
   })
 
-  test("works in controlled mode", () => {
-    const onChange = vi.fn()
+  test("prioritizes value over defaultValue in controlled mode", () => {
+    const { result } = renderHook(() =>
+      useControllableState<string>({
+        defaultValue: "initial",
+        value: "controlled",
+      }),
+    )
 
-    const Component: FC = () => {
-      const [value, setValue] = useState("controlled")
-      const [state, setState] = useControllableState<string>({
-        value,
-        onChange: (v) => {
-          onChange(v)
-          setValue(v)
-        },
-      })
-
-      return (
-        <button data-testid="btn" onClick={() => setState("new")}>
-          {state}
-        </button>
-      )
-    }
-
-    render(<Component />)
-    expect(screen.getByTestId("btn")).toHaveTextContent("controlled")
-
-    act(() => {
-      fireEvent.click(screen.getByTestId("btn"))
-    })
-
-    expect(onChange).toHaveBeenCalledWith("new")
-    expect(screen.getByTestId("btn")).toHaveTextContent("new")
+    expect(result.current[0]).toBe("controlled")
   })
 })


### PR DESCRIPTION
Closes #7510

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Split `use-controllable-state` hook tests into jsdom and browser mode based on test categorization.

## Current behavior (updates)

`packages/react/src/hooks/use-controllable-state/index.test.tsx` mixed pure state-resolution checks and interaction/event-driven checks under jsdom.

## New behavior

- Kept pure logic checks (`defaultValue` resolution and `value` precedence) in jsdom `index.test.tsx`.
- Added browser interaction tests to `index.test.browser.tsx` and migrated to `#test/browser` with `page` and `user` interactions.
- Verified commands from issue:
  - `pnpm react test:jsdom --run src/hooks/use-controllable-state/`
  - `pnpm react test:browser --run src/hooks/use-controllable-state/`
- Verified folder-scoped before/after coverage with same command:
  - Before: `24/26 (92.31%)`
  - After: `24/26 (92.31%)`
  - Delta: `0.00%` (within ±5%)

## Is this a breaking change (Yes/No):

No

## Additional Information

- Coverage verification command:
  - `pnpm -C packages/react exec vitest run --project=jsdom --project=browser:chromium --project=browser:firefox --project=browser:webkit --coverage --coverage.provider=istanbul --run src/hooks/use-controllable-state/`
