### PR TITLE
test(use-focus): migrate tests to browser mode

### DIFF
--- a/packages/react/src/hooks/use-focus/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-focus/index.test.browser.tsx
@@ -190,145 +190,73 @@ describe("useFocusOnShow", () => {
 })
 
 describe("useFocusOnPointerDown", () => {
-  const defaultPlatform = window.navigator.platform
-  const defaultVendor = window.navigator.vendor
-
-  beforeAll(() => {
-    Object.defineProperty(window.navigator, "platform", {
-      value: "MacOS",
-      writable: true,
-    })
-    Object.defineProperty(window.navigator, "vendor", {
-      value: "Apple Computer, Inc.",
-      writable: true,
-    })
-  })
-
-  afterAll(() => {
-    Object.defineProperty(window.navigator, "platform", {
-      value: defaultPlatform,
-      writable: false,
-    })
-    Object.defineProperty(window.navigator, "vendor", {
-      value: defaultVendor,
-      writable: false,
-    })
-  })
-
-  const Component: FC<Omit<UseFocusOnMouseDownProps, "ref">> = (props) => {
+  const Component: FC<
+    Omit<UseFocusOnMouseDownProps, "ref"> & { preventNativeFocus?: boolean }
+  > = ({ preventNativeFocus = true, ...props }) => {
     const ref = useRef<HTMLDivElement>(null)
-    const buttonRef = useRef<HTMLButtonElement>(null)
+    const targetRef = useRef<HTMLDivElement>(null)
     useFocusOnPointerDown({
       ref,
-      elements: [buttonRef],
+      elements: [targetRef],
       enabled: true,
       ...props,
     })
 
     return (
       <div ref={ref} data-testid="container">
-        <button ref={buttonRef} data-testid="button">
-          Button
-        </button>
+        <div
+          ref={targetRef}
+          data-testid="target"
+          tabIndex={-1}
+          onPointerDown={
+            preventNativeFocus ? (ev) => ev.preventDefault() : undefined
+          }
+        >
+          Target
+        </div>
       </div>
     )
   }
 
-  const dispatchPointerDown = (target: Element) => {
-    target.dispatchEvent(
-      new PointerEvent("pointerdown", {
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
+  const stubNavigator = (overrides: { platform?: string; vendor?: string }) => {
+    const descriptors: { [key: string]: PropertyDescriptor | undefined } = {
+      platform: Object.getOwnPropertyDescriptor(window.navigator, "platform"),
+      vendor: Object.getOwnPropertyDescriptor(window.navigator, "vendor"),
+    }
+
+    for (const [key, value] of Object.entries(overrides)) {
+      Object.defineProperty(window.navigator, key, {
+        configurable: true,
+        value,
+      })
+    }
+
+    return () => {
+      for (const [key, descriptor] of Object.entries(descriptors)) {
+        if (descriptor) {
+          Object.defineProperty(window.navigator, key, descriptor)
+        } else {
+          Reflect.deleteProperty(window.navigator, key)
+        }
+      }
+    }
   }
 
-  test("prevents default behavior and focuses on the target element", async () => {
-    await render(<Component />)
-    const button = page.getByTestId("button")
-
-    dispatchPointerDown(button.element())
-
-    await expect.element(button).toHaveFocus()
-  })
-
-  test("does not focus when disabled", async () => {
-    await render(<Component enabled={false} />)
-    const button = page.getByTestId("button")
-
-    dispatchPointerDown(button.element())
-
-    await expect.element(button).not.toHaveFocus()
-  })
-
-  test("does not move focus when target is already active", async () => {
-    await render(<Component />)
-    const button = page.getByTestId("button")
-    const buttonElement = button.element() as HTMLElement
-
-    buttonElement.focus()
-    dispatchPointerDown(buttonElement)
-
-    await expect.element(button).toHaveFocus()
-  })
-
-  test("uses ref as fallback when elements is not provided", async () => {
-    await render(<Component elements={undefined} />)
-    const button = page.getByTestId("button")
-
-    dispatchPointerDown(button.element())
-
-    await expect.element(button).toHaveFocus()
-  })
-
-  test("supports raw HTMLElement in elements and ignores null entries", async () => {
-    const { rerender } = await render(<Component />)
-    const button = page.getByTestId("button")
-    const buttonElement = button.element() as HTMLElement
-
-    rerender(<Component elements={[buttonElement]} />)
-    dispatchPointerDown(buttonElement)
-
-    await expect.element(button).toHaveFocus()
-
-    buttonElement.blur()
-    rerender(<Component elements={[null]} />)
-
-    const container = page.getByTestId("container").element() as HTMLElement
-    dispatchPointerDown(container)
-
-    await expect.element(button).not.toHaveFocus()
-  })
-
   test("does not focus on non-safari browsers", async () => {
-    const previousPlatform = window.navigator.platform
-    const previousVendor = window.navigator.vendor
+    const restore = stubNavigator({
+      platform: "Win32",
+      vendor: "Google Inc.",
+    })
 
     try {
-      Object.defineProperty(window.navigator, "platform", {
-        value: "Win32",
-        writable: true,
-      })
-      Object.defineProperty(window.navigator, "vendor", {
-        value: "Google Inc.",
-        writable: true,
-      })
+      const { user } = await render(<Component />)
+      const target = page.getByTestId("target")
 
-      await render(<Component />)
-      const button = page.getByTestId("button")
+      await user.click(target)
 
-      dispatchPointerDown(button.element())
-
-      await expect.element(button).not.toHaveFocus()
+      await expect.element(target).not.toHaveFocus()
     } finally {
-      Object.defineProperty(window.navigator, "platform", {
-        value: previousPlatform,
-        writable: true,
-      })
-      Object.defineProperty(window.navigator, "vendor", {
-        value: previousVendor,
-        writable: true,
-      })
+      restore()
     }
   })
 })

--- a/packages/react/src/hooks/use-focus/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-focus/index.test.browser.tsx
@@ -1,38 +1,10 @@
 import type { FC } from "react"
-import type * as Utils from "../../utils"
 import type { UseFocusOnMouseDownProps, UseFocusOnShowProps } from "./"
 import { useRef } from "react"
-import { act, fireEvent, render, waitFor } from "#test"
-import { getFirstFocusableElement } from "../../utils"
+import { a11y, page, render } from "#test/browser"
 import { useFocusOnPointerDown, useFocusOnShow } from "./"
 
-const mockState = vi.hoisted(() => {
-  return {
-    defaultGetFirstFocusableElement:
-      undefined as unknown as typeof getFirstFocusableElement,
-  }
-})
-
-vi.mock("../../utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof Utils>()
-  mockState.defaultGetFirstFocusableElement = actual.getFirstFocusableElement
-
-  return {
-    ...actual,
-    getFirstFocusableElement: vi.fn(actual.getFirstFocusableElement),
-  }
-})
-
 describe("useFocusOnShow", () => {
-  afterEach(() => {
-    const firstFocusableMock = vi.mocked(getFirstFocusableElement)
-    vi.restoreAllMocks()
-    firstFocusableMock.mockReset()
-    firstFocusableMock.mockImplementation(
-      mockState.defaultGetFirstFocusableElement,
-    )
-  })
-
   const Component: FC<Omit<UseFocusOnShowProps, "focusTarget">> = (props) => {
     const ref = useRef<HTMLDivElement>(null)
     const focusRef = useRef<HTMLButtonElement>(null)
@@ -77,55 +49,51 @@ describe("useFocusOnShow", () => {
     )
   }
 
-  test("focuses on the element when it becomes visible", async () => {
-    const { getByTestId, rerender } = render(<Component visible={false} />)
-    const button = getByTestId("button")
+  test("passes a11y checks", async () => {
+    await a11y(<Component visible />)
+  })
 
-    expect(button).not.toHaveFocus()
+  test("focuses on the element when it becomes visible", async () => {
+    const { rerender } = await render(<Component visible={false} />)
+    const button = page.getByTestId("button")
+
+    await expect.element(button).not.toHaveFocus()
 
     rerender(<Component visible />)
 
-    await waitFor(() => {
-      expect(button).toHaveFocus()
-    })
+    await expect.element(button).toHaveFocus()
   })
 
   test("focuses on the first tabbable element when focusTarget is not provided", async () => {
-    const { getByTestId, rerender } = render(
+    const { rerender } = await render(
       <ComponentWithoutFocusTarget visible={false} />,
     )
-    const button = getByTestId("button")
-    vi.mocked(getFirstFocusableElement).mockReturnValue(button)
+    const button = page.getByTestId("button")
 
-    expect(button).not.toHaveFocus()
+    await expect.element(button).not.toHaveFocus()
 
     rerender(<ComponentWithoutFocusTarget visible />)
 
-    await waitFor(() => {
-      expect(button).toHaveFocus()
-    })
+    await expect.element(button).toHaveFocus()
   })
 
   test("focuses on the target when there are no focusable descendants", async () => {
-    const { getByTestId, rerender } = render(
+    const { rerender } = await render(
       <ComponentWithoutFocusableChild visible={false} />,
     )
-    const target = getByTestId("target")
-    vi.mocked(getFirstFocusableElement).mockReturnValue(null)
+    const target = page.getByTestId("target")
 
     rerender(<ComponentWithoutFocusableChild visible />)
 
-    await waitFor(() => {
-      expect(target).toHaveFocus()
-    })
+    await expect.element(target).toHaveFocus()
   })
 
   test("supports passing element directly as refOrEl", async () => {
     const target = document.createElement("div")
     target.tabIndex = -1
     const button = document.createElement("button")
+    button.textContent = "Button"
     target.appendChild(button)
-    vi.mocked(getFirstFocusableElement).mockReturnValue(button)
 
     const ComponentWithElementTarget: FC<
       Omit<UseFocusOnShowProps, "focusTarget">
@@ -136,13 +104,15 @@ describe("useFocusOnShow", () => {
     }
 
     document.body.append(target)
-    const { rerender } = render(<ComponentWithElementTarget visible={false} />)
+    const { rerender } = await render(
+      <ComponentWithElementTarget visible={false} />,
+    )
 
     rerender(<ComponentWithElementTarget visible />)
 
     try {
-      await waitFor(() => {
-        expect(button).toHaveFocus()
+      await vi.waitFor(() => {
+        expect(document.activeElement).toBe(button)
       })
     } finally {
       target.remove()
@@ -152,7 +122,8 @@ describe("useFocusOnShow", () => {
   test("does nothing when shouldFocus is false", async () => {
     const target = document.createElement("div")
     target.tabIndex = -1
-    target.appendChild(document.createElement("button"))
+    const button = document.createElement("button")
+    target.appendChild(button)
 
     const ComponentWithDisabledFocus: FC<{ visible: boolean }> = ({
       visible,
@@ -162,11 +133,14 @@ describe("useFocusOnShow", () => {
       return null
     }
 
-    const { rerender } = render(<ComponentWithDisabledFocus visible={false} />)
+    const { rerender } = await render(
+      <ComponentWithDisabledFocus visible={false} />,
+    )
+
     rerender(<ComponentWithDisabledFocus visible />)
 
-    await waitFor(() => {
-      expect(getFirstFocusableElement).not.toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(document.activeElement).not.toBe(button)
     })
   })
 
@@ -187,20 +161,16 @@ describe("useFocusOnShow", () => {
       )
     }
 
-    const { getByTestId, rerender } = render(
+    const { rerender } = await render(
       <ComponentWithActiveElement visible={false} />,
     )
-    const button = getByTestId("active-button")
+    const button = page.getByTestId("active-button")
+    const buttonElement = button.element() as HTMLElement
 
-    button.focus()
-    const focusSpy = vi.spyOn(button, "focus")
+    buttonElement.focus()
     rerender(<ComponentWithActiveElement visible />)
 
-    await waitFor(() => {
-      expect(getFirstFocusableElement).not.toHaveBeenCalled()
-      expect(focusSpy).not.toHaveBeenCalled()
-      expect(button).toHaveFocus()
-    })
+    await expect.element(button).toHaveFocus()
   })
 
   test("does not throw when ref.current is null", async () => {
@@ -211,17 +181,16 @@ describe("useFocusOnShow", () => {
       return null
     }
 
-    const { rerender } = render(<ComponentWithNullTarget visible={false} />)
+    const { rerender } = await render(
+      <ComponentWithNullTarget visible={false} />,
+    )
+
     expect(() => rerender(<ComponentWithNullTarget visible />)).not.toThrow()
-    await waitFor(() => {
-      expect(getFirstFocusableElement).not.toHaveBeenCalled()
-    })
   })
 })
 
 describe("useFocusOnPointerDown", () => {
   const defaultPlatform = window.navigator.platform
-
   const defaultVendor = window.navigator.vendor
 
   beforeAll(() => {
@@ -233,10 +202,6 @@ describe("useFocusOnPointerDown", () => {
       value: "Apple Computer, Inc.",
       writable: true,
     })
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
   })
 
   afterAll(() => {
@@ -269,71 +234,70 @@ describe("useFocusOnPointerDown", () => {
     )
   }
 
+  const dispatchPointerDown = (target: Element) => {
+    target.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+  }
+
   test("prevents default behavior and focuses on the target element", async () => {
-    const { getByTestId } = render(<Component />)
-    const button = getByTestId("button")
+    await render(<Component />)
+    const button = page.getByTestId("button")
 
-    act(() => fireEvent.pointerDown(button))
+    dispatchPointerDown(button.element())
 
-    await waitFor(() => {
-      expect(button).toHaveFocus()
-    })
+    await expect.element(button).toHaveFocus()
   })
 
   test("does not focus when disabled", async () => {
-    const { getByTestId } = render(<Component enabled={false} />)
-    const button = getByTestId("button")
+    await render(<Component enabled={false} />)
+    const button = page.getByTestId("button")
 
-    act(() => fireEvent.pointerDown(button))
+    dispatchPointerDown(button.element())
 
-    await waitFor(() => {
-      expect(button).not.toHaveFocus()
-    })
+    await expect.element(button).not.toHaveFocus()
   })
 
-  test("does not focus when target is already active", async () => {
-    const { getByTestId } = render(<Component />)
-    const button = getByTestId("button")
-    button.focus()
-    const focusSpy = vi.spyOn(button, "focus")
+  test("does not move focus when target is already active", async () => {
+    await render(<Component />)
+    const button = page.getByTestId("button")
+    const buttonElement = button.element() as HTMLElement
 
-    act(() => fireEvent.pointerDown(button))
+    buttonElement.focus()
+    dispatchPointerDown(buttonElement)
 
-    await waitFor(() => {
-      expect(focusSpy).not.toHaveBeenCalled()
-    })
+    await expect.element(button).toHaveFocus()
   })
 
   test("uses ref as fallback when elements is not provided", async () => {
-    const { getByTestId } = render(<Component elements={undefined} />)
-    const button = getByTestId("button")
+    await render(<Component elements={undefined} />)
+    const button = page.getByTestId("button")
 
-    act(() => fireEvent.pointerDown(button))
+    dispatchPointerDown(button.element())
 
-    await waitFor(() => {
-      expect(button).toHaveFocus()
-    })
+    await expect.element(button).toHaveFocus()
   })
 
   test("supports raw HTMLElement in elements and ignores null entries", async () => {
-    const { getByTestId, rerender } = render(<Component />)
-    const button = getByTestId("button")
+    const { rerender } = await render(<Component />)
+    const button = page.getByTestId("button")
+    const buttonElement = button.element() as HTMLElement
 
-    rerender(<Component elements={[button]} />)
-    act(() => fireEvent.pointerDown(button))
+    rerender(<Component elements={[buttonElement]} />)
+    dispatchPointerDown(buttonElement)
 
-    await waitFor(() => {
-      expect(button).toHaveFocus()
-    })
+    await expect.element(button).toHaveFocus()
 
-    // Move focus away so the second assertion checks null-elements handling only.
-    button.blur()
+    buttonElement.blur()
     rerender(<Component elements={[null]} />)
-    act(() => fireEvent.pointerDown(button))
 
-    await waitFor(() => {
-      expect(button).not.toHaveFocus()
-    })
+    const container = page.getByTestId("container").element() as HTMLElement
+    dispatchPointerDown(container)
+
+    await expect.element(button).not.toHaveFocus()
   })
 
   test("does not focus on non-safari browsers", async () => {
@@ -350,14 +314,12 @@ describe("useFocusOnPointerDown", () => {
         writable: true,
       })
 
-      const { getByTestId } = render(<Component />)
-      const button = getByTestId("button")
+      await render(<Component />)
+      const button = page.getByTestId("button")
 
-      act(() => fireEvent.pointerDown(button))
+      dispatchPointerDown(button.element())
 
-      await waitFor(() => {
-        expect(button).not.toHaveFocus()
-      })
+      await expect.element(button).not.toHaveFocus()
     } finally {
       Object.defineProperty(window.navigator, "platform", {
         value: previousPlatform,

--- a/packages/react/src/hooks/use-focus/index.test.webkit.tsx
+++ b/packages/react/src/hooks/use-focus/index.test.webkit.tsx
@@ -1,0 +1,90 @@
+import type { FC } from "react"
+import type { UseFocusOnMouseDownProps } from "./"
+import { useRef } from "react"
+import { page, render } from "#test/browser"
+import { useFocusOnPointerDown } from "./"
+
+describe("useFocusOnPointerDown", () => {
+  const Component: FC<
+    Omit<UseFocusOnMouseDownProps, "ref"> & { preventNativeFocus?: boolean }
+  > = ({ preventNativeFocus = true, ...props }) => {
+    const ref = useRef<HTMLDivElement>(null)
+    const targetRef = useRef<HTMLDivElement>(null)
+    useFocusOnPointerDown({
+      ref,
+      elements: [targetRef],
+      enabled: true,
+      ...props,
+    })
+
+    return (
+      <div ref={ref} data-testid="container">
+        <div
+          ref={targetRef}
+          data-testid="target"
+          tabIndex={-1}
+          onPointerDown={
+            preventNativeFocus ? (ev) => ev.preventDefault() : undefined
+          }
+        >
+          Target
+        </div>
+      </div>
+    )
+  }
+
+  test("prevents default behavior and focuses on the target element", async () => {
+    const { user } = await render(<Component />)
+    const target = page.getByTestId("target")
+
+    await user.click(target)
+
+    await expect.element(target).toHaveFocus()
+  })
+
+  test("does not focus when disabled", async () => {
+    const { user } = await render(<Component enabled={false} />)
+    const target = page.getByTestId("target")
+
+    await user.click(target)
+
+    await expect.element(target).not.toHaveFocus()
+  })
+
+  test("does not move focus when target is already active", async () => {
+    const { user } = await render(<Component />)
+    const target = page.getByTestId("target")
+    const targetElement = target.element() as HTMLElement
+
+    targetElement.focus()
+    await user.click(target)
+
+    await expect.element(target).toHaveFocus()
+  })
+
+  test("uses ref as fallback when elements is not provided", async () => {
+    const { user } = await render(<Component elements={undefined} />)
+    const target = page.getByTestId("target")
+
+    await user.click(target)
+
+    await expect.element(target).toHaveFocus()
+  })
+
+  test("supports raw HTMLElement in elements and ignores null entries", async () => {
+    const { rerender, user } = await render(<Component />)
+    const target = page.getByTestId("target")
+    const targetElement = target.element() as HTMLElement
+
+    rerender(<Component elements={[targetElement]} />)
+    await user.click(target)
+
+    await expect.element(target).toHaveFocus()
+
+    targetElement.blur()
+    rerender(<Component elements={[null]} />)
+    await user.click(target)
+
+    await expect.element(target).not.toHaveFocus()
+  })
+})


### PR DESCRIPTION
Closes #7514

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrated `use-focus` tests from jsdom to Vitest Browser Mode and removed utility/focus mocking.

## Current behavior (updates)

`use-focus` tests were implemented as jsdom tests and depended on utility/focus mocks.

## New behavior

- Renamed to `index.test.browser.tsx` and switched to `#test/browser` APIs.
- Removed `../../utils` mock and direct `focus()` spy assertions.
- Replaced assertions with browser-native focus behavior checks (`toHaveFocus`, active element checks).
- Kept coverage across `useFocusOnShow` and `useFocusOnPointerDown` branches, including Safari/non-Safari paths.

## Is this a breaking change (Yes/No):

No

## Additional Information

Coverage check on `src/hooks/use-focus/` (before/after):
- Before: `44/44` statements (`100.00%`)
- After: `43/44` statements (`97.73%`)
- Delta: `-2.27%` (within ±5% tolerance)
