### PR TITLE
test(use-hover): add browser-mode hover interaction tests

### DIFF
--- a/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
@@ -1,0 +1,38 @@
+import { page, render } from "#test/browser"
+import { useHover } from "./"
+
+describe("useHover", () => {
+  test("should work correctly (not-hovered => hovered => not-hovered)", async () => {
+    const hoveredText = /^Hovered$/
+    const notHoveredText = /^Not hovered$/
+
+    const Text = () => {
+      const { ref, hovered } = useHover()
+
+      return <span ref={ref}>{hovered ? "Hovered" : "Not hovered"}</span>
+    }
+
+    const { user } = await render(<Text />)
+
+    const text = page.getByText(notHoveredText)
+
+    await expect.element(text).toBeInTheDocument()
+    await expect
+      .element(page.getByText(hoveredText).query())
+      .not.toBeInTheDocument()
+
+    await user.hover(text)
+
+    await expect.element(page.getByText(hoveredText)).toBeInTheDocument()
+    await expect
+      .element(page.getByText(notHoveredText).query())
+      .not.toBeInTheDocument()
+
+    await user.unhover(text)
+
+    await expect.element(page.getByText(notHoveredText)).toBeInTheDocument()
+    await expect
+      .element(page.getByText(hoveredText).query())
+      .not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/hooks/use-hover/use-hover.test.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.tsx
@@ -2,30 +2,16 @@ import { render, screen } from "#test"
 import { useHover } from "./"
 
 describe("useHover", () => {
-  test("should work correctly (not-hovered => hovered => not-hovered))", async () => {
-    const hoveredText = "Hovered"
-    const notHoveredText = "Not hovered"
-
+  test("renders initial non-hover state in jsdom", async () => {
     const Text = () => {
       const { ref, hovered } = useHover()
 
-      return <span ref={ref}>{hovered ? hoveredText : notHoveredText}</span>
+      return <span ref={ref}>{hovered ? "Hovered" : "Not hovered"}</span>
     }
 
-    const { user } = render(<Text />)
+    render(<Text />)
 
-    const initialTextComponent = await screen.findByText(notHoveredText)
-    expect(initialTextComponent).toBeInTheDocument()
-    expect(screen.queryByText(hoveredText)).toBeNull()
-
-    await user.hover(initialTextComponent)
-    const hoveredTextComponent = await screen.findByText(hoveredText)
-    expect(hoveredTextComponent).toBeInTheDocument()
-    expect(screen.queryByText(notHoveredText)).toBeNull()
-
-    await user.unhover(hoveredTextComponent)
-    const unHoveredTextComponent = await screen.findByText(notHoveredText)
-    expect(unHoveredTextComponent).toBeInTheDocument()
-    expect(screen.queryByText(hoveredText)).toBeNull()
+    await expect(screen.findByText("Not hovered")).resolves.toBeInTheDocument()
+    expect(screen.queryByText("Hovered")).toBeNull()
   })
 })


### PR DESCRIPTION
Closes #7515

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add browser-mode interaction coverage for `useHover` and keep a jsdom smoke assertion for initial render behavior.

## Current behavior (updates)

`use-hover` testing was only in jsdom and relied on simulated hover/unhover interaction.

## New behavior

- Added `use-hover.test.browser.tsx` using `#test/browser`, `page`, and `user.hover`/`user.unhover`.
- Simplified `use-hover.test.tsx` to a jsdom smoke test for the initial non-hover state.
- Browser-mode test now validates the hover state transition in chromium/firefox/webkit.

## Is this a breaking change (Yes/No):

No

## Additional Information

Coverage check (folder-scoped jsdom coverage command, before/after):
- Before: Statements `22.36%` / Lines `23.73%`
- After: Statements `22.34%` / Lines `23.73%`
- Delta: Statements `-0.02%`, Lines `0.00%` (within ±5%)
