### PR TITLE
test(use-window-event): migrate listener tests to browser mode

### DIFF
--- a/packages/react/src/hooks/use-window-event/index.test.browser.tsx
+++ b/packages/react/src/hooks/use-window-event/index.test.browser.tsx
@@ -1,0 +1,38 @@
+import { renderHook } from "#test/browser"
+import { useWindowEvent } from "./"
+
+describe("useWindowEvent", () => {
+  test("adds and removes an event listener to the window", async () => {
+    const eventType = "resize"
+    const handler = vi.fn()
+
+    const { unmount } = await renderHook(() =>
+      useWindowEvent(eventType, handler),
+    )
+
+    window.dispatchEvent(new Event(eventType))
+
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    unmount()
+    window.dispatchEvent(new Event(eventType))
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test("handles custom events", async () => {
+    const eventType = "yamada:custom"
+    const handler = vi.fn<(ev: CustomEvent) => void>()
+
+    const { unmount } = await renderHook(() =>
+      useWindowEvent(eventType, handler),
+    )
+    const event = new CustomEvent(eventType, { detail: { value: 1 } })
+
+    window.dispatchEvent(event)
+
+    expect(handler).toHaveBeenCalledExactlyOnceWith(event)
+
+    unmount()
+  })
+})

--- a/packages/react/src/hooks/use-window-event/index.test.tsx
+++ b/packages/react/src/hooks/use-window-event/index.test.tsx
@@ -1,22 +1,8 @@
-import { a11y, renderHook } from "#test"
-import { useWindowEvent } from "./"
+import { a11y } from "#test"
 import { Basic } from "./index.stories"
 
 describe("useWindowEvent", () => {
   test("renders with no a11y violations", async () => {
     await a11y(<Basic />)
-  })
-
-  test("adds and removes an event listener to the window", () => {
-    const eventType = "resize"
-    const handler = vi.fn()
-
-    const { unmount } = renderHook(() => useWindowEvent(eventType, handler))
-    window.dispatchEvent(new Event(eventType))
-    expect(handler).toHaveBeenCalledTimes(1)
-
-    unmount()
-    window.dispatchEvent(new Event(eventType))
-    expect(handler).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Closes #7521

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Migrate `use-window-event` listener-behavior tests to Vitest Browser Mode.

## Current behavior (updates)

`use-window-event` listener tests were in jsdom together with story-based a11y coverage.

## New behavior

- Added `index.test.browser.tsx` with hook listener behavior checks (`add/remove` and custom event handling).
- Reduced jsdom `index.test.tsx` to story-level a11y smoke only.

## Is this a breaking change (Yes/No):

No

## Additional Information

Coverage check (jsdom, folder-scoped) before/after this change:

- Command: `NODE_OPTIONS='--localstorage-file=/tmp/yamada-ui-localstorage.json' pnpm react test:jsdom --run --coverage src/hooks/use-window-event/`
- Before: Statements `23.52%`, Lines `24.94%`
- After: Statements `23.51%`, Lines `24.93%`
- Delta: Statements `-0.01%`, Lines `-0.01%` (within ±5%)

Browser command status:

- `pnpm react test:browser --run src/hooks/use-window-event/` failed in this environment due Playwright browser launch errors (Firefox headless process abort), not assertion failures.
