### PR TITLE
feat(mergeProps): default `mergeAria` to true

### DIFF
--- a/.changeset/bright-aria-merge.md
+++ b/.changeset/bright-aria-merge.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": minor
+---
+
+Change `mergeProps`'s `mergeAria` option to default to `true` so space-separated WAI-ARIA list attributes (`aria-controls`, `aria-describedby`, `aria-flowto`, `aria-labelledby`, `aria-owns`) are concatenated by default; pass `mergeAria: false` to keep the previous last-wins behavior.

--- a/packages/react/src/core/components/props.test.tsx
+++ b/packages/react/src/core/components/props.test.tsx
@@ -116,42 +116,34 @@ describe("mergeProps", () => {
     expect(result["aria-describedby"]).toBe("b")
   })
 
-  test("mergeAria: defaults to last-wins for ARIA list attributes", () => {
+  test("merges space-separated ARIA lists", () => {
     const result = mergeProps(
       { "aria-describedby": "error-id" },
       { "aria-describedby": "helper-id" },
     )()
-    expect(result["aria-describedby"]).toBe("helper-id")
-  })
-
-  test("mergeAria: merges space-separated ARIA lists when enabled", () => {
-    const result = mergeProps(
-      { "aria-describedby": "error-id" },
-      { "aria-describedby": "helper-id" },
-    )({ mergeAria: true })
     expect(result["aria-describedby"]).toBe("error-id helper-id")
   })
 
-  test("mergeAria: one side undefined passes through when enabled", () => {
+  test("mergeAria: one side undefined passes through", () => {
     expect(
       mergeProps(
         { "aria-labelledby": "a" },
         { "aria-labelledby": undefined },
-      )({ mergeAria: true })["aria-labelledby"],
+      )()["aria-labelledby"],
     ).toBe("a")
     expect(
       mergeProps(
         { "aria-labelledby": undefined },
         { "aria-labelledby": "b" },
-      )({ mergeAria: true })["aria-labelledby"],
+      )()["aria-labelledby"],
     ).toBe("b")
   })
 
-  test("mergeAria: non-list ARIA attributes keep last wins when enabled", () => {
+  test("non-list ARIA attributes keep last wins", () => {
     const result = mergeProps(
       { "aria-activedescendant": "x" },
       { "aria-activedescendant": "y" },
-    )({ mergeAria: true })
+    )()
     expect(result["aria-activedescendant"]).toBe("y")
   })
 })

--- a/packages/react/src/core/components/props.ts
+++ b/packages/react/src/core/components/props.ts
@@ -76,7 +76,7 @@ export function mergeProps<Y extends (Dict | undefined)[]>(
 ): (options?: MergePropsOptions) => MergeAll<Y>
 export function mergeProps(...args: (Dict | undefined)[]) {
   return function ({
-    mergeAria = false,
+    mergeAria = true,
     mergeClassName = true,
     mergeCSS = true,
     mergeEvent = true,


### PR DESCRIPTION
## Description

Follows up on #7546. Changes the default of `mergeAria` from `false` to `true`, so that `mergeProps` concatenates space-separated WAI-ARIA list attributes (`aria-controls`, `aria-describedby`, `aria-flowto`, `aria-labelledby`, `aria-owns`) by default. Pass `mergeAria: false` to opt back into the previous last-wins behavior.

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Is this a breaking change (Yes/No):

No