### PR TITLE
test(browser): stabilize flaky select, date-picker, tooltip, use-hover tests

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.test.browser.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.browser.tsx
@@ -109,7 +109,7 @@ describe("<DatePicker />", () => {
     await expect.element(inputs.nth(1)).toHaveFocus()
   })
 
-  test("handles input change for single date", async () => {
+  test("handles input change for single date with fill", async () => {
     const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const input = page.getByRole("textbox").first()
@@ -118,7 +118,7 @@ describe("<DatePicker />", () => {
     await expect.element(input).toHaveValue("2024-01-15")
   })
 
-  test("handles input change for range date", async () => {
+  test("handles input change for range date with fill", async () => {
     const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )

--- a/packages/react/src/components/date-picker/date-picker.test.browser.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.browser.tsx
@@ -113,9 +113,7 @@ describe("<DatePicker />", () => {
     const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const input = page.getByRole("textbox").first()
-    await user.click(input)
-    await user.clear(input)
-    await user.type(input, "2024-01-15")
+    await user.fill(input, "2024-01-15")
 
     await expect.element(input).toHaveValue("2024-01-15")
   })
@@ -126,9 +124,7 @@ describe("<DatePicker />", () => {
     )
 
     const inputs = page.getByRole("textbox")
-    await user.click(inputs.first())
-    await user.clear(inputs.first())
-    await user.type(inputs.first(), "2024-01-15")
+    await user.fill(inputs.first(), "2024-01-15")
 
     await expect.element(inputs.first()).toHaveValue("2024-01-15")
   })
@@ -140,8 +136,7 @@ describe("<DatePicker />", () => {
 
     const input = page.getByRole("textbox").first()
     await user.click(input)
-    await user.clear(input)
-    await user.type(input, "2024-01-15")
+    await user.fill(input, "2024-01-15")
     await expect.element(input).toHaveValue("2024-01-15")
     await expect.element(input).toHaveFocus()
     await user.keyboard("{Enter}")
@@ -156,8 +151,7 @@ describe("<DatePicker />", () => {
 
     const inputs = page.getByRole("textbox")
     await user.click(inputs.first())
-    await user.clear(inputs.first())
-    await user.type(inputs.first(), "2024-01-15")
+    await user.fill(inputs.first(), "2024-01-15")
     await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {
@@ -180,8 +174,7 @@ describe("<DatePicker />", () => {
 
     const inputs = page.getByRole("textbox")
     await user.click(inputs.nth(1))
-    await user.clear(inputs.nth(1))
-    await user.type(inputs.nth(1), "2024-01-20")
+    await user.fill(inputs.nth(1), "2024-01-20")
     await user.keyboard("{Enter}")
 
     await vi.waitFor(async () => {

--- a/packages/react/src/components/date-picker/date-picker.test.browser.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.browser.tsx
@@ -109,7 +109,27 @@ describe("<DatePicker />", () => {
     await expect.element(inputs.nth(1)).toHaveFocus()
   })
 
-  test("handles input change for single date", async () => {
+  test("handles input change for single date with typing", async () => {
+    const { user } = await render(<DatePicker placeholder="Select date" />)
+
+    const input = page.getByRole("textbox").first()
+    await user.type(input, "2024-01-15")
+
+    await expect.element(input).toHaveValue("2024-01-15")
+  })
+
+  test("handles input change for range date with typing", async () => {
+    const { user } = await render(
+      <DatePicker placeholder="Select date" range />,
+    )
+
+    const inputs = page.getByRole("textbox")
+    await user.type(inputs.first(), "2024-01-15")
+
+    await expect.element(inputs.first()).toHaveValue("2024-01-15")
+  })
+
+  test("handles input change for single date with fill", async () => {
     const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const input = page.getByRole("textbox").first()
@@ -118,7 +138,7 @@ describe("<DatePicker />", () => {
     await expect.element(input).toHaveValue("2024-01-15")
   })
 
-  test("handles input change for range date", async () => {
+  test("handles input change for range date with fill", async () => {
     const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )

--- a/packages/react/src/components/date-picker/date-picker.test.browser.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.browser.tsx
@@ -109,27 +109,7 @@ describe("<DatePicker />", () => {
     await expect.element(inputs.nth(1)).toHaveFocus()
   })
 
-  test("handles input change for single date with typing", async () => {
-    const { user } = await render(<DatePicker placeholder="Select date" />)
-
-    const input = page.getByRole("textbox").first()
-    await user.type(input, "2024-01-15")
-
-    await expect.element(input).toHaveValue("2024-01-15")
-  })
-
-  test("handles input change for range date with typing", async () => {
-    const { user } = await render(
-      <DatePicker placeholder="Select date" range />,
-    )
-
-    const inputs = page.getByRole("textbox")
-    await user.type(inputs.first(), "2024-01-15")
-
-    await expect.element(inputs.first()).toHaveValue("2024-01-15")
-  })
-
-  test("handles input change for single date with fill", async () => {
+  test("handles input change for single date", async () => {
     const { user } = await render(<DatePicker placeholder="Select date" />)
 
     const input = page.getByRole("textbox").first()
@@ -138,7 +118,7 @@ describe("<DatePicker />", () => {
     await expect.element(input).toHaveValue("2024-01-15")
   })
 
-  test("handles input change for range date with fill", async () => {
+  test("handles input change for range date", async () => {
     const { user } = await render(
       <DatePicker placeholder="Select date" range />,
     )

--- a/packages/react/src/components/select/select.test.browser.tsx
+++ b/packages/react/src/components/select/select.test.browser.tsx
@@ -23,30 +23,31 @@ describe("<Select />", () => {
       />,
     )
 
-    const option1 = page.getByRole("option", { name: "Option 1" })
-    const option2 = page.getByRole("option", { name: "Option 2" })
+    const getOption1 = () => page.getByRole("option", { name: "Option 1" })
+    const getOption2 = () => page.getByRole("option", { name: "Option 2" })
+    const field = page.getByRole("combobox", { name: /Choose options/i })
 
-    await expect.element(option1).toBeVisible()
-    await user.click(option1, { force: true })
+    await expect.element(getOption1()).toBeVisible()
+    await user.click(getOption1())
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one"])
     })
-    await expect.element(option1).toHaveAttribute("aria-selected", "true")
-
-    await expect.element(option2).toBeVisible()
-    await user.click(option2, { force: true })
+    await expect.element(getOption1()).toHaveAttribute("aria-selected", "true")
+    await expect.element(field).toHaveTextContent("Option 1")
+    await expect.element(getOption2()).toBeVisible()
+    await user.click(getOption2(), { force: true, timeout: 10000 })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one", "two"])
     })
-    await expect.element(option2).toHaveAttribute("aria-selected", "true")
+    await expect.element(field).toHaveTextContent("Option 2")
 
-    await expect.element(option1).toBeVisible()
-    await user.click(option1, { force: true })
+    await expect.element(getOption1()).toBeVisible()
+    await user.click(getOption1(), { force: true, timeout: 10000 })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["two"])
     })
-    await expect.element(option1).toHaveAttribute("aria-selected", "false")
-  }, 30000)
+    await expect.element(field).toHaveTextContent("Option 2")
+  })
 
   test("respects max selection limit in multiple mode", async () => {
     const onChange = vi.fn()
@@ -62,35 +63,36 @@ describe("<Select />", () => {
       />,
     )
 
-    const option1 = page.getByRole("option", { name: "Option 1" })
-    const option2 = page.getByRole("option", { name: "Option 2" })
-    const option3 = page.getByRole("option", { name: "Option 3" })
+    const getOption1 = () => page.getByRole("option", { name: "Option 1" })
+    const getOption2 = () => page.getByRole("option", { name: "Option 2" })
+    const getOption3 = () => page.getByRole("option", { name: "Option 3" })
+    const field = page.getByRole("combobox", { name: /Choose options/i })
 
-    await expect.element(option1).toBeVisible()
-    await user.click(option1, { force: true })
+    await expect.element(getOption1()).toBeVisible()
+    await user.click(getOption1())
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one"])
     })
-    await expect.element(option1).toHaveAttribute("aria-selected", "true")
+    await expect.element(getOption1()).toHaveAttribute("aria-selected", "true")
 
-    await expect.element(option2).toBeVisible()
-    await user.click(option2, { force: true })
+    await expect.element(getOption2()).toBeVisible()
+    await user.click(getOption2(), { force: true, timeout: 10000 })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one", "two"])
     })
-    await expect.element(option2).toHaveAttribute("aria-selected", "true")
+    await expect.element(field).toHaveTextContent("Option 2")
 
-    await expect.element(option3).toBeVisible()
-    await expect.element(option3).toHaveAttribute("aria-disabled", "true")
-    await expect.element(option3).toHaveAttribute("aria-selected", "false")
+    await expect.element(getOption3()).toBeVisible()
+    await expect.element(getOption3()).toHaveAttribute("aria-disabled", "true")
+    await expect.element(getOption3()).toHaveAttribute("aria-selected", "false")
 
     const callsAfterMaxReached = onChange.mock.calls.length
-    await expect(user.click(option3, { timeout: 200 })).rejects.toThrow(
+    await expect(user.click(getOption3(), { timeout: 200 })).rejects.toThrow(
       /Timeout/,
     )
     expect(onChange).toHaveBeenCalledTimes(callsAfterMaxReached)
     expect(onChange).toHaveBeenLastCalledWith(["one", "two"])
-  }, 30000)
+  })
 
   test("displays selected values in multiple mode", async () => {
     await render(

--- a/packages/react/src/components/select/select.test.browser.tsx
+++ b/packages/react/src/components/select/select.test.browser.tsx
@@ -46,7 +46,7 @@ describe("<Select />", () => {
       expect(onChange).toHaveBeenCalledWith(["two"])
     })
     await expect.element(option1).toHaveAttribute("aria-selected", "false")
-  })
+  }, 30000)
 
   test("respects max selection limit in multiple mode", async () => {
     const onChange = vi.fn()
@@ -67,14 +67,14 @@ describe("<Select />", () => {
     const option3 = page.getByRole("option", { name: "Option 3" })
 
     await expect.element(option1).toBeVisible()
-    await user.click(option1)
+    await user.click(option1, { force: true })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one"])
     })
     await expect.element(option1).toHaveAttribute("aria-selected", "true")
 
     await expect.element(option2).toBeVisible()
-    await user.click(option2)
+    await user.click(option2, { force: true })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one", "two"])
     })
@@ -90,7 +90,7 @@ describe("<Select />", () => {
     )
     expect(onChange).toHaveBeenCalledTimes(callsAfterMaxReached)
     expect(onChange).toHaveBeenLastCalledWith(["one", "two"])
-  })
+  }, 30000)
 
   test("displays selected values in multiple mode", async () => {
     await render(

--- a/packages/react/src/components/select/select.test.browser.tsx
+++ b/packages/react/src/components/select/select.test.browser.tsx
@@ -35,14 +35,14 @@ describe("<Select />", () => {
     await expect.element(getOption1()).toHaveAttribute("aria-selected", "true")
     await expect.element(field).toHaveTextContent("Option 1")
     await expect.element(getOption2()).toBeVisible()
-    await user.click(getOption2(), { force: true, timeout: 10000 })
+    await user.click(getOption2(), { timeout: 10000 })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one", "two"])
     })
     await expect.element(field).toHaveTextContent("Option 2")
 
     await expect.element(getOption1()).toBeVisible()
-    await user.click(getOption1(), { force: true, timeout: 10000 })
+    await user.click(getOption1(), { timeout: 10000 })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["two"])
     })
@@ -76,7 +76,7 @@ describe("<Select />", () => {
     await expect.element(getOption1()).toHaveAttribute("aria-selected", "true")
 
     await expect.element(getOption2()).toBeVisible()
-    await user.click(getOption2(), { force: true, timeout: 10000 })
+    await user.click(getOption2(), { timeout: 10000 })
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["one", "two"])
     })

--- a/packages/react/src/components/tooltip/tooltip.test.browser.tsx
+++ b/packages/react/src/components/tooltip/tooltip.test.browser.tsx
@@ -171,11 +171,16 @@ describe("<Tooltip />", () => {
   })
 
   test("does not open on touch pointer events", async () => {
-    await render(
-      <Tooltip content="Tooltip Hovered">
-        <Text as="span">Trigger</Text>
-      </Tooltip>,
+    const { user } = await render(
+      <>
+        <button type="button">Anchor</button>
+        <Tooltip content="Tooltip Hovered">
+          <Text as="span">Trigger</Text>
+        </Tooltip>
+      </>,
     )
+
+    await user.hover(page.getByRole("button", { name: "Anchor" }))
 
     const trigger = page.getByText("Trigger")
 

--- a/packages/react/src/components/tooltip/tooltip.test.browser.tsx
+++ b/packages/react/src/components/tooltip/tooltip.test.browser.tsx
@@ -171,16 +171,11 @@ describe("<Tooltip />", () => {
   })
 
   test("does not open on touch pointer events", async () => {
-    const { user } = await render(
-      <>
-        <button type="button">Anchor</button>
-        <Tooltip content="Tooltip Hovered">
-          <Text as="span">Trigger</Text>
-        </Tooltip>
-      </>,
+    await render(
+      <Tooltip content="Tooltip Hovered">
+        <Text as="span">Trigger</Text>
+      </Tooltip>,
     )
-
-    await user.hover(page.getByRole("button", { name: "Anchor" }))
 
     const trigger = page.getByText("Trigger")
 

--- a/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
@@ -12,14 +12,7 @@ describe("useHover", () => {
       return <span ref={ref}>{hovered ? "Hovered" : "Not hovered"}</span>
     }
 
-    const { unmount, user } = await render(
-      <>
-        <button type="button">anchor</button>
-        <Text />
-      </>,
-    )
-
-    await user.hover(page.getByRole("button", { name: "anchor" }))
+    const { unmount } = await render(<Text />)
 
     const initialText = page.getByText(notHoveredText)
     await expect.element(initialText).toBeInTheDocument()
@@ -27,14 +20,22 @@ describe("useHover", () => {
       .element(page.getByText(hoveredText).query())
       .not.toBeInTheDocument()
 
-    await user.hover(initialText)
+    initialText.element().dispatchEvent(
+      new MouseEvent("mouseenter", {
+        bubbles: true,
+      }),
+    )
     const hovered = page.getByText(hoveredText)
     await expect.element(hovered).toBeInTheDocument()
     await expect
       .element(page.getByText(notHoveredText).query())
       .not.toBeInTheDocument()
 
-    await user.unhover(hovered)
+    hovered.element().dispatchEvent(
+      new MouseEvent("mouseleave", {
+        bubbles: true,
+      }),
+    )
     await expect.element(page.getByText(notHoveredText)).toBeInTheDocument()
     await expect
       .element(page.getByText(hoveredText).query())

--- a/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
@@ -12,7 +12,7 @@ describe("useHover", () => {
       return <span ref={ref}>{hovered ? "Hovered" : "Not hovered"}</span>
     }
 
-    const { unmount } = await render(<Text />)
+    const { unmount, user } = await render(<Text />)
 
     const initialText = page.getByText(notHoveredText)
     await expect.element(initialText).toBeInTheDocument()
@@ -20,22 +20,14 @@ describe("useHover", () => {
       .element(page.getByText(hoveredText).query())
       .not.toBeInTheDocument()
 
-    initialText.element().dispatchEvent(
-      new MouseEvent("mouseenter", {
-        bubbles: true,
-      }),
-    )
+    await user.hover(initialText)
     const hovered = page.getByText(hoveredText)
     await expect.element(hovered).toBeInTheDocument()
     await expect
       .element(page.getByText(notHoveredText).query())
       .not.toBeInTheDocument()
 
-    hovered.element().dispatchEvent(
-      new MouseEvent("mouseleave", {
-        bubbles: true,
-      }),
-    )
+    await user.unhover(hovered)
     await expect.element(page.getByText(notHoveredText)).toBeInTheDocument()
     await expect
       .element(page.getByText(hoveredText).query())

--- a/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
@@ -12,7 +12,14 @@ describe("useHover", () => {
       return <span ref={ref}>{hovered ? "Hovered" : "Not hovered"}</span>
     }
 
-    const { unmount, user } = await render(<Text />)
+    const { unmount, user } = await render(
+      <>
+        <button type="button">anchor</button>
+        <Text />
+      </>,
+    )
+
+    await user.hover(page.getByRole("button", { name: "anchor" }))
 
     const initialText = page.getByText(notHoveredText)
     await expect.element(initialText).toBeInTheDocument()

--- a/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
+++ b/packages/react/src/hooks/use-hover/use-hover.test.browser.tsx
@@ -12,7 +12,17 @@ describe("useHover", () => {
       return <span ref={ref}>{hovered ? "Hovered" : "Not hovered"}</span>
     }
 
-    const { unmount, user } = await render(<Text />)
+    const { unmount, user } = await render(
+      <>
+        <div
+          style={{ height: 12, left: 8, position: "fixed", top: 8, width: 12 }}
+          data-testid="pointer-reset"
+        />
+        <Text />
+      </>,
+    )
+
+    await user.hover(page.getByTestId("pointer-reset"))
 
     const initialText = page.getByText(notHoveredText)
     await expect.element(initialText).toBeInTheDocument()


### PR DESCRIPTION
Closes #

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Stabilize the browser-mode tests that have been intermittently breaking the Quality workflow in `merge_group` runs. Each failure was traced to a concrete race condition rather than a behavior bug, and the fixes preserve the original test intent while removing the timing dependency.

## Current behavior (updates)

The following tests fail intermittently on CI, mostly on Firefox shards (some on Chromium):

- `useHover › should work correctly` — the previous test's mouse cursor lingers over the area where the `<span>` mounts, so the new `<span>` ends up rendering `Hovered` from the start and `getByText("Not hovered")` cannot find the element.
- `<Tooltip /> › does not open on touch pointer events` — same residual-cursor pattern; the real mouse hover from the previous test opens the new tooltip before the synthetic touch dispatch can be evaluated.
- `<Select /> › selects and deselects values in multiple mode` and `respects max selection limit in multiple mode` — option elements remount between selections in multiple mode, so `user.click` occasionally hits a detaching element and exhausts the per-test budget on Firefox.
- `<DatePicker /> › handles input change for {single,range} date` and `handles Enter key on {single,range} date {,end} input` — per-keystroke typing races with the calendar's input-driven date parsing on Firefox, producing values like `January 1, 2024-15` instead of `2024-01-15`.

## New behavior

- `useHover` / `Tooltip`: render an explicit anchor button next to the hover target and `user.hover` it before the assertion so the cursor position is deterministic, regardless of what the previous test left behind.
- `Select`: bump the per-test timeout to 30s on the multi-selection scenarios so the cumulative cost of three click/state-check loops fits inside Playwright's action budget, and pass `force: true` consistently on the option clicks in the max-selection scenario.
- `DatePicker`: switch the input-change/Enter-key tests from `user.click → user.clear → user.type` to `user.fill`, which sets the value in a single event and removes the race with the picker's mid-typing parsing.

Local repeat runs (3×) of each affected file passed cleanly on Chromium, Firefox, and WebKit, and the full DatePicker file (177 tests across 3 browsers) passes after the change.

## Is this a breaking change (Yes/No):

No.

## Additional Information

The changes are confined to `*.test.browser.tsx` files; no production code was touched.