### PR TITLE
refactor(color-picker): use mergeProps with mergeAria for aria attribute merging

### DIFF
--- a/.changeset/refactor-color-picker-merge-aria.md
+++ b/.changeset/refactor-color-picker-merge-aria.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Refactored `useColorPicker` to use `mergeProps` with `mergeAria` for aria attribute merging.

--- a/packages/react/src/components/color-picker/use-color-picker.ts
+++ b/packages/react/src/components/color-picker/use-color-picker.ts
@@ -7,6 +7,7 @@ import type { ColorFormat } from "../../utils"
 import type { UseColorSelectorProps } from "../color-selector"
 import type { FieldProps } from "../field"
 import { useCallback, useEffect, useRef } from "react"
+import { mergeProps } from "../../core"
 import { useCombobox } from "../../hooks/use-combobox"
 import { useControllableState } from "../../hooks/use-controllable-state"
 import { useEyeDropper } from "../../hooks/use-eye-dropper"
@@ -16,7 +17,6 @@ import {
   calcFormat,
   contains,
   convertColor,
-  cx,
   focusTransfer,
   handlerAll,
   mergeRefs,
@@ -121,7 +121,7 @@ export const useColorPicker = (props: UseColorPickerProps) => {
       ref,
       name,
       "aria-label": ariaLabel,
-      "aria-labelledby": ariaLabelledbyProp,
+      "aria-labelledby": ariaLabelledby,
       allowInput = true,
       closeOnChange = false,
       defaultValue,
@@ -323,34 +323,31 @@ export const useColorPicker = (props: UseColorPickerProps) => {
   )
 
   const getInputProps: PropGetter<"input"> = useCallback(
-    ({ "aria-labelledby": ariaLabelledby, ...props } = {}) => ({
-      id,
-      ref: mergeRefs(props.ref, ref, inputRef),
-      name,
-      style: {
-        ...(!allowInput ? { pointerEvents: "none" } : {}),
-        ...props.style,
-      },
-      "aria-label": ariaLabel,
-      "aria-labelledby": cx(ariaLabelledby, ariaLabelledbyProp),
-      autoComplete: "off",
-      disabled,
-      placeholder,
-      readOnly,
-      required,
-      tabIndex: allowInput ? 0 : -1,
-      value,
-      ...dataProps,
-      ...props,
-      onBlur: handlerAll(props.onBlur, onBlur),
-      onChange: handlerAll(props.onChange, onInputChange),
-      onFocus: handlerAll(props.onFocus, onInputFocus),
-      onMouseDown: handlerAll(props.onMouseDown, onMouseDown),
-    }),
+    (props = {}) =>
+      mergeProps(
+        {
+          id,
+          ref: mergeRefs(ref, inputRef),
+          name,
+          style: !allowInput ? { pointerEvents: "none" } : {},
+          "aria-label": ariaLabel,
+          "aria-labelledby": ariaLabelledby,
+          autoComplete: "off",
+          disabled,
+          placeholder,
+          readOnly,
+          required,
+          tabIndex: allowInput ? 0 : -1,
+          value,
+          ...dataProps,
+        },
+        props,
+        { onBlur, onChange: onInputChange, onFocus: onInputFocus, onMouseDown },
+      )(),
     [
       allowInput,
       ariaLabel,
-      ariaLabelledbyProp,
+      ariaLabelledby,
       dataProps,
       disabled,
       id,


### PR DESCRIPTION
Closes #7562

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Refactored `useColorPicker` to use `mergeProps` with `mergeAria` for aria attribute merging.

## Current behavior (updates)

Manually destructures aria attributes and merges them with `cx()`.

## New behavior

Delegates aria attribute merging to `mergeProps` via the `mergeAria` option (default `true`, added in #7546).

## Is this a breaking change (Yes/No):

No

## Additional Information

Follow-up to #7546.