### PR TITLE
docs(agents): exclude tests from changesets rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ When editing or reviewing files that match a pattern below, read the linked rule
   - `.claude/skills/**/*.md`
 - [Changesets](.agents/rules/changesets.md):
   - `packages/{cli,react,utils}/src/**/*.{ts,tsx}`
+  - `!packages/{cli,react,utils}/src/**/*.test.{ts,tsx}`
+  - `!packages/{cli,react,utils}/src/**/*.test.{browser,chromium,firefox,webkit}.{ts,tsx}`
   - `.changeset/*.md`
 - [Test Categorization](.agents/rules/test-categorization.md):
   - `packages/react/src/**/*.test.{ts,tsx}`


### PR DESCRIPTION
Closes #7610

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Exclude test file globs from the `Changesets` rule in `AGENTS.md`.

## Current behavior (updates)

The `Changesets` rule matched all TypeScript source files under `packages/{cli,react,utils}/src/**/*.{ts,tsx}`, including test files.

## New behavior

Unit and browser test files are excluded from the `Changesets` rule and remain covered by the dedicated test rules.

## Is this a breaking change (Yes/No):

No

## Additional Information

Local tests were not run because this only updates repository agent instructions.