### PR TITLE
chore(opencode): add Magi configuration

### DIFF
--- a/.agents/references/pr-merge-guidelines.md
+++ b/.agents/references/pr-merge-guidelines.md
@@ -12,7 +12,7 @@ The following branch protection rules are enabled on the `main` and `v*` branche
 
 ### Review
 
-- **Require review from specific teams**: At least 1 approval from each of the `Prime`, `Standard`, and `Growth` teams is required. `hirotomoyamada` belongs to all 3 teams, so a single approval satisfies every team requirement. `codex-for-yamada-ui` belongs to `Prime`, `claude-for-yamada-ui` belongs to `Standard`, and `composer-for-yamada-ui` belongs to `Growth`.
+- **Require review from specific teams**: At least 1 approval from each of the `Melchior`, `Balthasar`, and `Caspar` teams is required. `hirotomoyamada` belongs to all 3 teams, so a single approval satisfies every team requirement. `melchior-magi` belongs to `Melchior`, `balthasar-magi` belongs to `Balthasar`, and `caspar-magi` belongs to `Caspar`.
 - **Require review from Code Owners**: Approval from a Code Owner listed in [CODEOWNERS](/.github/CODEOWNERS) is required.
 - **Require conversation resolution before merging**: All review comments and conversations must be resolved before merging.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-* @yamada-ui/prime @yamada-ui/standard @yamada-ui/growth
+* @yamada-ui/melchior @yamada-ui/balthasar @yamada-ui/caspar
 
 *.md @hirotomoyamada
-.changeset/*.md @yamada-ui/prime @yamada-ui/standard @yamada-ui/growth
+.changeset/*.md @yamada-ui/melchior @yamada-ui/balthasar @yamada-ui/caspar
 package.json @hirotomoyamada
 LICENSE @hirotomoyamada
 .github/ @hirotomoyamada

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# worktree
-.worktrees
-
 # pnpm
 .pnpm-store
 
@@ -42,6 +39,8 @@ next-env.d.ts
 .vitest-attachments
 .react-router
 .tanstack
+.magi
+.worktrees
 
 # dotenv environment variables file
 .env

--- a/.opencode/magi.json
+++ b/.opencode/magi.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/magi-ai/opencode-magi/main/schema.json",
+  "language": "en",
+  "github": {
+    "owner": "yamada-ui",
+    "repo": "yamada-ui"
+  },
+  "review": {
+    "agents": [
+      {
+        "id": "Melchior",
+        "account": "melchior-magi",
+        "model": "openai/gpt-5.5"
+      },
+      {
+        "id": "Balthasar",
+        "account": "balthasar-magi",
+        "model": "opencode/deepseek-v4-flash-free"
+      },
+      {
+        "id": "Caspar",
+        "account": "caspar-magi",
+        "model": "opencode/qwen3.6-plus-free"
+      }
+    ],
+    "merge": {
+      "queue": true,
+      "approvalPolicy": "unanimous"
+    },
+    "prompts": {
+      "reviewGuidelines": ".agents/references/pr-review-guidelines.md"
+    }
+  },
+  "merge": {
+    "editor": {
+      "account": "hirotomoyamada",
+      "model": "openai/gpt-5.5",
+      "author": {
+        "name": "hirotomoyamada",
+        "email": "hirotomo.yamada@avap.co.jp"
+      }
+    },
+    "prompts": {
+      "editGuidelines": ".agents/references/edit-guidelines.md"
+    }
+  }
+}


### PR DESCRIPTION
Closes #7612

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Set up OpenCode Magi for Yamada UI repository review and merge orchestration.

## Current behavior (updates)

OpenCode Magi repository-specific settings are not tracked in this repository, and CODEOWNERS/merge guidance still reference the previous reviewer team names and accounts.

## New behavior

Adds `.opencode/magi.json` for `yamada-ui/yamada-ui`, configures the `Melchior`, `Balthasar`, and `Caspar` reviewer agents, enables unanimous approval through the merge queue, and updates CODEOWNERS and merge guidance to the renamed teams and accounts.

## Is this a breaking change (Yes/No):

No

## Additional Information

https://github.com/magi-ai/opencode-magi