### PR TITLE
docs(visually-hidden): add usage tips

### DIFF
--- a/www/contents/components/(utilities)/visually-hidden.ja.mdx
+++ b/www/contents/components/(utilities)/visually-hidden.ja.mdx
@@ -38,6 +38,22 @@ import { VisuallyHidden } from "@workspaces/ui"
 
 視覚的に要素を隠すために使用されますが、スクリーンリーダーではアクセス可能にします。デフォルトでは、`span`要素をレンダリングします。
 
+:::tip
+`VisuallyHidden`は、視覚的なUIだけで意味が伝わる一方で、支援技術には追加のテキストが必要な場合に使用します。たとえば、アイコンのみの操作、短い状態表示、省略されたラベルに、より具体的なアクセシブルネームを追加する場合です。
+:::
+
+:::tip
+コントロールに短いアクセシブルネームだけを設定したい場合は、そのコントロールに`aria-label`または`aria-labelledby`を設定することを優先します。ヘルプテキスト、エラーテキスト、その他の説明と関連付ける場合は、`Field.HelperMessage`や`Field.ErrorMessage`などを通じて`aria-describedby`を使用します。
+:::
+
+:::tip
+すべてのユーザーから隠したいコンテンツには`VisuallyHidden`を使用しないでください。アイコンのみのボタンには[IconButton](/docs/components/icon-button)、フォームの補足には[Field](/docs/components/field)、追加の文脈的なヘルプには[Tooltip](/docs/components/tooltip)や[Popover](/docs/components/popover)を検討してください。
+:::
+
+:::note
+`VisuallyHidden`の子要素はアクセシビリティツリーに残ります。例を確認するときは、隠しテキストが短く、周囲の要素に関連しており、すでに表示されているラベルと重複していないことを確認してください。
+:::
+
 ## Props
 
 <PropsTable name="visually-hidden" />

--- a/www/contents/components/(utilities)/visually-hidden.ja.mdx
+++ b/www/contents/components/(utilities)/visually-hidden.ja.mdx
@@ -39,19 +39,11 @@ import { VisuallyHidden } from "@workspaces/ui"
 視覚的に要素を隠すために使用されますが、スクリーンリーダーではアクセス可能にします。デフォルトでは、`span`要素をレンダリングします。
 
 :::tip
-`VisuallyHidden`は、視覚的なUIだけで意味が伝わる一方で、支援技術には追加のテキストが必要な場合に使用します。たとえば、アイコンのみの操作、短い状態表示、省略されたラベルに、より具体的なアクセシブルネームを追加する場合です。
+`VisuallyHidden`は、視覚的には表示しないテキストをスクリーンリーダーによって読み上げられるようにしたい場合に使用します。アクセシブルな名前を提供するだけであれば、余分な隠し要素を追加せず、対象の要素に`aria-label`または`aria-labelledby`を設定してください。
 :::
 
 :::tip
-コントロールに短いアクセシブルネームだけを設定したい場合は、そのコントロールに`aria-label`または`aria-labelledby`を設定することを優先します。ヘルプテキスト、エラーテキスト、その他の説明と関連付ける場合は、`Field.HelperMessage`や`Field.ErrorMessage`などを通じて`aria-describedby`を使用します。
-:::
-
-:::tip
-すべてのユーザーから隠したいコンテンツには`VisuallyHidden`を使用しないでください。アイコンのみのボタンには[IconButton](/docs/components/icon-button)、フォームの補足には[Field](/docs/components/field)、追加の文脈的なヘルプには[Tooltip](/docs/components/tooltip)や[Popover](/docs/components/popover)を検討してください。
-:::
-
-:::note
-`VisuallyHidden`の子要素はアクセシビリティツリーに残ります。例を確認するときは、隠しテキストが短く、周囲の要素に関連しており、すでに表示されているラベルと重複していないことを確認してください。
+すべてのユーザーから隠したいコンテンツには`VisuallyHidden`を使用しないでください。`VisuallyHidden`の内容はスクリーンリーダーによって読み上げられます。フォームの補足や追加の文脈的なヘルプは、[Field](/docs/components/field)、[Tooltip](/docs/components/tooltip)、[Popover](/docs/components/popover)など、視覚的にも利用できるコンポーネントを検討してください。
 :::
 
 ## Props

--- a/www/contents/components/(utilities)/visually-hidden.ja.mdx
+++ b/www/contents/components/(utilities)/visually-hidden.ja.mdx
@@ -39,11 +39,7 @@ import { VisuallyHidden } from "@workspaces/ui"
 視覚的に要素を隠すために使用されますが、スクリーンリーダーではアクセス可能にします。デフォルトでは、`span`要素をレンダリングします。
 
 :::tip
-`VisuallyHidden`は、視覚的には表示しないテキストをスクリーンリーダーによって読み上げられるようにしたい場合に使用します。アクセシブルな名前を提供するだけであれば、余分な隠し要素を追加せず、対象の要素に`aria-label`または`aria-labelledby`を設定してください。
-:::
-
-:::tip
-すべてのユーザーから隠したいコンテンツには`VisuallyHidden`を使用しないでください。`VisuallyHidden`の内容はスクリーンリーダーによって読み上げられます。フォームの補足や追加の文脈的なヘルプは、[Field](/docs/components/field)、[Tooltip](/docs/components/tooltip)、[Popover](/docs/components/popover)など、視覚的にも利用できるコンポーネントを検討してください。
+アクセシブルな名前や説明を提供するだけであれば、対象の要素に`aria-label`、`aria-labelledby`、または`aria-describedby`を設定することを検討します。視覚的に要素を隠す必要があり、どうしても他の方法で対応できない場合の最終手段として`VisuallyHidden`を使用します。
 :::
 
 ## Props

--- a/www/contents/components/(utilities)/visually-hidden.mdx
+++ b/www/contents/components/(utilities)/visually-hidden.mdx
@@ -41,19 +41,11 @@ import { VisuallyHidden } from "@workspaces/ui"
 It is used to visually hide elements, but it is accessible in screen readers. By default, it renders a `span` element.
 
 :::tip
-Use `VisuallyHidden` when the visual UI is already clear, but assistive technology needs additional text. Common cases include icon-only controls, short status badges, or abbreviated labels that need a fuller accessible name.
+Use `VisuallyHidden` when text should not be visually displayed but should still be read by screen readers. If you only need to provide an accessible name, avoid adding an extra hidden element; set `aria-label` or `aria-labelledby` on the target element instead.
 :::
 
 :::tip
-If a control only needs a short accessible name, prefer setting `aria-label` or `aria-labelledby` on that control. If the control needs help text, error text, or another description, prefer `aria-describedby` through components such as `Field.HelperMessage` or `Field.ErrorMessage`.
-:::
-
-:::tip
-Do not use `VisuallyHidden` for content that should be hidden from everyone. For icon-only buttons, use [IconButton](/docs/components/icon-button); for form guidance, use [Field](/docs/components/field); and for additional contextual help, consider [Tooltip](/docs/components/tooltip) or [Popover](/docs/components/popover).
-:::
-
-:::note
-`VisuallyHidden` keeps its children in the accessibility tree. When reviewing examples, make sure the hidden text is concise, relevant to the surrounding element, and does not duplicate an already visible label.
+Do not use `VisuallyHidden` for content that should be hidden from all users. The content of `VisuallyHidden` will still be read by screen readers. For form guidance or additional contextual help, consider visually available components such as [Field](/docs/components/field), [Tooltip](/docs/components/tooltip), or [Popover](/docs/components/popover).
 :::
 
 ## Props

--- a/www/contents/components/(utilities)/visually-hidden.mdx
+++ b/www/contents/components/(utilities)/visually-hidden.mdx
@@ -40,6 +40,22 @@ import { VisuallyHidden } from "@workspaces/ui"
 
 It is used to visually hide elements, but it is accessible in screen readers. By default, it renders a `span` element.
 
+:::tip
+Use `VisuallyHidden` when the visual UI is already clear, but assistive technology needs additional text. Common cases include icon-only controls, short status badges, or abbreviated labels that need a fuller accessible name.
+:::
+
+:::tip
+If a control only needs a short accessible name, prefer setting `aria-label` or `aria-labelledby` on that control. If the control needs help text, error text, or another description, prefer `aria-describedby` through components such as `Field.HelperMessage` or `Field.ErrorMessage`.
+:::
+
+:::tip
+Do not use `VisuallyHidden` for content that should be hidden from everyone. For icon-only buttons, use [IconButton](/docs/components/icon-button); for form guidance, use [Field](/docs/components/field); and for additional contextual help, consider [Tooltip](/docs/components/tooltip) or [Popover](/docs/components/popover).
+:::
+
+:::note
+`VisuallyHidden` keeps its children in the accessibility tree. When reviewing examples, make sure the hidden text is concise, relevant to the surrounding element, and does not duplicate an already visible label.
+:::
+
 ## Props
 
 <PropsTable name="visually-hidden" />

--- a/www/contents/components/(utilities)/visually-hidden.mdx
+++ b/www/contents/components/(utilities)/visually-hidden.mdx
@@ -41,11 +41,7 @@ import { VisuallyHidden } from "@workspaces/ui"
 It is used to visually hide elements, but it is accessible in screen readers. By default, it renders a `span` element.
 
 :::tip
-Use `VisuallyHidden` when text should not be visually displayed but should still be read by screen readers. If you only need to provide an accessible name, avoid adding an extra hidden element; set `aria-label` or `aria-labelledby` on the target element instead.
-:::
-
-:::tip
-Do not use `VisuallyHidden` for content that should be hidden from all users. The content of `VisuallyHidden` will still be read by screen readers. For form guidance or additional contextual help, consider visually available components such as [Field](/docs/components/field), [Tooltip](/docs/components/tooltip), or [Popover](/docs/components/popover).
+If you only need to provide an accessible name or description, consider setting `aria-label`, `aria-labelledby`, or `aria-describedby` on the target element. Use `VisuallyHidden` as a last resort when the element needs to be visually hidden and other methods cannot be used.
 :::
 
 ## Props


### PR DESCRIPTION
Closes #7647

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the English and Japanese `VisuallyHidden` docs. The new guidance explains when to use hidden text, when `aria-label`, `aria-labelledby`, or `aria-describedby` is a better fit, and which components to consider for common misuses.

## Current behavior (updates)

The `VisuallyHidden` docs show basic imports and usage, but do not explain how to choose it compared with ARIA attributes or related components.

## New behavior

The docs now include concise tips and a note that hidden text remains in the accessibility tree, so examples should keep that text relevant and avoid duplicating visible labels.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verification:

- `pnpm www build:content`
- `git diff --check`