### PR TITLE
feat(cli): add docs command

### DIFF
--- a/.changeset/silent-clubs-help.md
+++ b/.changeset/silent-clubs-help.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/cli": minor
+---
+
+Added `docs` command to fetch documentation markdown from the Yamada UI docs site.

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -21,6 +21,12 @@ describe("buildUrl", () => {
       "https://yamada-ui.com/ja/docs/components/button.md",
     )
   })
+
+  test("should not double-append .md when path already ends with .md", () => {
+    expect(buildUrl("/docs/components/button.md", "en")).toBe(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+  })
 })
 
 describe("fetchDoc", () => {

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -1,5 +1,11 @@
 import fetch from "node-fetch"
-import { buildUrl, fetchDoc, trimToSection } from "./fetch-doc"
+import {
+  buildUrl,
+  fetchDoc,
+  findHeadingIndex,
+  trimToSection,
+  trimToSectionByIndex,
+} from "./fetch-doc"
 
 vi.mock("node-fetch", () => ({ default: vi.fn() }))
 
@@ -87,5 +93,100 @@ describe("trimToSection", () => {
     expect(() => trimToSection(content, "nonexistent")).toThrow(
       "Section not found:",
     )
+  })
+})
+
+describe("findHeadingIndex", () => {
+  const content = [
+    "# Button",
+    "",
+    "Intro.",
+    "",
+    "## Usage",
+    "",
+    "Details.",
+    "",
+    "### SubUsage",
+    "",
+    "Sub details.",
+    "",
+    "## Props",
+    "",
+    "Props content.",
+  ].join("\n")
+
+  test("should return 0 for the first heading", () => {
+    expect(findHeadingIndex(content, "button")).toBe(0)
+  })
+
+  test("should return index by heading order", () => {
+    expect(findHeadingIndex(content, "props")).toBe(3)
+  })
+
+  test("should return -1 for non-existent heading", () => {
+    expect(findHeadingIndex(content, "nonexistent")).toBe(-1)
+  })
+
+  test("should strip hash prefix before matching", () => {
+    expect(findHeadingIndex(content, "#usage")).toBe(1)
+  })
+
+  test("should match case-insensitively", () => {
+    expect(findHeadingIndex(content, "USAGE")).toBe(1)
+  })
+})
+
+describe("trimToSectionByIndex", () => {
+  const content = [
+    "# Button",
+    "",
+    "Intro.",
+    "",
+    "## Usage",
+    "",
+    "Usage content.",
+    "",
+    "## Props",
+    "",
+    "Props content.",
+  ].join("\n")
+
+  test("should return section by heading index", () => {
+    const result = trimToSectionByIndex(content, 1, "usage")
+
+    expect(result).toMatch(/^## Usage/)
+    expect(result).toContain("Usage content.")
+    expect(result).not.toContain("Intro.")
+    expect(result).not.toContain("Props content.")
+  })
+
+  test("should throw when heading index is out of range", () => {
+    expect(() => trimToSectionByIndex(content, 99, "nonexistent")).toThrow(
+      "Section not found:",
+    )
+  })
+
+  test("should include nested subheadings", () => {
+    const nestedContent = [
+      "# Button",
+      "",
+      "## Usage",
+      "",
+      "Usage content.",
+      "",
+      "### SubUsage",
+      "",
+      "Sub content.",
+      "",
+      "## Props",
+      "",
+      "Props content.",
+    ].join("\n")
+
+    const result = trimToSectionByIndex(nestedContent, 1, "usage")
+
+    expect(result).toContain("Usage content.")
+    expect(result).toContain("Sub content.")
+    expect(result).not.toContain("Props content.")
   })
 })

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -11,11 +11,12 @@ import {
 vi.mock("node-fetch", () => ({ default: vi.fn() }))
 
 const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
 
 vi.mock("node:fs", () => ({
   mkdirSync: vi.fn(),
   readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
-  writeFileSync: vi.fn(),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
 }))
 
 const mockFetch = vi.mocked(fetch)
@@ -74,6 +75,7 @@ describe("fetchDoc", () => {
   beforeEach(() => {
     mockFetch.mockReset()
     mockReadFileSync.mockReset()
+    mockWriteFileSync.mockReset()
     mockReadFileSync.mockImplementation(() => {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
     })
@@ -149,6 +151,22 @@ describe("fetchDoc", () => {
       "https://yamada-ui.com/docs/components/new-page.md",
       expect.anything(),
     )
+  })
+
+  test("should return content even when writing cache fails", async () => {
+    mockWriteFileSync.mockImplementation(() => {
+      throw new Error("EROFS")
+    })
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("# Button\n\nContent here."),
+    } as any)
+
+    const result = await fetchDoc(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+
+    expect(result).toBe("# Button\n\nContent here.")
   })
 
   test("should use proxy agent when https_proxy env variable is set", async () => {

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch"
 import {
   buildUrl,
+  extractSections,
   fetchDoc,
   findHeadingIndex,
   trimToSection,
@@ -55,6 +56,30 @@ describe("fetchDoc", () => {
     await expect(
       fetchDoc("https://yamada-ui.com/docs/components/nonexistent.md"),
     ).rejects.toThrow("Documentation not found:")
+  })
+})
+
+describe("extractSections", () => {
+  test("should return only heading lines joined by newlines", () => {
+    const content = [
+      "# Button",
+      "",
+      "Introduction text.",
+      "",
+      "## Usage",
+      "",
+      "Usage content.",
+      "",
+      "### Variants",
+      "",
+      "Variants content.",
+    ].join("\n")
+
+    expect(extractSections(content)).toBe("# Button\n## Usage\n### Variants")
+  })
+
+  test("should return empty string when no headings exist", () => {
+    expect(extractSections("No headings here.\nJust plain text.")).toBe("")
   })
 })
 

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -72,7 +72,7 @@ describe("trimToSection", () => {
 
     expect(result).toMatch(/^## Usage/)
     expect(result).not.toContain("Introduction text.")
-    expect(result).toContain("Props content here.")
+    expect(result).not.toContain("Props content here.")
   })
 
   test("should match case-insensitively", () => {

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -1,0 +1,85 @@
+import fetch from "node-fetch"
+import { buildUrl, fetchDoc, trimToSection } from "./fetch-doc"
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }))
+
+const mockFetch = vi.mocked(fetch)
+
+describe("buildUrl", () => {
+  test("should return llms.txt url when no path given", () => {
+    expect(buildUrl(undefined, "en")).toBe("https://yamada-ui.com/llms.txt")
+  })
+
+  test("should return english doc url", () => {
+    expect(buildUrl("/docs/components/button", "en")).toBe(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+  })
+
+  test("should return japanese doc url", () => {
+    expect(buildUrl("/docs/components/button", "ja")).toBe(
+      "https://yamada-ui.com/ja/docs/components/button.md",
+    )
+  })
+})
+
+describe("fetchDoc", () => {
+  test("should return text content on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("# Button\n\nContent here."),
+    } as any)
+
+    const result = await fetchDoc(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+
+    expect(result).toBe("# Button\n\nContent here.")
+  })
+
+  test("should throw when response is not ok", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 } as any)
+
+    await expect(
+      fetchDoc("https://yamada-ui.com/docs/components/nonexistent.md"),
+    ).rejects.toThrow("Documentation not found: /docs/components/nonexistent")
+  })
+})
+
+describe("trimToSection", () => {
+  const content = [
+    "# Button",
+    "",
+    "Introduction text.",
+    "",
+    "## Usage",
+    "",
+    "Usage content here.",
+    "",
+    "## Props",
+    "",
+    "Props content here.",
+  ].join("\n")
+
+  test("should trim content to start from matched heading", () => {
+    const result = trimToSection(content, "usage")
+
+    expect(result).toMatch(/^## Usage/)
+    expect(result).not.toContain("Introduction text.")
+    expect(result).toContain("Props content here.")
+  })
+
+  test("should match case-insensitively", () => {
+    expect(trimToSection(content, "Usage")).toMatch(/^## Usage/)
+  })
+
+  test("should strip hash prefix before matching", () => {
+    expect(trimToSection(content, "#usage")).toMatch(/^## Usage/)
+  })
+
+  test("should throw when section is not found", () => {
+    expect(() => trimToSection(content, "nonexistent")).toThrow(
+      "Section not found: #nonexistent",
+    )
+  })
+})

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -177,7 +177,7 @@ describe("fetchDoc", () => {
 })
 
 describe("extractSections", () => {
-  test("should return only heading lines joined by newlines", () => {
+  test("should return heading lines with trailing newline", () => {
     const content = [
       "# Button",
       "",
@@ -192,11 +192,17 @@ describe("extractSections", () => {
       "Variants content.",
     ].join("\n")
 
-    expect(extractSections(content)).toBe("# Button\n## Usage\n### Variants")
+    expect(extractSections(content)).toBe("# Button\n## Usage\n### Variants\n")
   })
 
   test("should return empty string when no headings exist", () => {
     expect(extractSections("No headings here.\nJust plain text.")).toBe("")
+  })
+
+  test("should match japanese headings", () => {
+    const content = "# ボタン\n\n## 使い方\n\nContent.\n"
+
+    expect(extractSections(content)).toBe("# ボタン\n## 使い方\n")
   })
 })
 
@@ -275,6 +281,12 @@ describe("findHeadingIndex", () => {
 
   test("should match case-insensitively", () => {
     expect(findHeadingIndex(content, "USAGE")).toBe(1)
+  })
+
+  test("should match japanese headings", () => {
+    const jaContent = "# ボタン\n\n## 使い方\n\nContent.\n"
+
+    expect(findHeadingIndex(jaContent, "使い方")).toBe(1)
   })
 })
 

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -17,46 +17,44 @@ describe("buildUrl", () => {
     expect(buildUrl(undefined, "en")).toBe("https://yamada-ui.com/llms.txt")
   })
 
-  test("should return english doc url", () => {
-    expect(buildUrl("/docs/components/button", "en")).toBe(
+  test.each([
+    [
+      "/docs/components/button",
+      "en",
       "https://yamada-ui.com/docs/components/button.md",
-    )
-  })
-
-  test("should return japanese doc url", () => {
-    expect(buildUrl("/docs/components/button", "ja")).toBe(
+    ],
+    [
+      "/docs/components/button",
+      "ja",
       "https://yamada-ui.com/ja/docs/components/button.md",
-    )
-  })
-
-  test("should not double-append .md when path already ends with .md", () => {
-    expect(buildUrl("/docs/components/button.md", "en")).toBe(
+    ],
+    [
+      "/docs/components/button.md",
+      "en",
       "https://yamada-ui.com/docs/components/button.md",
-    )
-  })
-
-  test("should add leading slash when path does not start with /", () => {
-    expect(buildUrl("docs/components/button", "en")).toBe(
+    ],
+    [
+      "docs/components/button",
+      "en",
       "https://yamada-ui.com/docs/components/button.md",
-    )
-  })
-
-  test("should prepend /docs when path starts with / but not /docs", () => {
-    expect(buildUrl("/components/button", "en")).toBe(
+    ],
+    [
+      "/components/button",
+      "en",
       "https://yamada-ui.com/docs/components/button.md",
-    )
-  })
-
-  test("should prepend /docs when path has no leading slash and no docs prefix", () => {
-    expect(buildUrl("components/button", "en")).toBe(
+    ],
+    [
+      "components/button",
+      "en",
       "https://yamada-ui.com/docs/components/button.md",
-    )
-  })
-
-  test("should prepend /docs for japanese doc when path omits /docs", () => {
-    expect(buildUrl("/components/button", "ja")).toBe(
+    ],
+    [
+      "/components/button",
+      "ja",
       "https://yamada-ui.com/ja/docs/components/button.md",
-    )
+    ],
+  ])("buildUrl(%s, %s) → %s", (path, lang, expected) => {
+    expect(buildUrl(path, lang)).toBe(expected)
   })
 })
 

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -10,7 +10,19 @@ import {
 
 vi.mock("node-fetch", () => ({ default: vi.fn() }))
 
+const mockReadFileSync = vi.fn()
+
+vi.mock("node:fs", () => ({
+  mkdirSync: vi.fn(),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  writeFileSync: vi.fn(),
+}))
+
 const mockFetch = vi.mocked(fetch)
+
+function makeCacheEntry(content: string, timestamp: number): string {
+  return JSON.stringify({ content, timestamp })
+}
 
 describe("buildUrl", () => {
   test("should return llms.txt url when no path given", () => {
@@ -59,6 +71,14 @@ describe("buildUrl", () => {
 })
 
 describe("fetchDoc", () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockReadFileSync.mockReset()
+    mockReadFileSync.mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    })
+  })
+
   test("should return text content on success", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
@@ -78,6 +98,57 @@ describe("fetchDoc", () => {
     await expect(
       fetchDoc("https://yamada-ui.com/docs/components/nonexistent.md"),
     ).rejects.toThrow("Documentation not found:")
+  })
+
+  test("should return cached content without fetching when cache is fresh", async () => {
+    mockReadFileSync.mockReturnValue(
+      makeCacheEntry("# Cached Content\n", Date.now()),
+    )
+
+    const result = await fetchDoc(
+      "https://yamada-ui.com/docs/components/cached.md",
+    )
+
+    expect(result).toBe("# Cached Content\n")
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  test("should fetch and update cache when cache is expired", async () => {
+    const expired = Date.now() - 11 * 60 * 1000
+
+    mockReadFileSync.mockReturnValue(makeCacheEntry("# Old Content\n", expired))
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("# Fresh Content\n"),
+    } as any)
+
+    const result = await fetchDoc(
+      "https://yamada-ui.com/docs/components/expired.md",
+    )
+
+    expect(result).toBe("# Fresh Content\n")
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/docs/components/expired.md",
+      expect.anything(),
+    )
+  })
+
+  test("should fetch normally when no cache file exists", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("# New Page\n"),
+    } as any)
+
+    const result = await fetchDoc(
+      "https://yamada-ui.com/docs/components/new-page.md",
+    )
+
+    expect(result).toBe("# New Page\n")
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/docs/components/new-page.md",
+      expect.anything(),
+    )
   })
 
   test("should use proxy agent when https_proxy env variable is set", async () => {

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -48,7 +48,7 @@ describe("fetchDoc", () => {
 
     await expect(
       fetchDoc("https://yamada-ui.com/docs/components/nonexistent.md"),
-    ).rejects.toThrow("Documentation not found: /docs/components/nonexistent")
+    ).rejects.toThrow("Documentation not found:")
   })
 })
 
@@ -85,7 +85,7 @@ describe("trimToSection", () => {
 
   test("should throw when section is not found", () => {
     expect(() => trimToSection(content, "nonexistent")).toThrow(
-      "Section not found: #nonexistent",
+      "Section not found:",
     )
   })
 })

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -34,6 +34,12 @@ describe("buildUrl", () => {
       "https://yamada-ui.com/docs/components/button.md",
     )
   })
+
+  test("should add leading slash when path does not start with /", () => {
+    expect(buildUrl("docs/components/button", "en")).toBe(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+  })
 })
 
 describe("fetchDoc", () => {
@@ -56,6 +62,30 @@ describe("fetchDoc", () => {
     await expect(
       fetchDoc("https://yamada-ui.com/docs/components/nonexistent.md"),
     ).rejects.toThrow("Documentation not found:")
+  })
+
+  test("should use proxy agent when https_proxy env variable is set", async () => {
+    vi.stubEnv("https_proxy", "http://proxy.example.com:8080")
+    vi.resetModules()
+
+    const mockFetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("content"),
+    })
+
+    vi.doMock("node-fetch", () => ({ default: mockFetchFn }))
+
+    const { fetchDoc: freshFetchDoc } = await import("./fetch-doc")
+    const result = await freshFetchDoc("https://yamada-ui.com/llms.txt")
+
+    expect(result).toBe("content")
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      "https://yamada-ui.com/llms.txt",
+      expect.objectContaining({ agent: expect.anything() }),
+    )
+
+    vi.unstubAllEnvs()
+    vi.resetModules()
   })
 })
 

--- a/packages/cli/src/commands/docs/fetch-doc.test.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.test.ts
@@ -40,6 +40,24 @@ describe("buildUrl", () => {
       "https://yamada-ui.com/docs/components/button.md",
     )
   })
+
+  test("should prepend /docs when path starts with / but not /docs", () => {
+    expect(buildUrl("/components/button", "en")).toBe(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+  })
+
+  test("should prepend /docs when path has no leading slash and no docs prefix", () => {
+    expect(buildUrl("components/button", "en")).toBe(
+      "https://yamada-ui.com/docs/components/button.md",
+    )
+  })
+
+  test("should prepend /docs for japanese doc when path omits /docs", () => {
+    expect(buildUrl("/components/button", "ja")).toBe(
+      "https://yamada-ui.com/ja/docs/components/button.md",
+    )
+  })
 })
 
 describe("fetchDoc", () => {

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -90,6 +90,13 @@ export function trimToSection(content: string, hash: string): string {
   throw new Error(`Section not found: ${c.yellow(`#${slug}`)}`)
 }
 
+export function extractSections(content: string): string {
+  return content
+    .split("\n")
+    .filter((line) => /^#{1,6}\s+/.test(line))
+    .join("\n")
+}
+
 export function trimToSectionByIndex(
   content: string,
   headingIndex: number,

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -9,8 +9,9 @@ export function buildUrl(path: string | undefined, lang: string): string {
   if (!path) return "https://yamada-ui.com/llms.txt"
 
   const prefix = lang === "ja" ? "/ja" : ""
+  const normalized = path.startsWith("/") ? path : `/${path}`
 
-  return `https://yamada-ui.com${prefix}${path.replace(/\.md$/, "")}.md`
+  return `https://yamada-ui.com${prefix}${normalized.replace(/\.md$/, "")}.md`
 }
 
 export async function fetchDoc(url: string): Promise<string> {

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -1,17 +1,18 @@
 import { HttpsProxyAgent } from "https-proxy-agent"
 import fetch from "node-fetch"
 import c from "picocolors"
+import { DOCS_BASE_URL } from "../../constant"
 
 const proxyUrl = process.env.https_proxy ?? process.env.HTTPS_PROXY
 const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined
 
 export function buildUrl(path: string | undefined, lang: string): string {
-  if (!path) return "https://yamada-ui.com/llms.txt"
+  if (!path) return `${DOCS_BASE_URL}/llms.txt`
 
   const prefix = lang === "ja" ? "/ja" : ""
   const normalized = path.startsWith("/") ? path : `/${path}`
 
-  return `https://yamada-ui.com${prefix}${normalized.replace(/\.md$/, "")}.md`
+  return `${DOCS_BASE_URL}${prefix}${normalized.replace(/\.md$/, "")}.md`
 }
 
 export async function fetchDoc(url: string): Promise<string> {

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -33,6 +33,27 @@ function headingToSlug(text: string): string {
     .replace(/\s+/g, "-")
 }
 
+function extractSection(lines: string[], startIndex: number): string {
+  const headingRegex = /^#{1,6}\s+(.+)$/
+  const level = (lines[startIndex]!.match(/^(#{1,6})/)?.[1] ?? "").length
+  let end = lines.length
+
+  for (let j = startIndex + 1; j < lines.length; j++) {
+    const nextMatch = lines[j]!.match(headingRegex)
+
+    if (nextMatch) {
+      const nextLevel = (lines[j]!.match(/^(#{1,6})/)?.[1] ?? "").length
+
+      if (nextLevel <= level) {
+        end = j
+        break
+      }
+    }
+  }
+
+  return lines.slice(startIndex, end).join("\n")
+}
+
 export function trimToSection(content: string, hash: string): string {
   const slug = hash.startsWith("#") ? hash.slice(1) : hash
   const lines = content.split("\n")
@@ -42,7 +63,7 @@ export function trimToSection(content: string, hash: string): string {
     const match = lines[i]!.match(headingRegex)
 
     if (match && headingToSlug(match[1]!) === headingToSlug(slug)) {
-      return lines.slice(i).join("\n")
+      return extractSection(lines, i)
     }
   }
 

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -9,7 +9,7 @@ export function buildUrl(path: string | undefined, lang: string): string {
 
   const prefix = lang === "ja" ? "/ja" : ""
 
-  return `https://yamada-ui.com${prefix}${path}.md`
+  return `https://yamada-ui.com${prefix}${path.replace(/\.md$/, "")}.md`
 }
 
 export async function fetchDoc(url: string): Promise<string> {

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -1,10 +1,47 @@
 import { HttpsProxyAgent } from "https-proxy-agent"
 import fetch from "node-fetch"
+import { createHash } from "node:crypto"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import c from "picocolors"
 import { DOCS_BASE_URL } from "../../constant"
 
 const proxyUrl = process.env.https_proxy ?? process.env.HTTPS_PROXY
 const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined
+
+const CACHE_DIR = join(tmpdir(), "yamada-ui", "docs")
+const CACHE_TTL = 10 * 60 * 1000
+
+interface CacheEntry {
+  content: string
+  timestamp: number
+}
+
+function getCachePath(url: string): string {
+  const hash = createHash("md5").update(url).digest("hex")
+  return join(CACHE_DIR, hash)
+}
+
+function readCache(url: string): string | undefined {
+  try {
+    const raw = readFileSync(getCachePath(url), "utf-8")
+    const entry = JSON.parse(raw) as CacheEntry
+    if (Date.now() - entry.timestamp < CACHE_TTL) return entry.content
+  } catch {
+    return undefined
+  }
+}
+
+function writeCache(url: string, content: string): void {
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true })
+    const entry: CacheEntry = { content, timestamp: Date.now() }
+    writeFileSync(getCachePath(url), JSON.stringify(entry))
+  } catch {
+    return
+  }
+}
 
 export function buildUrl(path: string | undefined, lang: string): string {
   if (!path) return `${DOCS_BASE_URL}/llms.txt`
@@ -20,6 +57,9 @@ export function buildUrl(path: string | undefined, lang: string): string {
 }
 
 export async function fetchDoc(url: string): Promise<string> {
+  const cached = readCache(url)
+  if (cached !== undefined) return cached
+
   const res = await fetch(url, { agent })
 
   if (!res.ok) {
@@ -28,7 +68,9 @@ export async function fetchDoc(url: string): Promise<string> {
     throw new Error(`Documentation not found: ${c.yellow(docPath)}`)
   }
 
-  return res.text()
+  const content = await res.text()
+  writeCache(url, content)
+  return content
 }
 
 function headingToSlug(text: string): string {

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -54,6 +54,25 @@ function extractSection(lines: string[], startIndex: number): string {
   return lines.slice(startIndex, end).join("\n")
 }
 
+export function findHeadingIndex(content: string, hash: string): number {
+  const slug = hash.startsWith("#") ? hash.slice(1) : hash
+  const lines = content.split("\n")
+  const headingRegex = /^#{1,6}\s+(.+)$/
+  let headingIndex = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i]!.match(headingRegex)
+
+    if (match) {
+      if (headingToSlug(match[1]!) === headingToSlug(slug)) return headingIndex
+
+      headingIndex++
+    }
+  }
+
+  return -1
+}
+
 export function trimToSection(content: string, hash: string): string {
   const slug = hash.startsWith("#") ? hash.slice(1) : hash
   const lines = content.split("\n")
@@ -68,4 +87,26 @@ export function trimToSection(content: string, hash: string): string {
   }
 
   throw new Error(`Section not found: ${c.yellow(`#${slug}`)}`)
+}
+
+export function trimToSectionByIndex(
+  content: string,
+  headingIndex: number,
+  hash: string,
+): string {
+  const lines = content.split("\n")
+  const headingRegex = /^#{1,6}\s+(.+)$/
+  let currentIndex = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i]!.match(headingRegex)
+
+    if (match) {
+      if (currentIndex === headingIndex) return extractSection(lines, i)
+
+      currentIndex++
+    }
+  }
+
+  throw new Error(`Section not found: ${c.yellow(`#${hash}`)}`)
 }

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -1,5 +1,6 @@
 import { HttpsProxyAgent } from "https-proxy-agent"
 import fetch from "node-fetch"
+import c from "picocolors"
 
 const proxyUrl = process.env.https_proxy ?? process.env.HTTPS_PROXY
 const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined
@@ -18,7 +19,7 @@ export async function fetchDoc(url: string): Promise<string> {
   if (!res.ok) {
     const docPath = new URL(url).pathname.replace(/\.md$/, "")
 
-    throw new Error(`Documentation not found: ${docPath}`)
+    throw new Error(`Documentation not found: ${c.yellow(docPath)}`)
   }
 
   return res.text()
@@ -45,5 +46,5 @@ export function trimToSection(content: string, hash: string): string {
     }
   }
 
-  throw new Error(`Section not found: #${slug}`)
+  throw new Error(`Section not found: ${c.yellow(`#${slug}`)}`)
 }

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -13,6 +13,8 @@ const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined
 const CACHE_DIR = join(tmpdir(), "yamada-ui", "docs")
 const CACHE_TTL = 10 * 60 * 1000
 
+const HEADING_REGEX = /^#{1,6}\s+(.+)$/
+
 interface CacheEntry {
   content: string
   timestamp: number
@@ -76,18 +78,17 @@ export async function fetchDoc(url: string): Promise<string> {
 function headingToSlug(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[^\w\s-]/g, "")
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
     .trim()
     .replace(/\s+/g, "-")
 }
 
 function extractSection(lines: string[], startIndex: number): string {
-  const headingRegex = /^#{1,6}\s+(.+)$/
   const level = (lines[startIndex]!.match(/^(#{1,6})/)?.[1] ?? "").length
   let end = lines.length
 
   for (let j = startIndex + 1; j < lines.length; j++) {
-    const nextMatch = lines[j]!.match(headingRegex)
+    const nextMatch = lines[j]!.match(HEADING_REGEX)
 
     if (nextMatch) {
       const nextLevel = (lines[j]!.match(/^(#{1,6})/)?.[1] ?? "").length
@@ -105,11 +106,10 @@ function extractSection(lines: string[], startIndex: number): string {
 export function findHeadingIndex(content: string, hash: string): number {
   const slug = hash.startsWith("#") ? hash.slice(1) : hash
   const lines = content.split("\n")
-  const headingRegex = /^#{1,6}\s+(.+)$/
   let headingIndex = 0
 
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i]!.match(headingRegex)
+    const match = lines[i]!.match(HEADING_REGEX)
 
     if (match) {
       if (headingToSlug(match[1]!) === headingToSlug(slug)) return headingIndex
@@ -124,10 +124,9 @@ export function findHeadingIndex(content: string, hash: string): number {
 export function trimToSection(content: string, hash: string): string {
   const slug = hash.startsWith("#") ? hash.slice(1) : hash
   const lines = content.split("\n")
-  const headingRegex = /^#{1,6}\s+(.+)$/
 
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i]!.match(headingRegex)
+    const match = lines[i]!.match(HEADING_REGEX)
 
     if (match && headingToSlug(match[1]!) === headingToSlug(slug)) {
       return extractSection(lines, i)
@@ -138,10 +137,13 @@ export function trimToSection(content: string, hash: string): string {
 }
 
 export function extractSections(content: string): string {
-  return content
+  const headings = content
     .split("\n")
-    .filter((line) => /^#{1,6}\s+/.test(line))
-    .join("\n")
+    .filter((line) => HEADING_REGEX.test(line))
+
+  if (headings.length === 0) return ""
+
+  return headings.join("\n") + "\n"
 }
 
 export function trimToSectionByIndex(
@@ -150,11 +152,10 @@ export function trimToSectionByIndex(
   hash: string,
 ): string {
   const lines = content.split("\n")
-  const headingRegex = /^#{1,6}\s+(.+)$/
   let currentIndex = 0
 
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i]!.match(headingRegex)
+    const match = lines[i]!.match(HEADING_REGEX)
 
     if (match) {
       if (currentIndex === headingIndex) return extractSection(lines, i)

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -10,7 +10,11 @@ export function buildUrl(path: string | undefined, lang: string): string {
   if (!path) return `${DOCS_BASE_URL}/llms.txt`
 
   const prefix = lang === "ja" ? "/ja" : ""
-  const normalized = path.startsWith("/") ? path : `/${path}`
+  let normalized = path.startsWith("/") ? path : `/${path}`
+
+  if (!normalized.startsWith("/docs")) {
+    normalized = `/docs${normalized}`
+  }
 
   return `${DOCS_BASE_URL}${prefix}${normalized.replace(/\.md$/, "")}.md`
 }

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -1,9 +1,8 @@
 import { HttpsProxyAgent } from "https-proxy-agent"
 import fetch from "node-fetch"
 
-const agent = process.env.https_proxy
-  ? new HttpsProxyAgent(process.env.https_proxy)
-  : undefined
+const proxyUrl = process.env.https_proxy ?? process.env.HTTPS_PROXY
+const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined
 
 export function buildUrl(path: string | undefined, lang: string): string {
   if (!path) return "https://yamada-ui.com/llms.txt"

--- a/packages/cli/src/commands/docs/fetch-doc.ts
+++ b/packages/cli/src/commands/docs/fetch-doc.ts
@@ -1,0 +1,50 @@
+import { HttpsProxyAgent } from "https-proxy-agent"
+import fetch from "node-fetch"
+
+const agent = process.env.https_proxy
+  ? new HttpsProxyAgent(process.env.https_proxy)
+  : undefined
+
+export function buildUrl(path: string | undefined, lang: string): string {
+  if (!path) return "https://yamada-ui.com/llms.txt"
+
+  const prefix = lang === "ja" ? "/ja" : ""
+
+  return `https://yamada-ui.com${prefix}${path}.md`
+}
+
+export async function fetchDoc(url: string): Promise<string> {
+  const res = await fetch(url, { agent })
+
+  if (!res.ok) {
+    const docPath = new URL(url).pathname.replace(/\.md$/, "")
+
+    throw new Error(`Documentation not found: ${docPath}`)
+  }
+
+  return res.text()
+}
+
+function headingToSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+}
+
+export function trimToSection(content: string, hash: string): string {
+  const slug = hash.startsWith("#") ? hash.slice(1) : hash
+  const lines = content.split("\n")
+  const headingRegex = /^#{1,6}\s+(.+)$/
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i]!.match(headingRegex)
+
+    if (match && headingToSlug(match[1]!) === headingToSlug(slug)) {
+      return lines.slice(i).join("\n")
+    }
+  }
+
+  throw new Error(`Section not found: #${slug}`)
+}

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -244,7 +244,7 @@ describe("docs", () => {
       from: "user",
     })
 
-    expect(stdoutSpy).toHaveBeenCalledWith("# Button\n## Usage\n### Variants")
+    expect(stdoutSpy).toHaveBeenCalledWith("# Button\n## Usage\n### Variants\n")
   })
 
   test("should read path from stdin when no argument given in non-TTY environment", async () => {
@@ -342,5 +342,35 @@ describe("docs", () => {
     await docs.parseAsync(["/docs/components/button"], { from: "user" })
 
     expect(spinner.fail).toHaveBeenCalledWith("An unknown error occurred")
+  })
+
+  test("should not call spinner.succeed when section is not found", async () => {
+    mockResponse("# Button\n\n## Usage\n\nContent.\n")
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["/docs/components/button#nonexistent"], {
+      from: "user",
+    })
+
+    expect(spinner.succeed).not.toHaveBeenCalled()
+    expect(spinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("Section not found:"),
+    )
+  })
+
+  test("should auto-detect japanese from /ja URL prefix without --lang ja", async () => {
+    mockResponse("# ボタン\n")
+    setTTY(true)
+
+    await docs.parseAsync(["https://yamada-ui.com/ja/docs/components/button"], {
+      from: "user",
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/ja/docs/components/button.md",
+      expect.anything(),
+    )
   })
 })

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -128,6 +128,21 @@ describe("docs", () => {
     expect(spinner.succeed).toHaveBeenCalledWith("Fetched documentation")
   })
 
+  test("should strip language prefix from full URL pathname", async () => {
+    mockResponse("# Button\n")
+    setTTY(true)
+
+    await docs.parseAsync(
+      ["https://yamada-ui.com/ja/docs/components/button", "--lang", "ja"],
+      { from: "user" },
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/ja/docs/components/button.md",
+      expect.anything(),
+    )
+  })
+
   test("should show error when full URL is not from yamada-ui.com", async () => {
     setTTY(true)
 

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -70,35 +70,15 @@ describe("docs", () => {
     expect(stdoutSpy).toHaveBeenCalledWith("# Index\n")
   })
 
-  test("should fetch english doc by path", async () => {
+  test.each([
+    ["/docs/components/button"],
+    ["/components/button"],
+    ["components/button"],
+  ])("should fetch english doc for path %s", async (path) => {
     mockResponse("# Button\n")
     setTTY(true)
 
-    await docs.parseAsync(["/docs/components/button"], { from: "user" })
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://yamada-ui.com/docs/components/button.md",
-      expect.anything(),
-    )
-  })
-
-  test("should fetch doc when path omits /docs prefix", async () => {
-    mockResponse("# Button\n")
-    setTTY(true)
-
-    await docs.parseAsync(["/components/button"], { from: "user" })
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://yamada-ui.com/docs/components/button.md",
-      expect.anything(),
-    )
-  })
-
-  test("should fetch doc when path has no leading slash or /docs prefix", async () => {
-    mockResponse("# Button\n")
-    setTTY(true)
-
-    await docs.parseAsync(["components/button"], { from: "user" })
+    await docs.parseAsync([path], { from: "user" })
 
     expect(mockFetch).toHaveBeenCalledWith(
       "https://yamada-ui.com/docs/components/button.md",

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -23,15 +23,20 @@ function mockNotFound() {
 
 describe("docs", () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let exitSpy: ReturnType<typeof vi.spyOn>
   let isTTY: boolean | undefined
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
     isTTY = process.stdin.isTTY
   })
 
   afterEach(() => {
     stdoutSpy.mockRestore()
+    exitSpy.mockRestore()
     setTTY(isTTY ?? true)
   })
 
@@ -137,15 +142,28 @@ describe("docs", () => {
     )
   })
 
-  test("should show error when both stdin and argument provided", async () => {
+  test("should use path argument even in non-TTY environment", async () => {
+    mockResponse("# Button\n")
     setTTY(false)
-
-    const spinner = ora()
 
     await docs.parseAsync(["/docs/components/button"], { from: "user" })
 
-    expect(spinner.fail).toHaveBeenCalledWith(
-      "Cannot specify both a path argument and stdin input.",
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/docs/components/button.md",
+      expect.anything(),
     )
+  })
+
+  test("should output section headings when --sections flag is given", async () => {
+    mockResponse(
+      "# Button\n\nIntro.\n\n## Usage\n\nUsage text.\n\n### Variants\n\nVariants text.\n",
+    )
+    setTTY(true)
+
+    await docs.parseAsync(["/docs/components/button", "--sections"], {
+      from: "user",
+    })
+
+    expect(stdoutSpy).toHaveBeenCalledWith("# Button\n## Usage\n### Variants")
   })
 })

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -1,0 +1,149 @@
+import fetch from "node-fetch"
+import ora from "ora"
+import { docs } from "."
+
+function setTTY(value: boolean) {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value })
+}
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }))
+
+const mockFetch = vi.mocked(fetch)
+
+function mockResponse(text: string) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(text),
+  } as any)
+}
+
+function mockNotFound() {
+  mockFetch.mockResolvedValue({ ok: false, status: 404 } as any)
+}
+
+describe("docs", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let isTTY: boolean | undefined
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    isTTY = process.stdin.isTTY
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    setTTY(isTTY ?? true)
+  })
+
+  test("should fetch llms.txt when no argument given", async () => {
+    mockResponse("# Index\n")
+    setTTY(true)
+
+    await docs.parseAsync([], { from: "user" })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/llms.txt",
+      expect.anything(),
+    )
+    expect(stdoutSpy).toHaveBeenCalledWith("# Index\n")
+  })
+
+  test("should fetch english doc by path", async () => {
+    mockResponse("# Button\n")
+    setTTY(true)
+
+    await docs.parseAsync(["/docs/components/button"], { from: "user" })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/docs/components/button.md",
+      expect.anything(),
+    )
+  })
+
+  test("should fetch japanese doc with --lang ja", async () => {
+    mockResponse("# Button\n")
+    setTTY(true)
+
+    await docs.parseAsync(["/docs/components/button", "--lang", "ja"], {
+      from: "user",
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/ja/docs/components/button.md",
+      expect.anything(),
+    )
+  })
+
+  test("should output from matched section when hash fragment given", async () => {
+    mockResponse("# Button\n\nIntro.\n\n## Usage\n\nUsage text.\n")
+    setTTY(true)
+
+    await docs.parseAsync(["/docs/components/button#usage"], { from: "user" })
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringMatching(/^## Usage/))
+  })
+
+  test("should show error when path not found", async () => {
+    mockNotFound()
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["/docs/components/nonexistent"], { from: "user" })
+
+    expect(spinner.fail).toHaveBeenCalledWith(
+      "Documentation not found: /docs/components/nonexistent",
+    )
+  })
+
+  test("should show error when hash section not found", async () => {
+    mockResponse("# Button\n\n## Usage\n\nContent.\n")
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["/docs/components/button#nonexistent"], {
+      from: "user",
+    })
+
+    expect(spinner.fail).toHaveBeenCalledWith("Section not found: #nonexistent")
+  })
+
+  test("should show spinner while fetching documentation", async () => {
+    mockResponse("# Button\n")
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["/docs/components/button"], { from: "user" })
+
+    expect(spinner.start).toHaveBeenCalledWith("Fetching documentation")
+    expect(spinner.succeed).toHaveBeenCalledWith("Fetched documentation")
+  })
+
+  test("should show error when full URL is not from yamada-ui.com", async () => {
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["https://example.com/docs/components/button"], {
+      from: "user",
+    })
+
+    expect(spinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("example.com"),
+    )
+  })
+
+  test("should show error when both stdin and argument provided", async () => {
+    setTTY(false)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["/docs/components/button"], { from: "user" })
+
+    expect(spinner.fail).toHaveBeenCalledWith(
+      "Cannot specify both a path argument and stdin input.",
+    )
+  })
+})

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -82,6 +82,30 @@ describe("docs", () => {
     )
   })
 
+  test("should fetch doc when path omits /docs prefix", async () => {
+    mockResponse("# Button\n")
+    setTTY(true)
+
+    await docs.parseAsync(["/components/button"], { from: "user" })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/docs/components/button.md",
+      expect.anything(),
+    )
+  })
+
+  test("should fetch doc when path has no leading slash or /docs prefix", async () => {
+    mockResponse("# Button\n")
+    setTTY(true)
+
+    await docs.parseAsync(["components/button"], { from: "user" })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/docs/components/button.md",
+      expect.anything(),
+    )
+  })
+
   test("should fetch japanese doc with --lang ja", async () => {
     mockResponse("# Button\n")
     setTTY(true)

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -3,6 +3,14 @@ import { Readable } from "node:stream"
 import ora from "ora"
 import { docs } from "."
 
+vi.mock("node:fs", () => ({
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn().mockImplementation(() => {
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+  }),
+  writeFileSync: vi.fn(),
+}))
+
 function setTTY(value: boolean) {
   Object.defineProperty(process.stdin, "isTTY", { configurable: true, value })
 }

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -88,6 +88,30 @@ describe("docs", () => {
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringMatching(/^## Usage/))
   })
 
+  test("should treat whitespace-only argument as no argument and fetch llms.txt", async () => {
+    mockResponse("# Index\n")
+    setTTY(true)
+
+    await docs.parseAsync(["   "], { from: "user" })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://yamada-ui.com/llms.txt",
+      expect.anything(),
+    )
+  })
+
+  test("should show error when hash given without a path", async () => {
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["#usage"], { from: "user" })
+
+    expect(spinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("A documentation path is required"),
+    )
+  })
+
   test("should show error when path not found", async () => {
     mockNotFound()
     setTTY(true)

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -1,9 +1,26 @@
 import fetch from "node-fetch"
+import { Readable } from "node:stream"
 import ora from "ora"
 import { docs } from "."
 
 function setTTY(value: boolean) {
   Object.defineProperty(process.stdin, "isTTY", { configurable: true, value })
+}
+
+function mockStdinStream(text: string): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "stdin")
+  const readable = Readable.from([Buffer.from(text)])
+
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: readable,
+  })
+
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(process, "stdin", descriptor)
+    }
+  }
 }
 
 vi.mock("node-fetch", () => ({ default: vi.fn() }))
@@ -167,6 +184,18 @@ describe("docs", () => {
     )
   })
 
+  test("should extract hash fragment from full URL", async () => {
+    mockResponse("# Button\n\n## Usage\n\nUsage text.\n")
+    setTTY(true)
+
+    await docs.parseAsync(
+      ["https://yamada-ui.com/docs/components/button#usage"],
+      { from: "user" },
+    )
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringMatching(/^## Usage/))
+  })
+
   test("should show error when full URL is not from yamada-ui.com", async () => {
     setTTY(true)
 
@@ -204,5 +233,102 @@ describe("docs", () => {
     })
 
     expect(stdoutSpy).toHaveBeenCalledWith("# Button\n## Usage\n### Variants")
+  })
+
+  test("should read path from stdin when no argument given in non-TTY environment", async () => {
+    const restore = mockStdinStream("/docs/components/button\n")
+
+    mockResponse("# Button\n")
+
+    try {
+      await docs.parseAsync([], { from: "user" })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://yamada-ui.com/docs/components/button.md",
+        expect.anything(),
+      )
+    } finally {
+      restore()
+    }
+  })
+
+  test("should fetch llms.txt when stdin provides only whitespace", async () => {
+    const restore = mockStdinStream("   \n")
+
+    mockResponse("# Index\n")
+
+    try {
+      await docs.parseAsync([], { from: "user" })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://yamada-ui.com/llms.txt",
+        expect.anything(),
+      )
+    } finally {
+      restore()
+    }
+  })
+
+  test("should trim ja section by en heading index when lang is ja and hash given", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            "# ボタン\n\n## 使い方\n\n使い方テキスト。\n\n## Props\n\nPropsテキスト。\n",
+          ),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            "# Button\n\n## Usage\n\nUsage text.\n\n## Props\n\nProps text.\n",
+          ),
+      } as any)
+
+    setTTY(true)
+
+    await docs.parseAsync(["/docs/components/button#usage", "--lang", "ja"], {
+      from: "user",
+    })
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringMatching(/^## 使い方/))
+  })
+
+  test("should show error when section hash is not found in en content for ja lang lookup", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () =>
+          Promise.resolve("# ボタン\n\n## 使い方\n\n使い方テキスト。\n"),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve("# Button\n\n## Usage\n\nUsage text.\n"),
+      } as any)
+
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(
+      ["/docs/components/button#nonexistent", "--lang", "ja"],
+      { from: "user" },
+    )
+
+    expect(spinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("Section not found:"),
+    )
+  })
+
+  test("should show generic error message when a non-Error value is thrown", async () => {
+    mockFetch.mockRejectedValue("unexpected string error")
+    setTTY(true)
+
+    const spinner = ora()
+
+    await docs.parseAsync(["/docs/components/button"], { from: "user" })
+
+    expect(spinner.fail).toHaveBeenCalledWith("An unknown error occurred")
   })
 })

--- a/packages/cli/src/commands/docs/index.test.ts
+++ b/packages/cli/src/commands/docs/index.test.ts
@@ -92,7 +92,7 @@ describe("docs", () => {
     await docs.parseAsync(["/docs/components/nonexistent"], { from: "user" })
 
     expect(spinner.fail).toHaveBeenCalledWith(
-      "Documentation not found: /docs/components/nonexistent",
+      expect.stringContaining("Documentation not found:"),
     )
   })
 
@@ -106,7 +106,9 @@ describe("docs", () => {
       from: "user",
     })
 
-    expect(spinner.fail).toHaveBeenCalledWith("Section not found: #nonexistent")
+    expect(spinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining("Section not found:"),
+    )
   })
 
   test("should show spinner while fetching documentation", async () => {

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -3,6 +3,7 @@ import ora from "ora"
 import c from "picocolors"
 import {
   buildUrl,
+  extractSections,
   fetchDoc,
   findHeadingIndex,
   trimToSection,
@@ -11,6 +12,7 @@ import {
 
 interface Options {
   lang: string
+  sections: boolean
 }
 
 async function readStdin(): Promise<string> {
@@ -57,13 +59,20 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
 
 export const docs = new Command("docs")
   .description("fetch documentation from yamada-ui.com.")
-  .argument("[path]", "documentation path (e.g. /docs/components/button).")
+  .argument(
+    "[path]",
+    "documentation path (e.g. /docs/components/button#disable).",
+  )
   .addOption(
     new Option("--lang <lang>", "language.")
       .choices(["en", "ja"])
       .default("en"),
   )
-  .action(async function (pathArg: string | undefined, { lang }: Options) {
+  .option("--sections", "list section headings instead of full content.")
+  .action(async function (
+    pathArg: string | undefined,
+    { lang, sections }: Options,
+  ) {
     const spinner = ora()
 
     try {
@@ -110,7 +119,7 @@ export const docs = new Command("docs")
         }
       }
 
-      process.stdout.write(content)
+      process.stdout.write(sections ? extractSections(content) : content)
     } catch (e) {
       if (e instanceof Error) {
         spinner.fail(e.message)

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -44,7 +44,7 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
 
     return {
       hash: url.hash ? url.hash.slice(1) : undefined,
-      path: url.pathname,
+      path: url.pathname.replace(/^\/(ja|en)(?=\/)/, ""),
     }
   }
 

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -102,30 +102,36 @@ export const docs = new Command("docs")
         )
       }
 
-      const url = buildUrl(docPath, lang)
+      const needsEnFallback = lang !== "en" && !!hash
 
       spinner.start("Fetching documentation")
 
-      let content = await fetchDoc(url)
+      const [content, enContent] = await Promise.all([
+        fetchDoc(buildUrl(docPath, lang)),
+        needsEnFallback
+          ? fetchDoc(buildUrl(docPath, "en"))
+          : Promise.resolve(undefined),
+      ])
 
       spinner.succeed("Fetched documentation")
 
+      let result = content
+
       if (hash) {
-        if (lang === "en") {
-          content = trimToSection(content, hash)
+        if (!needsEnFallback) {
+          result = trimToSection(content, hash)
         } else {
-          const enContent = await fetchDoc(buildUrl(docPath, "en"))
-          const idx = findHeadingIndex(enContent, hash)
+          const idx = findHeadingIndex(enContent!, hash)
 
           if (idx === -1) {
             throw new Error(`Section not found: ${c.yellow(`#${hash}`)}`)
           }
 
-          content = trimToSectionByIndex(content, idx, hash)
+          result = trimToSectionByIndex(content, idx, hash)
         }
       }
 
-      process.stdout.write(sections ? extractSections(content) : content)
+      process.stdout.write(sections ? extractSections(result) : result)
     } catch (e) {
       if (e instanceof Error) {
         spinner.fail(e.message)

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from "commander"
 import ora from "ora"
 import c from "picocolors"
+import { DOCS_BASE_URL } from "../../constant"
 import {
   buildUrl,
   extractSections,
@@ -36,9 +37,11 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
   if (input.startsWith("http://") || input.startsWith("https://")) {
     const url = new URL(input)
 
-    if (url.hostname !== "yamada-ui.com") {
+    const docsHostname = new URL(DOCS_BASE_URL).hostname
+
+    if (url.hostname !== docsHostname) {
       throw new Error(
-        `Invalid URL: only ${c.cyan("yamada-ui.com")} URLs are supported, got ${c.yellow(url.hostname)}`,
+        `Invalid URL: only ${c.cyan(docsHostname)} URLs are supported, got ${c.yellow(url.hostname)}`,
       )
     }
 

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -20,7 +20,14 @@ async function readStdin(): Promise<string> {
     chunks.push(chunk as Buffer)
   }
 
-  return Buffer.concat(chunks).toString().trim()
+  const text = Buffer.concat(chunks).toString()
+
+  return (
+    text
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? ""
+  )
 }
 
 function parsePath(input: string): { hash: string | undefined; path: string } {

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -10,7 +10,7 @@ async function readStdin(): Promise<string> {
   const chunks: Buffer[] = []
 
   for await (const chunk of process.stdin) {
-    chunks.push(Buffer.from(chunk as ArrayBuffer))
+    chunks.push(chunk as Buffer)
   }
 
   return Buffer.concat(chunks).toString().trim()

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -62,10 +62,7 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
 
 export const docs = new Command("docs")
   .description("fetch documentation from yamada-ui.com.")
-  .argument(
-    "[path]",
-    "documentation path (e.g. /docs/components/button#disable).",
-  )
+  .argument("[path]", "documentation path (e.g. /components/button#disable).")
   .addOption(
     new Option("--lang <lang>", "language.")
       .choices(["en", "ja"])

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -117,5 +117,7 @@ export const docs = new Command("docs")
       } else {
         spinner.fail("An unknown error occurred")
       }
+
+      process.exit(1)
     }
   })

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander"
+import { Command, Option } from "commander"
 import ora from "ora"
 import { buildUrl, fetchDoc, trimToSection } from "./fetch-doc"
 
@@ -20,6 +20,12 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
   if (input.startsWith("http://") || input.startsWith("https://")) {
     const url = new URL(input)
 
+    if (url.hostname !== "yamada-ui.com") {
+      throw new Error(
+        `Invalid URL: only yamada-ui.com URLs are supported, got ${url.hostname}`,
+      )
+    }
+
     return {
       hash: url.hash ? url.hash.slice(1) : undefined,
       path: url.pathname,
@@ -38,7 +44,11 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
 export const docs = new Command("docs")
   .description("fetch documentation from the Yamada UI documentation site.")
   .argument("[path]", "documentation path (e.g. /docs/components/button)")
-  .option("--lang <lang>", "language: en | ja", "en")
+  .addOption(
+    new Option("--lang <lang>", "language: en | ja")
+      .choices(["en", "ja"])
+      .default("en"),
+  )
   .action(async function (pathArg: string | undefined, { lang }: Options) {
     const spinner = ora()
 
@@ -68,7 +78,12 @@ export const docs = new Command("docs")
       }
 
       const url = buildUrl(docPath, lang)
+
+      spinner.start("Fetching documentation")
+
       let content = await fetchDoc(url)
+
+      spinner.succeed("Fetched documentation")
 
       if (hash) {
         content = trimToSection(content, hash)

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -78,7 +78,7 @@ export const docs = new Command("docs")
     try {
       const isStdin = !process.stdin.isTTY && pathArg === undefined
 
-      let rawInput: string | undefined = pathArg
+      let rawInput: string | undefined = pathArg?.trim() || undefined
 
       if (isStdin) {
         const stdinText = await readStdin()
@@ -92,8 +92,14 @@ export const docs = new Command("docs")
       if (rawInput) {
         const parsed = parsePath(rawInput)
 
-        docPath = parsed.path
+        docPath = parsed.path || undefined
         hash = parsed.hash
+      }
+
+      if (hash && !docPath) {
+        throw new Error(
+          `A documentation path is required when specifying a section hash: ${c.yellow(`#${hash}`)}`,
+        )
       }
 
       const url = buildUrl(docPath, lang)

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -33,7 +33,11 @@ async function readStdin(): Promise<string> {
   )
 }
 
-function parsePath(input: string): { hash: string | undefined; path: string } {
+function parsePath(input: string): {
+  detectedLang: string | undefined
+  hash: string | undefined
+  path: string
+} {
   if (input.startsWith("http://") || input.startsWith("https://")) {
     const url = new URL(input)
 
@@ -45,7 +49,10 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
       )
     }
 
+    const langMatch = url.pathname.match(/^\/(ja|en)(?=\/)/)
+
     return {
+      detectedLang: langMatch?.[1],
       hash: url.hash ? url.hash.slice(1) : undefined,
       path: url.pathname.replace(/^\/(ja|en)(?=\/)/, ""),
     }
@@ -54,10 +61,14 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
   const hashIndex = input.indexOf("#")
 
   if (hashIndex !== -1) {
-    return { hash: input.slice(hashIndex + 1), path: input.slice(0, hashIndex) }
+    return {
+      detectedLang: undefined,
+      hash: input.slice(hashIndex + 1),
+      path: input.slice(0, hashIndex),
+    }
   }
 
-  return { hash: undefined, path: input }
+  return { detectedLang: undefined, hash: undefined, path: input }
 }
 
 export const docs = new Command("docs")
@@ -88,12 +99,14 @@ export const docs = new Command("docs")
 
       let docPath: string | undefined
       let hash: string | undefined
+      let effectiveLang = lang
 
       if (rawInput) {
         const parsed = parsePath(rawInput)
 
         docPath = parsed.path || undefined
         hash = parsed.hash
+        if (parsed.detectedLang) effectiveLang = parsed.detectedLang
       }
 
       if (hash && !docPath) {
@@ -102,18 +115,16 @@ export const docs = new Command("docs")
         )
       }
 
-      const needsEnFallback = lang !== "en" && !!hash
+      const needsEnFallback = effectiveLang !== "en" && !!hash
 
       spinner.start("Fetching documentation")
 
       const [content, enContent] = await Promise.all([
-        fetchDoc(buildUrl(docPath, lang)),
+        fetchDoc(buildUrl(docPath, effectiveLang)),
         needsEnFallback
           ? fetchDoc(buildUrl(docPath, "en"))
           : Promise.resolve(undefined),
       ])
-
-      spinner.succeed("Fetched documentation")
 
       let result = content
 
@@ -131,6 +142,7 @@ export const docs = new Command("docs")
         }
       }
 
+      spinner.succeed("Fetched documentation")
       process.stdout.write(sections ? extractSections(result) : result)
     } catch (e) {
       if (e instanceof Error) {

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -1,7 +1,13 @@
 import { Command, Option } from "commander"
 import ora from "ora"
 import c from "picocolors"
-import { buildUrl, fetchDoc, trimToSection } from "./fetch-doc"
+import {
+  buildUrl,
+  fetchDoc,
+  findHeadingIndex,
+  trimToSection,
+  trimToSectionByIndex,
+} from "./fetch-doc"
 
 interface Options {
   lang: string
@@ -87,7 +93,18 @@ export const docs = new Command("docs")
       spinner.succeed("Fetched documentation")
 
       if (hash) {
-        content = trimToSection(content, hash)
+        if (lang === "en") {
+          content = trimToSection(content, hash)
+        } else {
+          const enContent = await fetchDoc(buildUrl(docPath, "en"))
+          const idx = findHeadingIndex(enContent, hash)
+
+          if (idx === -1) {
+            throw new Error(`Section not found: ${c.yellow(`#${hash}`)}`)
+          }
+
+          content = trimToSectionByIndex(content, idx, hash)
+        }
       }
 
       process.stdout.write(content)

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -67,11 +67,7 @@ export const docs = new Command("docs")
     const spinner = ora()
 
     try {
-      const isStdin = !process.stdin.isTTY
-
-      if (isStdin && pathArg !== undefined) {
-        throw new Error("Cannot specify both a path argument and stdin input.")
-      }
+      const isStdin = !process.stdin.isTTY && pathArg === undefined
 
       let rawInput: string | undefined = pathArg
 

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -1,0 +1,85 @@
+import { Command } from "commander"
+import ora from "ora"
+import { buildUrl, fetchDoc, trimToSection } from "./fetch-doc"
+
+interface Options {
+  lang: string
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk as ArrayBuffer))
+  }
+
+  return Buffer.concat(chunks).toString().trim()
+}
+
+function parsePath(input: string): { hash: string | undefined; path: string } {
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    const url = new URL(input)
+
+    return {
+      hash: url.hash ? url.hash.slice(1) : undefined,
+      path: url.pathname,
+    }
+  }
+
+  const hashIndex = input.indexOf("#")
+
+  if (hashIndex !== -1) {
+    return { hash: input.slice(hashIndex + 1), path: input.slice(0, hashIndex) }
+  }
+
+  return { hash: undefined, path: input }
+}
+
+export const docs = new Command("docs")
+  .description("fetch documentation from the Yamada UI documentation site.")
+  .argument("[path]", "documentation path (e.g. /docs/components/button)")
+  .option("--lang <lang>", "language: en | ja", "en")
+  .action(async function (pathArg: string | undefined, { lang }: Options) {
+    const spinner = ora()
+
+    try {
+      const isStdin = !process.stdin.isTTY
+
+      if (isStdin && pathArg !== undefined) {
+        throw new Error("Cannot specify both a path argument and stdin input.")
+      }
+
+      let rawInput: string | undefined = pathArg
+
+      if (isStdin) {
+        const stdinText = await readStdin()
+
+        rawInput = stdinText || undefined
+      }
+
+      let docPath: string | undefined
+      let hash: string | undefined
+
+      if (rawInput) {
+        const parsed = parsePath(rawInput)
+
+        docPath = parsed.path
+        hash = parsed.hash
+      }
+
+      const url = buildUrl(docPath, lang)
+      let content = await fetchDoc(url)
+
+      if (hash) {
+        content = trimToSection(content, hash)
+      }
+
+      process.stdout.write(content)
+    } catch (e) {
+      if (e instanceof Error) {
+        spinner.fail(e.message)
+      } else {
+        spinner.fail("An unknown error occurred")
+      }
+    }
+  })

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from "commander"
 import ora from "ora"
+import c from "picocolors"
 import { buildUrl, fetchDoc, trimToSection } from "./fetch-doc"
 
 interface Options {
@@ -22,7 +23,7 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
 
     if (url.hostname !== "yamada-ui.com") {
       throw new Error(
-        `Invalid URL: only yamada-ui.com URLs are supported, got ${url.hostname}`,
+        `Invalid URL: only ${c.cyan("yamada-ui.com")} URLs are supported, got ${c.yellow(url.hostname)}`,
       )
     }
 
@@ -42,10 +43,10 @@ function parsePath(input: string): { hash: string | undefined; path: string } {
 }
 
 export const docs = new Command("docs")
-  .description("fetch documentation from the Yamada UI documentation site.")
-  .argument("[path]", "documentation path (e.g. /docs/components/button)")
+  .description("fetch documentation from yamada-ui.com.")
+  .argument("[path]", "documentation path (e.g. /docs/components/button).")
   .addOption(
-    new Option("--lang <lang>", "language: en | ja")
+    new Option("--lang <lang>", "language.")
       .choices(["en", "ja"])
       .default("en"),
   )

--- a/packages/cli/src/constant.ts
+++ b/packages/cli/src/constant.ts
@@ -5,7 +5,8 @@ export const PACKAGE_NAME = "@yamada-ui/react"
 export const CONFIG_FILE_NAME = "ui.json"
 export const REGISTRY_FILE_NAME = "registry.json"
 export const REGISTRY_VERSION = "v2"
-export const REGISTRY_URL = "https://yamada-ui.com/registry"
+export const DOCS_BASE_URL = "https://yamada-ui.com"
+export const REGISTRY_URL = `${DOCS_BASE_URL}/registry`
 export const SECTION_NAMES = ["components", "hooks", "providers"] as const
 export const DEFAULT_PACKAGE_NAME = {
   ui: "@workspaces/ui",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import updateNotifier from "update-notifier"
 import packageJson from "../package.json"
 import { add } from "./commands/add"
 import { diff } from "./commands/diff"
+import { docs } from "./commands/docs"
 import { init } from "./commands/init"
 import { theme } from "./commands/theme"
 import { tokens } from "./commands/tokens"
@@ -34,6 +35,7 @@ export function run() {
   program.addCommand(diff)
   program.addCommand(theme)
   program.addCommand(tokens)
+  program.addCommand(docs)
 
   program.parse()
 }


### PR DESCRIPTION
Closes #5997

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a `docs` command to `@yamada-ui/cli` that fetches documentation markdown from the Yamada UI documentation site, designed for AI agent consumption.

## Current behavior (updates)

There is no CLI command to fetch Yamada UI documentation. Developers and AI agents have to manually visit `https://yamada-ui.com/docs/components/{component}.md` in a browser.

## New behavior

```sh
# Display llms.txt (documentation index)
yamada-cli docs

# Fetch documentation for a component
yamada-cli docs /docs/components/button

# Start from a specific section
yamada-cli docs /docs/components/button#usage

# Fetch Japanese documentation
yamada-cli docs /docs/components/button --lang ja

# Pipe from stdin
echo "/docs/components/button" | yamada-cli docs
```

- No argument: fetches `https://yamada-ui.com/llms.txt`
- With path: fetches `https://yamada-ui.com{path}.md`
- With hash fragment: trims output to start from the matched heading (error if not found)
- `--lang ja`: fetches `/ja{path}.md`
- stdin (non-TTY): reads path from stdin; accepts bare paths or full `yamada-ui.com` URLs
- `--lang` is validated with `.choices(["en", "ja"])`

## Is this a breaking change (Yes/No):

No

## Additional Information

Modeled after [Hono's `hono docs` command](https://github.com/honojs/cli).