### PR TITLE
ci(security): add zizmor workflow

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,4 @@
-name: Security
+name: GitHub Actions
 
 on:
   push:
@@ -32,6 +32,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  actionlint:
+    name: Actionlint
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint
+        run: |
+          curl -sSfL -o actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum --check
+          tar -xzf actionlint.tar.gz actionlint
+
+      - name: Run actionlint
+        run: ./actionlint
+
   zizmor:
     name: Zizmor
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -47,3 +69,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: true

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -32,45 +32,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  actionlint:
-    name: Actionlint
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Check modified workflow files
-        id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            .github/workflows/**/*.yml
-            .github/workflows/**/*.yaml
-
-      - name: Install actionlint
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
-          curl -sSfL -o actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
-          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum --check
-          tar -xzf actionlint.tar.gz actionlint
-
-      - name: Run actionlint
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
-          read -r -a workflow_files <<< "$WORKFLOW_FILES"
-          ./actionlint "${workflow_files[@]}"
-        env:
-          WORKFLOW_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-
   zizmor:
-    name: Zizmor
+    name: zizmor
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Run actionlint
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: ./actionlint $WORKFLOW_FILES
+        run: |
+          read -r -a workflow_files <<< "$WORKFLOW_FILES"
+          ./actionlint "${workflow_files[@]}"
         env:
           WORKFLOW_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -43,16 +43,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Check modified workflow files
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            .github/workflows/**/*.yml
+            .github/workflows/**/*.yaml
+
       - name: Install actionlint
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           curl -sSfL -o actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum --check
           tar -xzf actionlint.tar.gz actionlint
 
       - name: Run actionlint
-        run: ./actionlint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: ./actionlint $WORKFLOW_FILES
+        env:
+          WORKFLOW_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
   zizmor:
     name: Zizmor

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,49 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - main
+      - v*
+    paths:
+      - ".github/workflows/**"
+      - ".github/composite-actions/**"
+      - ".github/dependabot.yml"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    branches:
+      - main
+      - v*
+    paths:
+      - ".github/workflows/**"
+      - ".github/composite-actions/**"
+      - ".github/dependabot.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
- Closes #7660

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a dedicated GitHub Actions workflow that runs zizmor for workflow, composite action, and Dependabot configuration changes.

## Current behavior (updates)

GitHub Actions security analysis is not run as a dedicated repository workflow.

## New behavior

The new `GitHub Actions` workflow runs the lowercase `zizmor` job with `zizmorcore/zizmor-action`, Advanced Security enabled, minimal workflow permissions, and checkout credential persistence disabled.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified with:

- `actionlint .github/workflows/github-actions.yml`
- `zizmor .github/workflows/github-actions.yml`
- `pnpm exec oxfmt --check .github/workflows/github-actions.yml`

The broader pre-PR helper was attempted, but repository-wide formatting is currently blocked by unrelated untracked local files outside this PR diff.