### PR TITLE
docs(container): add related component tips

### DIFF
--- a/www/contents/components/(components)/container.ja.mdx
+++ b/www/contents/components/(components)/container.ja.mdx
@@ -48,6 +48,10 @@ import { Container } from "@workspaces/ui"
 </Container.Root>
 ```
 
+::::tip
+関連する情報をカードのようにグループ化して表示したい場合は、[Card](/docs/components/card)の使用を検討してください。
+::::
+
 ### バリアントを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/container.ja.mdx
+++ b/www/contents/components/(components)/container.ja.mdx
@@ -48,9 +48,9 @@ import { Container } from "@workspaces/ui"
 </Container.Root>
 ```
 
-::::tip
+:::tip
 関連する情報をカードのようにグループ化して表示したい場合は、[Card](/docs/components/card)の使用を検討してください。
-::::
+:::
 
 ### バリアントを変更する
 

--- a/www/contents/components/(components)/container.ja.mdx
+++ b/www/contents/components/(components)/container.ja.mdx
@@ -49,7 +49,7 @@ import { Container } from "@workspaces/ui"
 ```
 
 :::tip
-関連する情報をカードのようにグループ化して表示したい場合は、[Card](/docs/components/card)の使用を検討してください。
+関連する情報をカードのようにグループ化して表示する場合は、[Card](/docs/components/card)を使用します。
 :::
 
 ### バリアントを変更する

--- a/www/contents/components/(components)/container.mdx
+++ b/www/contents/components/(components)/container.mdx
@@ -52,6 +52,10 @@ import { Container } from "@workspaces/ui"
 </Container.Root>
 ```
 
+::::tip
+If you want to group and display related information with a card-like appearance, consider using [Card](/docs/components/card).
+::::
+
 ### Change Variant
 
 ```tsx preview

--- a/www/contents/components/(components)/container.mdx
+++ b/www/contents/components/(components)/container.mdx
@@ -52,9 +52,9 @@ import { Container } from "@workspaces/ui"
 </Container.Root>
 ```
 
-::::tip
+:::tip
 If you want to group and display related information with a card-like appearance, consider using [Card](/docs/components/card).
-::::
+:::
 
 ### Change Variant
 

--- a/www/contents/components/(components)/container.mdx
+++ b/www/contents/components/(components)/container.mdx
@@ -53,7 +53,7 @@ import { Container } from "@workspaces/ui"
 ```
 
 :::tip
-If you want to group and display related information with a card-like appearance, consider using [Card](/docs/components/card).
+Use [Card](/docs/components/card) to group and display related information with a card-like appearance.
 :::
 
 ### Change Variant


### PR DESCRIPTION
Closes #6284

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds Container docs tips that point readers to Card when related information should be grouped and displayed with a card-like presentation.

## Current behavior (updates)

The Container docs describe Container as a general division component without a related-component note for Card.

## New behavior

The English and Japanese Container docs include a tip linking to Card for grouped related information, using the direct related-component wording pattern.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Verified with `pnpm www build:content`.
- Commit hooks passed format and commitlint; lint/typecheck hooks skipped because no files matched those inspections.
