### PR TITLE
docs(carousel): add related component tips

### DIFF
--- a/www/contents/components/(components)/carousel.ja.mdx
+++ b/www/contents/components/(components)/carousel.ja.mdx
@@ -75,7 +75,7 @@ import { Carousel } from "@workspaces/ui"
 ```
 
 :::tip
-コンテンツがあふれたときにカスタムされたスクロールバーだけが必要な場合は、[ScrollArea](/docs/components/scroll-area)の使用を検討してください。
+コンテンツがあふれたときにカスタムされたスクロールバーだけが必要な場合は、[ScrollArea](/docs/components/scroll-area)を使用します。
 :::
 
 :::note

--- a/www/contents/components/(components)/carousel.ja.mdx
+++ b/www/contents/components/(components)/carousel.ja.mdx
@@ -74,6 +74,10 @@ import { Carousel } from "@workspaces/ui"
 </Carousel.Root>
 ```
 
+::::tip
+コンテンツがあふれたときにカスタムされたスクロールバーだけが必要な場合は、[ScrollArea](/docs/components/scroll-area)の使用を検討してください。
+::::
+
 :::note
 `Carousel`は、内部で[embla-carousel-react](https://www.embla-carousel.com/)を使用しています。
 :::

--- a/www/contents/components/(components)/carousel.ja.mdx
+++ b/www/contents/components/(components)/carousel.ja.mdx
@@ -74,9 +74,9 @@ import { Carousel } from "@workspaces/ui"
 </Carousel.Root>
 ```
 
-::::tip
+:::tip
 コンテンツがあふれたときにカスタムされたスクロールバーだけが必要な場合は、[ScrollArea](/docs/components/scroll-area)の使用を検討してください。
-::::
+:::
 
 :::note
 `Carousel`は、内部で[embla-carousel-react](https://www.embla-carousel.com/)を使用しています。

--- a/www/contents/components/(components)/carousel.mdx
+++ b/www/contents/components/(components)/carousel.mdx
@@ -74,6 +74,10 @@ import { Carousel } from "@workspaces/ui"
 </Carousel.Root>
 ```
 
+::::tip
+If you only need customized scrollbars for overflowing content, consider using [ScrollArea](/docs/components/scroll-area) instead.
+::::
+
 :::note
 `Carousel` internally uses [embla-carousel-react](https://www.embla-carousel.com/).
 :::

--- a/www/contents/components/(components)/carousel.mdx
+++ b/www/contents/components/(components)/carousel.mdx
@@ -74,9 +74,9 @@ import { Carousel } from "@workspaces/ui"
 </Carousel.Root>
 ```
 
-::::tip
+:::tip
 If you only need customized scrollbars for overflowing content, consider using [ScrollArea](/docs/components/scroll-area) instead.
-::::
+:::
 
 :::note
 `Carousel` internally uses [embla-carousel-react](https://www.embla-carousel.com/).

--- a/www/contents/components/(components)/carousel.mdx
+++ b/www/contents/components/(components)/carousel.mdx
@@ -75,7 +75,7 @@ import { Carousel } from "@workspaces/ui"
 ```
 
 :::tip
-If you only need customized scrollbars for overflowing content, consider using [ScrollArea](/docs/components/scroll-area) instead.
+Use [ScrollArea](/docs/components/scroll-area) when you only need customized scrollbars for overflowing content.
 :::
 
 :::note


### PR DESCRIPTION
Closes #6284

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a related component tip to the Carousel docs so readers can choose ScrollArea when they only need customized scrollbars for overflowing content.

## Current behavior (updates)

The Carousel docs describe slideshow-style behavior, but they do not point readers to ScrollArea when carousel controls and slide behavior are not the goal.

## New behavior

Adds English and Japanese tip sections that link from Carousel to ScrollArea for customized-scrollbar use cases with direct "Use ..." wording.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `git diff --check` passed locally.
- Checked the new tip wording against the Carousel and ScrollArea frontmatter descriptions in English and Japanese.
- `pnpm www build:content` could not run in the temporary worktree because `velite` was unavailable: `sh: velite: command not found`.
