### PR TITLE
docs(wrap): add related component tips

### DIFF
--- a/www/contents/components/(components)/wrap.ja.mdx
+++ b/www/contents/components/(components)/wrap.ja.mdx
@@ -39,6 +39,10 @@ import { Wrap } from "@workspaces/ui"
 <Wrap />
 ```
 
+::::tip
+折り返しが不要で、より汎用的なフレックスレイアウトを使いたい場合は、[Flex](/docs/components/flex)の使用を検討してください。
+::::
+
 ## Props
 
 <PropsTable name="wrap" />

--- a/www/contents/components/(components)/wrap.ja.mdx
+++ b/www/contents/components/(components)/wrap.ja.mdx
@@ -40,7 +40,7 @@ import { Wrap } from "@workspaces/ui"
 ```
 
 :::tip
-折り返しが不要で、より汎用的なフレックスレイアウトを使いたい場合は、[Flex](/docs/components/flex)の使用を検討してください。
+折り返しが不要で、より汎用的なフレックスレイアウトを使いたい場合は、[Flex](/docs/components/flex)を使用します。
 :::
 
 ## Props

--- a/www/contents/components/(components)/wrap.ja.mdx
+++ b/www/contents/components/(components)/wrap.ja.mdx
@@ -39,9 +39,9 @@ import { Wrap } from "@workspaces/ui"
 <Wrap />
 ```
 
-::::tip
+:::tip
 折り返しが不要で、より汎用的なフレックスレイアウトを使いたい場合は、[Flex](/docs/components/flex)の使用を検討してください。
-::::
+:::
 
 ## Props
 

--- a/www/contents/components/(components)/wrap.mdx
+++ b/www/contents/components/(components)/wrap.mdx
@@ -39,6 +39,10 @@ import { Wrap } from "@workspaces/ui"
 <Wrap />
 ```
 
+::::tip
+If you do not need wrapping and want a general flex layout instead, consider using [Flex](/docs/components/flex).
+::::
+
 ## Props
 
 <PropsTable name="wrap" />

--- a/www/contents/components/(components)/wrap.mdx
+++ b/www/contents/components/(components)/wrap.mdx
@@ -40,7 +40,7 @@ import { Wrap } from "@workspaces/ui"
 ```
 
 :::tip
-If you do not need wrapping and want a general flex layout instead, consider using [Flex](/docs/components/flex).
+If you do not need wrapping and want a general flex layout instead, use [Flex](/docs/components/flex).
 :::
 
 ## Props

--- a/www/contents/components/(components)/wrap.mdx
+++ b/www/contents/components/(components)/wrap.mdx
@@ -39,9 +39,9 @@ import { Wrap } from "@workspaces/ui"
 <Wrap />
 ```
 
-::::tip
+:::tip
 If you do not need wrapping and want a general flex layout instead, consider using [Flex](/docs/components/flex).
-::::
+:::
 
 ## Props
 


### PR DESCRIPTION
Closes #6284

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add Wrap documentation tips that point readers to Flex when wrapping behavior is not needed.

## Current behavior (updates)

The Wrap docs describe the component as Flex with wrapping enabled, but do not guide readers toward Flex when they only need a general flex layout.

## New behavior

Adds English and Japanese tip sections to the Wrap docs that suggest Flex for layouts that do not need wrapping.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `pnpm www build:content` passed locally.
