### PR TITLE
docs(grid): add related component tips

### DIFF
--- a/www/contents/components/(components)/grid.ja.mdx
+++ b/www/contents/components/(components)/grid.ja.mdx
@@ -47,6 +47,10 @@ import { Grid, GridItem } from "@workspaces/ui"
 </Grid>
 ```
 
+::::tip
+等幅カラムのレイアウトでは、[SimpleGrid](/docs/components/simple-grid)を使うと設定を簡潔にできます。
+::::
+
 ### templateAreasを使う
 
 ```tsx preview

--- a/www/contents/components/(components)/grid.ja.mdx
+++ b/www/contents/components/(components)/grid.ja.mdx
@@ -48,7 +48,7 @@ import { Grid, GridItem } from "@workspaces/ui"
 ```
 
 :::tip
-等幅カラムのレイアウトでは、[SimpleGrid](/docs/components/simple-grid)を使うと設定を簡潔にできます。
+等幅カラムのレイアウトでは、[SimpleGrid](/docs/components/simple-grid)を使用します。
 :::
 
 ### templateAreasを使う

--- a/www/contents/components/(components)/grid.ja.mdx
+++ b/www/contents/components/(components)/grid.ja.mdx
@@ -47,9 +47,9 @@ import { Grid, GridItem } from "@workspaces/ui"
 </Grid>
 ```
 
-::::tip
+:::tip
 等幅カラムのレイアウトでは、[SimpleGrid](/docs/components/simple-grid)を使うと設定を簡潔にできます。
-::::
+:::
 
 ### templateAreasを使う
 

--- a/www/contents/components/(components)/grid.mdx
+++ b/www/contents/components/(components)/grid.mdx
@@ -47,6 +47,10 @@ import { Grid, GridItem } from "@workspaces/ui"
 </Grid>
 ```
 
+::::tip
+For equal-width column layouts, [SimpleGrid](/docs/components/simple-grid) can reduce setup.
+::::
+
 ### Use Template Areas
 
 ```tsx preview

--- a/www/contents/components/(components)/grid.mdx
+++ b/www/contents/components/(components)/grid.mdx
@@ -47,9 +47,9 @@ import { Grid, GridItem } from "@workspaces/ui"
 </Grid>
 ```
 
-::::tip
+:::tip
 For equal-width column layouts, [SimpleGrid](/docs/components/simple-grid) can reduce setup.
-::::
+:::
 
 ### Use Template Areas
 

--- a/www/contents/components/(components)/grid.mdx
+++ b/www/contents/components/(components)/grid.mdx
@@ -48,7 +48,7 @@ import { Grid, GridItem } from "@workspaces/ui"
 ```
 
 :::tip
-For equal-width column layouts, [SimpleGrid](/docs/components/simple-grid) can reduce setup.
+For equal-width column layouts, use [SimpleGrid](/docs/components/simple-grid).
 :::
 
 ### Use Template Areas


### PR DESCRIPTION
Closes #7679

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a Grid docs tip that points readers to SimpleGrid when a simpler Grid wrapper fits the layout.

## Current behavior (updates)

The Grid docs describe managing grid layouts, but they do not guide readers toward SimpleGrid for simpler repeated-column layouts.

## New behavior

The English and Japanese Grid docs include a related-component tip linking to SimpleGrid for equal-width column layouts.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `pnpm www build:content`
- `git diff --check -- 'www/contents/components/(components)/grid.mdx' 'www/contents/components/(components)/grid.ja.mdx'`

