### PR TITLE
docs(stack): add related component tips

### DIFF
--- a/www/contents/components/(components)/stack.ja.mdx
+++ b/www/contents/components/(components)/stack.ja.mdx
@@ -40,15 +40,15 @@ import { Stack } from "@workspaces/ui"
 ```
 
 :::tip
-縦方向に積み重ねたい場合は、[VStack](/docs/components/v-stack)の使用を検討してください。
+縦方向に積み重ねたい場合は、[VStack](/docs/components/v-stack)を使用します。
 :::
 
 :::tip
-横方向に積み重ねたい場合は、[HStack](/docs/components/h-stack)の使用を検討してください。
+横方向に積み重ねたい場合は、[HStack](/docs/components/h-stack)を使用します。
 :::
 
 :::tip
-子要素を奥行き方向に積み重ねたい場合は、[ZStack](/docs/components/z-stack)の使用を検討してください。
+子要素を重ねて表示したい場合は、[ZStack](/docs/components/z-stack)を使用します。
 :::
 
 ### 子要素間に区切り線を設ける

--- a/www/contents/components/(components)/stack.ja.mdx
+++ b/www/contents/components/(components)/stack.ja.mdx
@@ -39,17 +39,17 @@ import { Stack } from "@workspaces/ui"
 <Stack />
 ```
 
-::::tip
+:::tip
 縦方向に積み重ねたい場合は、[VStack](/docs/components/v-stack)の使用を検討してください。
-::::
+:::
 
-::::tip
+:::tip
 横方向に積み重ねたい場合は、[HStack](/docs/components/h-stack)の使用を検討してください。
-::::
+:::
 
-::::tip
+:::tip
 子要素を奥行き方向に積み重ねたい場合は、[ZStack](/docs/components/z-stack)の使用を検討してください。
-::::
+:::
 
 ### 子要素間に区切り線を設ける
 

--- a/www/contents/components/(components)/stack.ja.mdx
+++ b/www/contents/components/(components)/stack.ja.mdx
@@ -39,6 +39,18 @@ import { Stack } from "@workspaces/ui"
 <Stack />
 ```
 
+::::tip
+縦方向に積み重ねたい場合は、[VStack](/docs/components/v-stack)の使用を検討してください。
+::::
+
+::::tip
+横方向に積み重ねたい場合は、[HStack](/docs/components/h-stack)の使用を検討してください。
+::::
+
+::::tip
+子要素を奥行き方向に積み重ねたい場合は、[ZStack](/docs/components/z-stack)の使用を検討してください。
+::::
+
 ### 子要素間に区切り線を設ける
 
 ```tsx preview

--- a/www/contents/components/(components)/stack.mdx
+++ b/www/contents/components/(components)/stack.mdx
@@ -39,6 +39,18 @@ import { Stack } from "@workspaces/ui"
 <Stack />
 ```
 
+::::tip
+If you want a vertical stack, consider using [VStack](/docs/components/v-stack).
+::::
+
+::::tip
+If you want a horizontal stack, consider using [HStack](/docs/components/h-stack).
+::::
+
+::::tip
+If you want to stack elements in depth, consider using [ZStack](/docs/components/z-stack).
+::::
+
 ### Adding Separators Between Child Elements
 
 ```tsx preview

--- a/www/contents/components/(components)/stack.mdx
+++ b/www/contents/components/(components)/stack.mdx
@@ -39,17 +39,17 @@ import { Stack } from "@workspaces/ui"
 <Stack />
 ```
 
-::::tip
+:::tip
 If you want a vertical stack, consider using [VStack](/docs/components/v-stack).
-::::
+:::
 
-::::tip
+:::tip
 If you want a horizontal stack, consider using [HStack](/docs/components/h-stack).
-::::
+:::
 
-::::tip
+:::tip
 If you want to stack elements in depth, consider using [ZStack](/docs/components/z-stack).
-::::
+:::
 
 ### Adding Separators Between Child Elements
 

--- a/www/contents/components/(components)/stack.mdx
+++ b/www/contents/components/(components)/stack.mdx
@@ -40,15 +40,15 @@ import { Stack } from "@workspaces/ui"
 ```
 
 :::tip
-If you want a vertical stack, consider using [VStack](/docs/components/v-stack).
+If you want a vertical stack, use [VStack](/docs/components/v-stack).
 :::
 
 :::tip
-If you want a horizontal stack, consider using [HStack](/docs/components/h-stack).
+If you want a horizontal stack, use [HStack](/docs/components/h-stack).
 :::
 
 :::tip
-If you want to stack elements in depth, consider using [ZStack](/docs/components/z-stack).
+To stack child elements on top of each other, use [ZStack](/docs/components/z-stack).
 :::
 
 ### Adding Separators Between Child Elements


### PR DESCRIPTION
Closes #6284

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add Stack docs tips that point readers to the more specific stack variants when the intended layout is vertical, horizontal, or depth-based.

## Current behavior (updates)

The Stack docs describe the base component but do not mention when VStack, HStack, or ZStack may better match the intended direction.

## New behavior

The English and Japanese Stack docs now include focused tips linking to VStack, HStack, and ZStack with wording checked against each linked component description.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `git diff --check origin/main...HEAD -- www/contents/components/(components)/stack.mdx www/contents/components/(components)/stack.ja.mdx`
- `pnpm www build:content`
- PR CI passed.
