### PR TITLE
docs(card): add related component tips

### DIFF
--- a/www/contents/components/(components)/card.ja.mdx
+++ b/www/contents/components/(components)/card.ja.mdx
@@ -48,9 +48,9 @@ import { Card } from "@workspaces/ui"
 </Card.Root>
 ```
 
-::::tip
+:::tip
 関連する情報をグループ化するカードではなく、デフォルトで`section`要素をレンダリングする汎用的な区分要素が必要な場合は、[Container](/docs/components/container)の使用を検討してください。
-::::
+:::
 
 ### バリアントを変更する
 

--- a/www/contents/components/(components)/card.ja.mdx
+++ b/www/contents/components/(components)/card.ja.mdx
@@ -49,7 +49,7 @@ import { Card } from "@workspaces/ui"
 ```
 
 :::tip
-関連する情報をグループ化するカードではなく、デフォルトで`section`要素をレンダリングする汎用的な区分要素が必要な場合は、[Container](/docs/components/container)の使用を検討してください。
+関連する情報をグループ化するカードではなく、デフォルトで`section`要素をレンダリングする汎用的な区分要素が必要な場合は、[Container](/docs/components/container)を使用します。
 :::
 
 ### バリアントを変更する

--- a/www/contents/components/(components)/card.ja.mdx
+++ b/www/contents/components/(components)/card.ja.mdx
@@ -48,6 +48,10 @@ import { Card } from "@workspaces/ui"
 </Card.Root>
 ```
 
+::::tip
+関連する情報をグループ化するカードではなく、デフォルトで`section`要素をレンダリングする汎用的な区分要素が必要な場合は、[Container](/docs/components/container)の使用を検討してください。
+::::
+
 ### バリアントを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/card.mdx
+++ b/www/contents/components/(components)/card.mdx
@@ -48,6 +48,10 @@ import { Card } from "@workspaces/ui"
 </Card.Root>
 ```
 
+::::tip
+If you need a general division element that renders a `section` by default rather than a card that groups related information, consider using [Container](/docs/components/container).
+::::
+
 ### Change Variant
 
 ```tsx preview

--- a/www/contents/components/(components)/card.mdx
+++ b/www/contents/components/(components)/card.mdx
@@ -48,9 +48,9 @@ import { Card } from "@workspaces/ui"
 </Card.Root>
 ```
 
-::::tip
+:::tip
 If you need a general division element that renders a `section` by default rather than a card that groups related information, consider using [Container](/docs/components/container).
-::::
+:::
 
 ### Change Variant
 

--- a/www/contents/components/(components)/card.mdx
+++ b/www/contents/components/(components)/card.mdx
@@ -49,7 +49,7 @@ import { Card } from "@workspaces/ui"
 ```
 
 :::tip
-If you need a general division element that renders a `section` by default rather than a card that groups related information, consider using [Container](/docs/components/container).
+Use [Container](/docs/components/container) when you need a general division element that renders a `section` by default rather than a card that groups related information.
 :::
 
 ### Change Variant


### PR DESCRIPTION
Closes #7674

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add related component usage tips to the card component docs page.

## Current behavior (updates)

The card docs page did not include guidance about when a related layout component might better match the use case.

## New behavior

Adds English and Japanese tip sections to the card docs page, scoped to the related component guidance from PR 6388.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `pnpm www build:content` passed locally.
- `git diff --check origin/main...HEAD` passed locally.

