### PR TITLE
docs(separator): add related component tips

### DIFF
--- a/www/contents/components/(components)/separator.ja.mdx
+++ b/www/contents/components/(components)/separator.ja.mdx
@@ -33,6 +33,10 @@ import { Separator } from "@workspaces/ui"
 <Separator />
 ```
 
+::::tip
+積み重ねた子要素の間に区切り線を自動で挿入したい場合は、`separator`プロパティを持つ[Stack](/docs/components/stack)、[VStack](/docs/components/v-stack)、または[HStack](/docs/components/h-stack)の使用を検討してください。
+::::
+
 ### バリアントを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/separator.ja.mdx
+++ b/www/contents/components/(components)/separator.ja.mdx
@@ -34,7 +34,15 @@ import { Separator } from "@workspaces/ui"
 ```
 
 :::tip
-積み重ねた子要素の間に区切り線を自動で挿入したい場合は、`separator`プロパティを持つ[Stack](/docs/components/stack)、[VStack](/docs/components/v-stack)、または[HStack](/docs/components/h-stack)の使用を検討してください。
+積み重ねた子要素の間に区切り線を挿入する場合は、`separator`プロパティを持つ[Stack](/docs/components/stack)を使用します。
+:::
+
+:::tip
+子要素を縦方向に積み重ね、その間に区切り線を挿入する場合は、`separator`プロパティを持つ[VStack](/docs/components/v-stack)を使用します。
+:::
+
+:::tip
+子要素を横方向に積み重ね、その間に区切り線を挿入する場合は、`separator`プロパティを持つ[HStack](/docs/components/h-stack)を使用します。
 :::
 
 ### バリアントを変更する

--- a/www/contents/components/(components)/separator.ja.mdx
+++ b/www/contents/components/(components)/separator.ja.mdx
@@ -33,9 +33,9 @@ import { Separator } from "@workspaces/ui"
 <Separator />
 ```
 
-::::tip
+:::tip
 積み重ねた子要素の間に区切り線を自動で挿入したい場合は、`separator`プロパティを持つ[Stack](/docs/components/stack)、[VStack](/docs/components/v-stack)、または[HStack](/docs/components/h-stack)の使用を検討してください。
-::::
+:::
 
 ### バリアントを変更する
 

--- a/www/contents/components/(components)/separator.mdx
+++ b/www/contents/components/(components)/separator.mdx
@@ -33,6 +33,10 @@ import { Separator } from "@workspaces/ui"
 <Separator />
 ```
 
+::::tip
+If you want separators to be inserted automatically between stacked child elements, consider using [Stack](/docs/components/stack), [VStack](/docs/components/v-stack), or [HStack](/docs/components/h-stack) with the `separator` prop.
+::::
+
 ### Change Variant
 
 ```tsx preview

--- a/www/contents/components/(components)/separator.mdx
+++ b/www/contents/components/(components)/separator.mdx
@@ -34,7 +34,15 @@ import { Separator } from "@workspaces/ui"
 ```
 
 :::tip
-If you want separators to be inserted automatically between stacked child elements, consider using [Stack](/docs/components/stack), [VStack](/docs/components/v-stack), or [HStack](/docs/components/h-stack) with the `separator` prop.
+Use [Stack](/docs/components/stack) with the `separator` prop to insert separators between stacked child elements.
+:::
+
+:::tip
+Use [VStack](/docs/components/v-stack) with the `separator` prop to insert separators between vertically stacked child elements.
+:::
+
+:::tip
+Use [HStack](/docs/components/h-stack) with the `separator` prop to insert separators between horizontally stacked child elements.
 :::
 
 ### Change Variant

--- a/www/contents/components/(components)/separator.mdx
+++ b/www/contents/components/(components)/separator.mdx
@@ -33,9 +33,9 @@ import { Separator } from "@workspaces/ui"
 <Separator />
 ```
 
-::::tip
+:::tip
 If you want separators to be inserted automatically between stacked child elements, consider using [Stack](/docs/components/stack), [VStack](/docs/components/v-stack), or [HStack](/docs/components/h-stack) with the `separator` prop.
-::::
+:::
 
 ### Change Variant
 


### PR DESCRIPTION
Closes #7680

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add separator docs tips that point readers to Stack, VStack, and HStack when they want a related layout component to place separators between stacked children.

## Current behavior (updates)

The Separator docs describe the divider component itself, but do not point readers to stack components when separators should be placed between child elements.

## New behavior

The English and Japanese Separator docs now include separate focused tips for Stack, VStack, and HStack with the `separator` prop.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Checked the tip text against the Separator, Stack, VStack, and HStack frontmatter descriptions.
- `pnpm www build:content` passed locally.
- `git diff --check` passed locally.
