### PR TITLE
docs(empty-state): add related component tips

### DIFF
--- a/www/contents/components/(components)/empty-state.ja.mdx
+++ b/www/contents/components/(components)/empty-state.ja.mdx
@@ -41,13 +41,13 @@ import { EmptyState } from "@workspaces/ui"
 </EmptyState.Root>
 ```
 
-::::tip
+:::tip
 リソースが空ではなく読み込み中の状態を表現したい場合は、[Skeleton](/docs/components/skeleton)の使用を検討してください。
-::::
+:::
 
-::::tip
+:::tip
 空または利用できないリソースを表示するのではなく、ユーザーに情報を伝達したい場合は、[Alert](/docs/components/alert)の使用を検討してください。
-::::
+:::
 
 ### サイズを変更する
 

--- a/www/contents/components/(components)/empty-state.ja.mdx
+++ b/www/contents/components/(components)/empty-state.ja.mdx
@@ -42,11 +42,11 @@ import { EmptyState } from "@workspaces/ui"
 ```
 
 :::tip
-リソースが空ではなく読み込み中の状態を表現したい場合は、[Skeleton](/docs/components/skeleton)の使用を検討してください。
+データの読み込み中は、[Loading](/docs/components/loading)や[Skeleton](/docs/components/skeleton)を使用します。`EmptyState`は、読み込み完了後にリソースが空または利用できない場合に使用します。
 :::
 
 :::tip
-空または利用できないリソースを表示するのではなく、ユーザーに情報を伝達したい場合は、[Alert](/docs/components/alert)の使用を検討してください。
+リソースが空または利用できない状態ではなくユーザーに情報を伝達したい場合は、[Alert](/docs/components/alert)を使用します。
 :::
 
 ### サイズを変更する

--- a/www/contents/components/(components)/empty-state.ja.mdx
+++ b/www/contents/components/(components)/empty-state.ja.mdx
@@ -41,6 +41,14 @@ import { EmptyState } from "@workspaces/ui"
 </EmptyState.Root>
 ```
 
+::::tip
+リソースが空ではなく読み込み中の状態を表現したい場合は、[Skeleton](/docs/components/skeleton)の使用を検討してください。
+::::
+
+::::tip
+空または利用できないリソースを表示するのではなく、ユーザーに情報を伝達したい場合は、[Alert](/docs/components/alert)の使用を検討してください。
+::::
+
 ### サイズを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/empty-state.mdx
+++ b/www/contents/components/(components)/empty-state.mdx
@@ -41,13 +41,13 @@ import { EmptyState } from "@workspaces/ui"
 </EmptyState.Root>
 ```
 
-::::tip
+:::tip
 If the resource is loading rather than empty, consider using [Skeleton](/docs/components/skeleton).
-::::
+:::
 
-::::tip
+:::tip
 If you need to convey information to the user instead of showing an empty or unavailable resource, consider using [Alert](/docs/components/alert).
-::::
+:::
 
 ### Change Size
 

--- a/www/contents/components/(components)/empty-state.mdx
+++ b/www/contents/components/(components)/empty-state.mdx
@@ -41,6 +41,14 @@ import { EmptyState } from "@workspaces/ui"
 </EmptyState.Root>
 ```
 
+::::tip
+If the resource is loading rather than empty, consider using [Skeleton](/docs/components/skeleton).
+::::
+
+::::tip
+If you need to convey information to the user instead of showing an empty or unavailable resource, consider using [Alert](/docs/components/alert).
+::::
+
 ### Change Size
 
 ```tsx preview

--- a/www/contents/components/(components)/empty-state.mdx
+++ b/www/contents/components/(components)/empty-state.mdx
@@ -42,11 +42,11 @@ import { EmptyState } from "@workspaces/ui"
 ```
 
 :::tip
-If the resource is loading rather than empty, consider using [Skeleton](/docs/components/skeleton).
+If data is loading, use [Loading](/docs/components/loading) or [Skeleton](/docs/components/skeleton). Use `EmptyState` when the resource is empty or unavailable after loading completes.
 :::
 
 :::tip
-If you need to convey information to the user instead of showing an empty or unavailable resource, consider using [Alert](/docs/components/alert).
+If you need to convey information to the user instead of showing an empty or unavailable resource, use [Alert](/docs/components/alert).
 :::
 
 ### Change Size


### PR DESCRIPTION
Closes #6284

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add related component tips to the EmptyState docs in English and Japanese.

## Current behavior (updates)

The EmptyState docs describe the component, but do not point readers to related feedback components when the content is loading or when the page only needs to convey information.

## New behavior

The EmptyState docs now suggest Skeleton for loading placeholders and Alert for conveying information instead of representing an empty or unavailable resource.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `pnpm www build:content` passed locally.
- `git diff --check origin/main...HEAD` passed locally.
