### PR TITLE
docs(simple-grid): add related component tips

### DIFF
--- a/www/contents/components/(components)/simple-grid.ja.mdx
+++ b/www/contents/components/(components)/simple-grid.ja.mdx
@@ -47,6 +47,10 @@ import { SimpleGrid } from "@workspaces/ui"
 <SimpleGrid />
 ```
 
+::::tip
+テンプレートエリアや、より細かな行・列の配置が必要な場合は、[Grid](/docs/components/grid)の使用を検討してください。
+::::
+
 ### 間隔を調整する
 
 間隔を調整する場合は、`gap`、`rowGap`、`columnGap`に値を渡します。

--- a/www/contents/components/(components)/simple-grid.ja.mdx
+++ b/www/contents/components/(components)/simple-grid.ja.mdx
@@ -47,9 +47,9 @@ import { SimpleGrid } from "@workspaces/ui"
 <SimpleGrid />
 ```
 
-::::tip
+:::tip
 テンプレートエリアや、より細かな行・列の配置が必要な場合は、[Grid](/docs/components/grid)の使用を検討してください。
-::::
+:::
 
 ### 間隔を調整する
 

--- a/www/contents/components/(components)/simple-grid.mdx
+++ b/www/contents/components/(components)/simple-grid.mdx
@@ -47,6 +47,10 @@ import { SimpleGrid } from "@workspaces/ui"
 <SimpleGrid />
 ```
 
+::::tip
+If you need template areas or more precise row and column placement, consider using [Grid](/docs/components/grid).
+::::
+
 ### Adjusting gaps
 
 To adjust gaps, pass values to `gap`, `rowGap`, and `columnGap`.

--- a/www/contents/components/(components)/simple-grid.mdx
+++ b/www/contents/components/(components)/simple-grid.mdx
@@ -47,9 +47,9 @@ import { SimpleGrid } from "@workspaces/ui"
 <SimpleGrid />
 ```
 
-::::tip
+:::tip
 If you need template areas or more precise row and column placement, consider using [Grid](/docs/components/grid).
-::::
+:::
 
 ### Adjusting gaps
 


### PR DESCRIPTION
Closes #7681

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add a SimpleGrid docs tip that points readers to Grid when they need template areas or more precise row and column placement.

## Current behavior (updates)

The SimpleGrid docs describe gap and child width adjustments, but do not note when Grid is better suited for advanced grid layout control.

## New behavior

Adds English and Japanese tip sections to the SimpleGrid docs linking to Grid for template areas and more precise row and column placement.

## Is this a breaking change (Yes/No):

No

## Additional Information

- `pnpm www build:content` passed.
- `git diff --check` passed.

