### PR TITLE
feat(cli): add --headless option to init, add, and update commands

### DIFF
--- a/.changeset/lucky-falcons-dream.md
+++ b/.changeset/lucky-falcons-dream.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/cli": minor
+---
+
+Added `--headless` option to `init`, `add`, and `update` commands to generate components with empty styles.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,7 @@
     "rimraf": "catalog:",
     "semver": "^7.7.4",
     "sucrase": "^3.35.1",
+    "typescript": "catalog:",
     "validate-npm-package-name": "^7.0.2",
     "yamljs": "catalog:"
   },

--- a/packages/cli/src/commands/add/index.test.ts
+++ b/packages/cli/src/commands/add/index.test.ts
@@ -51,6 +51,10 @@ vi.mock("node-fetch", () => ({
                 name: "index.ts",
                 content: `export const Button = () => {}\n`,
               },
+              {
+                name: "button.style.ts",
+                content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "red" },\n\n  defaultProps: { variant: "solid" },\n})\n`,
+              },
             ],
           }),
         ok: true,
@@ -90,7 +94,10 @@ vi.mock("node-fetch", () => ({
 
 import { add } from "."
 
-function setupProject(tempDir: string) {
+function setupProject(
+  tempDir: string,
+  overrides: { [key: string]: unknown } = {},
+) {
   const config = {
     $schema: "https://yamada-ui.com/registry/v2/config.schema.json",
     components: { overwrite: true },
@@ -100,6 +107,7 @@ function setupProject(tempDir: string) {
     monorepo: true,
     path: "./workspaces/ui",
     providers: { overwrite: true },
+    ...overrides,
   }
 
   writeFileSync(path.join(tempDir, "ui.json"), JSON.stringify(config))
@@ -605,6 +613,106 @@ describe("add", () => {
     expect(spinner.fail).toHaveBeenCalledWith(
       expect.stringContaining("unknown error"),
     )
+  })
+
+  test("should generate empty styles and record headless with --headless", async () => {
+    setupProject(tempDir)
+
+    await add.parseAsync(
+      [
+        "button",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--headless",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+      ],
+      { from: "user" },
+    )
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    const style = readFileSync(path.join(buttonDir, "button.style.ts"), "utf-8")
+    expect(style).toContain("base: {}")
+    expect(style).not.toContain("red")
+    const registry = JSON.parse(
+      readFileSync(path.join(buttonDir, "registry.json"), "utf-8"),
+    )
+    expect(registry.headless).toBeTruthy()
+  })
+
+  test("should generate empty styles without recording headless when config headless is enabled", async () => {
+    setupProject(tempDir, { components: { headless: true, overwrite: true } })
+
+    await add.parseAsync(
+      [
+        "button",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+      ],
+      { from: "user" },
+    )
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    const style = readFileSync(path.join(buttonDir, "button.style.ts"), "utf-8")
+    expect(style).toContain("base: {}")
+    expect(style).not.toContain("red")
+    const registry = JSON.parse(
+      readFileSync(path.join(buttonDir, "registry.json"), "utf-8"),
+    )
+    expect(registry.headless).toBeUndefined()
+  })
+
+  test("should generate default styles and record headless with --no-headless when config headless is enabled", async () => {
+    setupProject(tempDir, { components: { headless: true, overwrite: true } })
+
+    await add.parseAsync(
+      [
+        "button",
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-headless",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+      ],
+      { from: "user" },
+    )
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    const style = readFileSync(path.join(buttonDir, "button.style.ts"), "utf-8")
+    expect(style).toContain(`color: "red"`)
+    const registry = JSON.parse(
+      readFileSync(path.join(buttonDir, "registry.json"), "utf-8"),
+    )
+    expect(registry.headless).toBeFalsy()
   })
 
   test("should show error when all components add without overwrite and dir exists with --yes", async () => {

--- a/packages/cli/src/commands/add/index.test.ts
+++ b/packages/cli/src/commands/add/index.test.ts
@@ -646,7 +646,7 @@ describe("add", () => {
     const registry = JSON.parse(
       readFileSync(path.join(buttonDir, "registry.json"), "utf-8"),
     )
-    expect(registry.headless).toBeTruthy()
+    expect(registry).toHaveProperty("headless", true)
   })
 
   test("should generate empty styles without recording headless when config headless is enabled", async () => {
@@ -712,7 +712,7 @@ describe("add", () => {
     const registry = JSON.parse(
       readFileSync(path.join(buttonDir, "registry.json"), "utf-8"),
     )
-    expect(registry.headless).toBeFalsy()
+    expect(registry).toHaveProperty("headless", false)
   })
 
   test("should show error when all components add without overwrite and dir exists with --yes", async () => {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -39,6 +39,7 @@ interface Options {
   sequential: boolean
   yes: boolean
   format?: boolean
+  headless?: boolean
   lint?: boolean
   tag?: string
 }
@@ -57,6 +58,8 @@ export const add = new Command("add")
   .option("--no-format", "do not format the output files.")
   .option("-l, --lint", "lint the output files.")
   .option("--no-lint", "do not lint the output files.")
+  .option("--headless", "generate the component styles empty.")
+  .option("--no-headless", "generate the component styles with default values.")
   .option("-t, --tag <name>", "tag for the registries (e.g. dev, next).")
   .action(async function (
     componentNames: string[],
@@ -64,6 +67,7 @@ export const add = new Command("add")
       config: configPath,
       cwd,
       format,
+      headless,
       install,
       lint,
       overwrite,
@@ -223,17 +227,28 @@ export const add = new Command("add")
         ...new Set([...omittedGeneratedNames, ...registryNames]),
       ]
 
+      const globalHeadless = config.components?.headless ?? false
+      const componentHeadless = headless ?? globalHeadless
+      const persistHeadless =
+        !isUndefined(headless) && headless !== globalHeadless
+
       const tasks = new Listr(
         Object.entries(registries)
           .map(([name, registry]): ListrTask | undefined => {
             if (!config.isSection(registry.section)) return
 
+            const components = registry.section === "components"
             const sectionPath = config.getSectionResolvedPath(registry.section)
             const dirPath = path.join(sectionPath, name)
 
+            if (components && persistHeadless)
+              registry = { ...registry, headless }
+
             return {
               task: async (_, task) => {
-                await generateSources(dirPath, registry, config, targetNames)
+                await generateSources(dirPath, registry, config, targetNames, {
+                  headless: components && componentHeadless,
+                })
 
                 task.title = `Generated ${c.cyan(name)}`
               },

--- a/packages/cli/src/commands/diff/get-diff.test.ts
+++ b/packages/cli/src/commands/diff/get-diff.test.ts
@@ -671,4 +671,130 @@ describe("getDiff", () => {
     expect(changeMap.button).toBeDefined()
     expect(changeMap.button!["colors/red.ts"]).toBeDefined()
   })
+
+  test("should skip style value changes for headless components", async () => {
+    const config = createConfig()
+    const registryMap: RegistryMap = {
+      local: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "red" },\n})\n`,
+            },
+          ],
+        },
+      },
+      remote: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "blue" },\n})\n`,
+            },
+          ],
+        },
+      },
+    }
+
+    const { changeMap } = await getDiff(["button"], registryMap, config)
+
+    expect(changeMap.button).toBeUndefined()
+  })
+
+  test("should detect structural style changes for headless components", async () => {
+    const config = createConfig()
+    const registryMap: RegistryMap = {
+      local: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  variants: {\n    solid: { color: "red" },\n  },\n})\n`,
+            },
+          ],
+        },
+      },
+      remote: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  variants: {\n    ghost: { color: "blue" },\n    solid: { color: "red" },\n  },\n})\n`,
+            },
+          ],
+        },
+      },
+    }
+
+    const { changeMap } = await getDiff(["button"], registryMap, config)
+
+    expect(changeMap.button).toBeDefined()
+    expect(changeMap.button!["button.style.ts"]).toBeDefined()
+  })
+
+  test("should detect style changes when switching to headless", async () => {
+    const config = createConfig()
+    const content = `export const buttonStyle = defineComponentStyle({\n  base: { color: "red" },\n})\n`
+    const registryMap: RegistryMap = {
+      local: {
+        button: {
+          section: "components",
+          sources: [{ name: "button.style.ts", content }],
+        },
+      },
+      remote: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [{ name: "button.style.ts", content }],
+        },
+      },
+    }
+
+    const { changeMap } = await getDiff(["button"], registryMap, config)
+
+    expect(changeMap.button).toBeDefined()
+    expect(changeMap.button!["button.style.ts"]).toBeDefined()
+  })
+
+  test("should skip style value changes when config headless is enabled", async () => {
+    const config = { ...createConfig(), components: { headless: true } }
+    const registryMap: RegistryMap = {
+      local: {
+        button: {
+          section: "components",
+          sources: [
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "red" },\n})\n`,
+            },
+          ],
+        },
+      },
+      remote: {
+        button: {
+          section: "components",
+          sources: [
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "blue" },\n})\n`,
+            },
+          ],
+        },
+      },
+    }
+
+    const { changeMap } = await getDiff(["button"], registryMap, config)
+
+    expect(changeMap.button).toBeUndefined()
+  })
 })

--- a/packages/cli/src/commands/diff/get-diff.test.ts
+++ b/packages/cli/src/commands/diff/get-diff.test.ts
@@ -766,6 +766,38 @@ describe("getDiff", () => {
     expect(changeMap.button!["button.style.ts"]).toBeDefined()
   })
 
+  test("should transform removed style sources for headless components", async () => {
+    const config = createConfig()
+    const registryMap: RegistryMap = {
+      local: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [
+            { name: "index.ts", content: "same\n" },
+            {
+              name: "button.style.ts",
+              content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "red" },\n})\n`,
+            },
+          ],
+        },
+      },
+      remote: {
+        button: {
+          headless: true,
+          section: "components",
+          sources: [{ name: "index.ts", content: "same\n" }],
+        },
+      },
+    }
+
+    const { changeMap } = await getDiff(["button"], registryMap, config)
+
+    const data = changeMap.button!["button.style.ts"]!
+    expect("local" in data && data.local).toContain("base: {}")
+    expect("local" in data && data.local).not.toContain("red")
+  })
+
   test("should skip style value changes when config headless is enabled", async () => {
     const config = { ...createConfig(), components: { headless: true } }
     const registryMap: RegistryMap = {

--- a/packages/cli/src/commands/diff/get-diff.ts
+++ b/packages/cli/src/commands/diff/get-diff.ts
@@ -14,10 +14,12 @@ import c from "picocolors"
 import {
   getPackageName,
   isJsx,
+  isStyleFile,
   splitVersion,
   transformContent,
   transformContentWithFormatAndLint,
   transformExtension,
+  transformHeadless,
   transformIndexWithFormatAndLint,
   transformTemplateContent,
   transformTsToJs,
@@ -64,10 +66,13 @@ export async function getDiff(
 
   const tasks = new Listr(
     Object.entries(remote).map(
-      ([componentName, { dependencies, section, sources }]) =>
+      ([componentName, { dependencies, headless, section, sources }]) =>
         ({
           task: async (_, task) => {
             const localRegistry = local[componentName]!
+            const globalHeadless = config.components?.headless ?? false
+            const remoteHeadless = headless ?? globalHeadless
+            const localHeadless = localRegistry.headless ?? globalHeadless
 
             if (componentName === "index") {
               const [source] = sources
@@ -134,9 +139,23 @@ export async function getDiff(
 
               await Promise.all(
                 sources.map(async ({ name, content, data, template }) => {
-                  const source = localRegistry.sources.find(
+                  let source = localRegistry.sources.find(
                     (source) => source.name === name,
                   )
+
+                  const styleFile =
+                    section === "components" && isStyleFile(name)
+
+                  if (styleFile) {
+                    if (remoteHeadless && content)
+                      content = transformHeadless(content)
+
+                    if (localHeadless && source?.content)
+                      source = {
+                        ...source,
+                        content: transformHeadless(source.content),
+                      }
+                  }
 
                   name = transformExtension(name, config.jsx)
 
@@ -277,6 +296,13 @@ export async function getDiff(
 
               removeSources.forEach(({ name, content, data, template }) => {
                 if (content) {
+                  if (
+                    localHeadless &&
+                    section === "components" &&
+                    isStyleFile(name)
+                  )
+                    content = transformHeadless(content)
+
                   let local = transformContent(
                     section,
                     content,

--- a/packages/cli/src/commands/diff/get-registries-and-files.ts
+++ b/packages/cli/src/commands/diff/get-registries-and-files.ts
@@ -1,5 +1,6 @@
 import type { ListrTask } from "listr2"
 import type { Config, Registries } from "../../index.type"
+import { isUndefined } from "@yamada-ui/utils"
 import { Listr } from "listr2"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
@@ -27,6 +28,7 @@ export interface RegistryMap {
 
 export interface GetComponentDataOptions {
   concurrent?: boolean
+  headless?: boolean
   index?: boolean
   tag?: string
   theme?: boolean
@@ -37,6 +39,7 @@ export async function getRegistriesAndFiles(
   config: Config,
   {
     concurrent = true,
+    headless,
     index = false,
     tag,
     theme = false,
@@ -126,10 +129,9 @@ export async function getRegistriesAndFiles(
             },
             {
               task: async (_, task) => {
-                registryMap.remote[componentName] = await fetchRegistry(
-                  componentName,
-                  { tag },
-                )
+                registryMap.remote[componentName] = {
+                  ...(await fetchRegistry(componentName, { tag })),
+                }
 
                 task.title = `Fetched ${c.cyan(componentName)} registry`
               },
@@ -141,6 +143,20 @@ export async function getRegistriesAndFiles(
   )
 
   await tasks.run()
+
+  const globalHeadless = config.components?.headless ?? false
+
+  Object.entries(registryMap.remote).forEach(([componentName, registry]) => {
+    if (registry.section !== "components") return
+
+    if (isUndefined(headless)) {
+      const localHeadless = registryMap.local[componentName]?.headless
+
+      if (!isUndefined(localHeadless)) registry.headless = localHeadless
+    } else if (headless !== globalHeadless) {
+      registry.headless = headless
+    }
+  })
 
   return { fileMap, registryMap }
 }

--- a/packages/cli/src/commands/init/index.test.ts
+++ b/packages/cli/src/commands/init/index.test.ts
@@ -105,6 +105,17 @@ describe("init", () => {
     )
   })
 
+  test("should set headless in config with --headless", async () => {
+    await init.parseAsync(
+      ["--cwd", tempDir, "--yes", "--monorepo", "--headless", "--no-install"],
+      { from: "user" },
+    )
+
+    const configPath = path.join(tempDir, "ui.json")
+    const config = JSON.parse(readFileSync(configPath, "utf-8"))
+    expect(config.components.headless).toBeTruthy()
+  })
+
   test("should generate monorepo with jsx", async () => {
     await init.parseAsync(
       ["--cwd", tempDir, "--yes", "--monorepo", "--jsx", "--no-install"],

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -44,6 +44,7 @@ import {
 interface Options {
   config: string
   cwd: string
+  headless: boolean
   jsx: boolean
   overwrite: boolean
   yes: boolean
@@ -78,12 +79,14 @@ export const init = new Command("init")
   .option("--no-format", "do not use Prettier.")
   .option("-l, --lint", "use ESLint.")
   .option("--no-lint", "do not use ESLint.")
+  .option("--headless", "generate the component styles empty.", false)
   .option("--outdir <path>", "output directory path.")
   .action(async function ({
     src,
     config: configPath,
     cwd,
     format,
+    headless,
     install,
     jsx,
     lint,
@@ -186,6 +189,7 @@ export const init = new Command("init")
 
       if (monorepo) config.monorepo = monorepo
       if (jsx) config.jsx = jsx
+      if (headless) config.components = { ...config.components, headless }
 
       config.path = outdir
       config.format = { enabled: format }

--- a/packages/cli/src/commands/update/index.test.ts
+++ b/packages/cli/src/commands/update/index.test.ts
@@ -35,6 +35,10 @@ vi.mock("node-fetch", () => ({
                 name: "index.ts",
                 content: `export const Button = () => {}\n`,
               },
+              {
+                name: "button.style.ts",
+                content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "blue" },\n})\n`,
+              },
             ],
           }),
         ok: true,
@@ -126,6 +130,123 @@ describe("update", () => {
 
   afterEach(() => {
     rmSync(tempDir, { force: true, recursive: true })
+  })
+
+  test("should skip style value changes for headless components", async () => {
+    setupProjectWithComponent(tempDir)
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    writeFileSync(
+      path.join(buttonDir, "registry.json"),
+      JSON.stringify({
+        dependencies: {
+          components: [],
+          externals: [],
+          hooks: [],
+          providers: [],
+        },
+        headless: true,
+        section: "components",
+        sources: [
+          { name: "index.ts", content: `export const Button = () => {}\n` },
+          {
+            name: "button.style.ts",
+            content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "red" },\n})\n`,
+          },
+        ],
+      }),
+    )
+
+    vi.mocked(console.log).mockClear()
+
+    await update.parseAsync(
+      [
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--force",
+      ],
+      { from: "user" },
+    )
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("No updates found."),
+    )
+  })
+
+  test("should switch component to headless with --headless", async () => {
+    setupProjectWithComponent(tempDir)
+
+    const buttonDir = path.join(
+      tempDir,
+      "workspaces",
+      "ui",
+      "src",
+      "components",
+      "button",
+    )
+    writeFileSync(
+      path.join(buttonDir, "registry.json"),
+      JSON.stringify({
+        dependencies: {
+          components: [],
+          externals: [],
+          hooks: [],
+          providers: [],
+        },
+        section: "components",
+        sources: [
+          { name: "index.ts", content: `export const Button = () => {}\n` },
+          {
+            name: "button.style.ts",
+            content: `export const buttonStyle = defineComponentStyle({\n  base: { color: "blue" },\n})\n`,
+          },
+        ],
+      }),
+    )
+
+    const { updateFiles } = await import("./update-files")
+    vi.mocked(updateFiles).mockClear()
+
+    await update.parseAsync(
+      [
+        "--cwd",
+        tempDir,
+        "--yes",
+        "--headless",
+        "--no-install",
+        "--no-format",
+        "--no-lint",
+        "--force",
+      ],
+      { from: "user" },
+    )
+
+    expect(updateFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        button: expect.objectContaining({
+          "button.style.ts": expect.anything(),
+        }),
+      }),
+      expect.anything(),
+      expect.objectContaining({
+        remote: expect.objectContaining({
+          button: expect.objectContaining({ headless: true }),
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    )
   })
 
   test("should update all components", async () => {

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -26,6 +26,7 @@ interface Options {
   sequential: boolean
   yes: boolean
   format?: boolean
+  headless?: boolean
   install?: boolean
   lint?: boolean
   tag?: string
@@ -45,6 +46,8 @@ export const update = new Command("update")
   .option("--no-format", "do not format the output files.")
   .option("-l, --lint", "lint the output files.")
   .option("--no-lint", "do not lint the output files.")
+  .option("--headless", "update the component styles to empty.")
+  .option("--no-headless", "update the component styles to default values.")
   .option("-t, --tag <name>", "tag for the registries (e.g. dev, next).")
   .action(async function (
     targetNames: string[],
@@ -53,6 +56,7 @@ export const update = new Command("update")
       cwd,
       force,
       format,
+      headless,
       install,
       lint,
       sequential,
@@ -140,7 +144,7 @@ export const update = new Command("update")
       const { registryMap } = await getRegistriesAndFiles(
         componentNames,
         config,
-        { concurrent: !sequential, index, tag, theme },
+        { concurrent: !sequential, headless, index, tag, theme },
       )
       const { changeMap, dependencyMap } = await getDiff(
         generatedNames,

--- a/packages/cli/src/index.type.ts
+++ b/packages/cli/src/index.type.ts
@@ -7,6 +7,10 @@ export interface SectionConfig {
   path?: string
 }
 
+export interface ComponentSectionConfig extends SectionConfig {
+  headless?: boolean
+}
+
 export interface ThemeConfig {
   path?: string
 }
@@ -22,7 +26,7 @@ export interface FormatConfig {
 
 export interface UserConfig {
   $schema?: string
-  components?: SectionConfig
+  components?: ComponentSectionConfig
   format?: FormatConfig
   hooks?: SectionConfig
   jsx?: boolean
@@ -90,6 +94,7 @@ export interface Registry {
   sources: Source[]
   dependencies?: Dependencies
   dependents?: Dependents
+  headless?: boolean
 }
 
 export interface Registries {

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./style"
 export * from "./config"
 export * from "./fs"
 export * from "./git"

--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -23,6 +23,7 @@ import {
 import { writeFileSafe } from "./fs"
 import { lintText } from "./lint"
 import { formatText } from "./prettier"
+import { isStyleFile, transformHeadless } from "./style"
 import {
   isJsx,
   transformExtension,
@@ -401,18 +402,27 @@ export async function transformIndexWithFormatAndLint(
   return content
 }
 
+export interface GenerateSourceOptions {
+  headless?: boolean
+}
+
 export async function generateSource(
   dirPath: string,
   section: RegistrySection,
   { name: fileName, content, data, template }: Source,
   config: Config,
   generatedNames: string[] = [],
+  { headless }: GenerateSourceOptions = {},
 ) {
+  const styleFile = section === "components" && isStyleFile(fileName)
+
   fileName = transformExtension(fileName, config.jsx)
 
   const targetPath = path.resolve(dirPath, fileName)
 
   if (content) {
+    if (headless && styleFile) content = transformHeadless(content)
+
     content = transformContent(section, content, config, generatedNames)
 
     if (config.jsx)
@@ -446,10 +456,18 @@ export async function generateSources(
   registry: Registry,
   config: Config,
   generatedNames: string[] = [],
+  options: GenerateSourceOptions = {},
 ) {
   await Promise.all([
     ...registry.sources.map((source) =>
-      generateSource(dirPath, registry.section, source, config, generatedNames),
+      generateSource(
+        dirPath,
+        registry.section,
+        source,
+        config,
+        generatedNames,
+        options,
+      ),
     ),
     writeFileSafe(
       path.resolve(dirPath, REGISTRY_FILE_NAME),

--- a/packages/cli/src/utils/style.test.ts
+++ b/packages/cli/src/utils/style.test.ts
@@ -1,0 +1,143 @@
+import { isStyleFile, transformHeadless } from "./style"
+
+describe("isStyleFile", () => {
+  test.each([
+    ["button.style.ts", true],
+    ["index.ts", false],
+    ["button.tsx", false],
+  ])("isStyleFile(%s) returns %s", (fileName, expected) => {
+    expect(isStyleFile(fileName)).toBe(expected)
+  })
+})
+
+describe("transformHeadless", () => {
+  test("should empty style values while preserving structure", () => {
+    const content = `import { defineComponentStyle } from "../../core"
+
+export const buttonStyle = defineComponentStyle({
+  base: {
+    alignItems: "center",
+    _hover: { color: "red" },
+  },
+
+  props: {
+    /**
+     * If \`true\`, the button is full rounded.
+     *
+     * @default false
+     */
+    fullRounded: {
+      true: { rounded: "full" },
+    },
+  },
+
+  variants: {
+    ghost: { layerStyle: "ghost" },
+    solid: { layerStyle: "solid" },
+  },
+
+  sizes: {
+    sm: { fontSize: "sm" },
+    md: { fontSize: "md" },
+  },
+
+  compounds: [{ css: { color: "red" }, variant: "solid" }],
+
+  defaultProps: {
+    size: "md",
+    variant: "solid",
+  },
+})
+
+export type ButtonStyle = typeof buttonStyle
+`
+
+    expect(transformHeadless(content))
+      .toBe(`import { defineComponentStyle } from "../../core"
+
+export const buttonStyle = defineComponentStyle({
+  base: {},
+
+  props: {
+    /**
+     * If \`true\`, the button is full rounded.
+     *
+     * @default false
+     */
+    fullRounded: {
+      true: {},
+    },
+  },
+
+  variants: {
+    ghost: {},
+    solid: {},
+  },
+
+  sizes: {
+    sm: {},
+    md: {},
+  },
+
+  compounds: [],
+
+  defaultProps: {},
+})
+
+export type ButtonStyle = typeof buttonStyle
+`)
+  })
+
+  test("should preserve slot keys and references in slot style", () => {
+    const content = `import { defineComponentSlotStyle } from "../../core"
+import { nativeAccordionStyle } from "../native-accordion"
+
+export const accordionStyle = defineComponentSlotStyle({
+  base: {
+    ...nativeAccordionStyle.base,
+    button: {
+      ...nativeAccordionStyle.base?.button,
+      "&[aria-disabled=true]": { cursor: "default" },
+    },
+    panel: { ...nativeAccordionStyle.base?.panel, pb: "3" },
+    root: { w: "full" },
+  },
+
+  variants: nativeAccordionStyle.variants,
+
+  defaultProps: {
+    variant: "plain",
+    animate: true,
+  },
+})
+
+export type AccordionStyle = typeof accordionStyle
+`
+
+    expect(transformHeadless(content))
+      .toBe(`import { defineComponentSlotStyle } from "../../core"
+import { nativeAccordionStyle } from "../native-accordion"
+
+export const accordionStyle = defineComponentSlotStyle({
+  base: {
+    ...nativeAccordionStyle.base,
+    button: { ...nativeAccordionStyle.base?.button },
+    panel: { ...nativeAccordionStyle.base?.panel },
+    root: {},
+  },
+
+  variants: nativeAccordionStyle.variants,
+
+  defaultProps: { animate: true },
+})
+
+export type AccordionStyle = typeof accordionStyle
+`)
+  })
+
+  test("should return content without style definitions unchanged", () => {
+    const content = `export const Button = () => {}\n`
+
+    expect(transformHeadless(content)).toBe(content)
+  })
+})

--- a/packages/cli/src/utils/style.test.ts
+++ b/packages/cli/src/utils/style.test.ts
@@ -140,4 +140,21 @@ export type AccordionStyle = typeof accordionStyle
 
     expect(transformHeadless(content)).toBe(content)
   })
+
+  test("should keep unknown properties unchanged", () => {
+    const content = `export const buttonStyle = defineComponentStyle({
+  className: "button",
+
+  base: { color: "red" },
+})
+`
+
+    expect(transformHeadless(content))
+      .toBe(`export const buttonStyle = defineComponentStyle({
+  className: "button",
+
+  base: {},
+})
+`)
+  })
 })

--- a/packages/cli/src/utils/style.ts
+++ b/packages/cli/src/utils/style.ts
@@ -1,0 +1,147 @@
+import ts from "typescript"
+
+const DEFINE_STYLE_NAMES = ["defineComponentSlotStyle", "defineComponentStyle"]
+const OMITTED_DEFAULT_PROPS = ["colorScheme", "size", "variant"]
+
+interface Edit {
+  end: number
+  start: number
+  text: string
+}
+
+export function isStyleFile(fileName: string) {
+  return fileName.endsWith(".style.ts")
+}
+
+export function transformHeadless(content: string) {
+  const sourceFile = ts.createSourceFile(
+    "style.ts",
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+  )
+  const edits: Edit[] = []
+
+  function getEmptyText(node: ts.ObjectLiteralExpression) {
+    const spreads = node.properties
+      .filter((property) => ts.isSpreadAssignment(property))
+      .map((property) => property.getText(sourceFile))
+
+    return spreads.length ? `{ ${spreads.join(", ")} }` : "{}"
+  }
+
+  function emptyObject(node: ts.Expression) {
+    if (!ts.isObjectLiteralExpression(node)) return
+
+    edits.push({
+      end: node.getEnd(),
+      start: node.getStart(sourceFile),
+      text: getEmptyText(node),
+    })
+  }
+
+  function emptyValues(node: ts.Expression) {
+    if (!ts.isObjectLiteralExpression(node)) return
+
+    node.properties.forEach((property) => {
+      if (ts.isPropertyAssignment(property)) emptyObject(property.initializer)
+    })
+  }
+
+  function omitDefaultProps(node: ts.Expression) {
+    if (!ts.isObjectLiteralExpression(node)) return
+
+    const properties = node.properties.filter(
+      (property) =>
+        !(
+          ts.isPropertyAssignment(property) &&
+          OMITTED_DEFAULT_PROPS.includes(property.name.getText(sourceFile))
+        ),
+    )
+
+    if (properties.length === node.properties.length) return
+
+    const text = properties.length
+      ? `{ ${properties.map((property) => property.getText(sourceFile)).join(", ")} }`
+      : "{}"
+
+    edits.push({ end: node.getEnd(), start: node.getStart(sourceFile), text })
+  }
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      DEFINE_STYLE_NAMES.includes(node.expression.text)
+    ) {
+      const slot = node.expression.text === "defineComponentSlotStyle"
+      const [arg] = node.arguments
+
+      if (arg && ts.isObjectLiteralExpression(arg)) {
+        arg.properties.forEach((property) => {
+          if (!ts.isPropertyAssignment(property)) return
+
+          const name = property.name.getText(sourceFile)
+          const value = property.initializer
+
+          switch (name) {
+            case "base":
+              if (slot) {
+                emptyValues(value)
+              } else {
+                emptyObject(value)
+              }
+
+              break
+
+            case "compounds":
+              if (ts.isArrayLiteralExpression(value))
+                edits.push({
+                  end: value.getEnd(),
+                  start: value.getStart(sourceFile),
+                  text: "[]",
+                })
+
+              break
+
+            case "defaultProps":
+              omitDefaultProps(value)
+
+              break
+
+            case "props":
+              if (ts.isObjectLiteralExpression(value)) {
+                value.properties.forEach((property) => {
+                  if (ts.isPropertyAssignment(property))
+                    emptyValues(property.initializer)
+                })
+              }
+
+              break
+
+            case "sizes":
+            case "variants":
+              emptyValues(value)
+
+              break
+
+            default:
+              break
+          }
+        })
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  return edits
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (content, { end, start, text }) =>
+        content.slice(0, start) + text + content.slice(end),
+      content,
+    )
+}

--- a/packages/cli/src/utils/style.ts
+++ b/packages/cli/src/utils/style.ts
@@ -1,4 +1,15 @@
-import ts from "typescript"
+import type { Expression, Node, ObjectLiteralExpression } from "typescript"
+import {
+  createSourceFile,
+  forEachChild,
+  isArrayLiteralExpression,
+  isCallExpression,
+  isIdentifier,
+  isObjectLiteralExpression,
+  isPropertyAssignment,
+  isSpreadAssignment,
+  ScriptTarget,
+} from "typescript"
 
 const DEFINE_STYLE_NAMES = ["defineComponentSlotStyle", "defineComponentStyle"]
 const OMITTED_DEFAULT_PROPS = ["colorScheme", "size", "variant"]
@@ -14,24 +25,24 @@ export function isStyleFile(fileName: string) {
 }
 
 export function transformHeadless(content: string) {
-  const sourceFile = ts.createSourceFile(
+  const sourceFile = createSourceFile(
     "style.ts",
     content,
-    ts.ScriptTarget.Latest,
+    ScriptTarget.Latest,
     true,
   )
   const edits: Edit[] = []
 
-  function getEmptyText(node: ts.ObjectLiteralExpression) {
+  function getEmptyText(node: ObjectLiteralExpression) {
     const spreads = node.properties
-      .filter((property) => ts.isSpreadAssignment(property))
+      .filter((property) => isSpreadAssignment(property))
       .map((property) => property.getText(sourceFile))
 
     return spreads.length ? `{ ${spreads.join(", ")} }` : "{}"
   }
 
-  function emptyObject(node: ts.Expression) {
-    if (!ts.isObjectLiteralExpression(node)) return
+  function emptyObject(node: Expression) {
+    if (!isObjectLiteralExpression(node)) return
 
     edits.push({
       end: node.getEnd(),
@@ -40,21 +51,21 @@ export function transformHeadless(content: string) {
     })
   }
 
-  function emptyValues(node: ts.Expression) {
-    if (!ts.isObjectLiteralExpression(node)) return
+  function emptyValues(node: Expression) {
+    if (!isObjectLiteralExpression(node)) return
 
     node.properties.forEach((property) => {
-      if (ts.isPropertyAssignment(property)) emptyObject(property.initializer)
+      if (isPropertyAssignment(property)) emptyObject(property.initializer)
     })
   }
 
-  function omitDefaultProps(node: ts.Expression) {
-    if (!ts.isObjectLiteralExpression(node)) return
+  function omitDefaultProps(node: Expression) {
+    if (!isObjectLiteralExpression(node)) return
 
     const properties = node.properties.filter(
       (property) =>
         !(
-          ts.isPropertyAssignment(property) &&
+          isPropertyAssignment(property) &&
           OMITTED_DEFAULT_PROPS.includes(property.name.getText(sourceFile))
         ),
     )
@@ -68,18 +79,18 @@ export function transformHeadless(content: string) {
     edits.push({ end: node.getEnd(), start: node.getStart(sourceFile), text })
   }
 
-  function visit(node: ts.Node) {
+  function visit(node: Node) {
     if (
-      ts.isCallExpression(node) &&
-      ts.isIdentifier(node.expression) &&
+      isCallExpression(node) &&
+      isIdentifier(node.expression) &&
       DEFINE_STYLE_NAMES.includes(node.expression.text)
     ) {
       const slot = node.expression.text === "defineComponentSlotStyle"
       const [arg] = node.arguments
 
-      if (arg && ts.isObjectLiteralExpression(arg)) {
+      if (arg && isObjectLiteralExpression(arg)) {
         arg.properties.forEach((property) => {
-          if (!ts.isPropertyAssignment(property)) return
+          if (!isPropertyAssignment(property)) return
 
           const name = property.name.getText(sourceFile)
           const value = property.initializer
@@ -95,7 +106,7 @@ export function transformHeadless(content: string) {
               break
 
             case "compounds":
-              if (ts.isArrayLiteralExpression(value))
+              if (isArrayLiteralExpression(value))
                 edits.push({
                   end: value.getEnd(),
                   start: value.getStart(sourceFile),
@@ -110,9 +121,9 @@ export function transformHeadless(content: string) {
               break
 
             case "props":
-              if (ts.isObjectLiteralExpression(value)) {
+              if (isObjectLiteralExpression(value)) {
                 value.properties.forEach((property) => {
-                  if (ts.isPropertyAssignment(property))
+                  if (isPropertyAssignment(property))
                     emptyValues(property.initializer)
                 })
               }
@@ -132,7 +143,7 @@ export function transformHeadless(content: string) {
       }
     }
 
-    ts.forEachChild(node, visit)
+    forEachChild(node, visit)
   }
 
   visit(sourceFile)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       sucrase:
         specifier: ^3.35.1
         version: 3.35.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
       validate-npm-package-name:
         specifier: ^7.0.2
         version: 7.0.2

--- a/www/public/registry/v2/config.schema.json
+++ b/www/public/registry/v2/config.schema.json
@@ -73,6 +73,11 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to include dependents when adding components."
+        },
+        "headless": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to generate the components with empty styles."
         }
       }
     },

--- a/www/public/registry/v2/schema.json
+++ b/www/public/registry/v2/schema.json
@@ -65,6 +65,11 @@
       },
       "required": ["components", "hooks", "providers"]
     },
+    "headless": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether the registry styles are generated empty."
+    },
     "section": {
       "type": "string",
       "description": "The section of the registry.",


### PR DESCRIPTION
Closes #6232

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds a `--headless` option to the `init`, `add`, and `update` commands so users can generate components with empty styles, following the requirements agreed upon in #6232.

## Current behavior (updates)

Users who want headless (unstyled) components must manually empty all `*.style.ts` files after running `init` or `add`. There is no way to express "I want headless" at the CLI level, and the update logic has no way to know which components should keep empty styles.

## New behavior

### `init`

- `--headless` sets `components.headless: true` in `ui.json`. Based on this value, the `--headless` option can be omitted when using the `add`, `update`, and `diff` commands.

### `add`

- `--headless` / `--no-headless` override the global `components.headless` setting per component.
- If the flag matches the global setting, it is ignored. Otherwise, `headless: true | false` is persisted in the component's `registry.json`, so mixed headless/headed projects are supported in both directions.
- When the effective value is headless, `*.style.ts` files are generated with empty style values.

### `update`

- Resolves the effective headless per component: `registry.json` entry → `components.headless` in `ui.json` → `false`.
- For headless components, both the local baseline and the remote content are converted to headless before comparison, so style-value-only upstream changes are skipped while structural changes (new variants, slots, props) are still detected and merged.
- `--headless` / `--no-headless` switch a component mid-project. The switch goes through the existing diff3 merge, so local changes are preserved or surfaced as conflicts as usual.

### `diff`

- Excludes style-value differences for headless components and only shows structural changes. No new flags; it follows the persisted state.

### Style conversion (local, AST-based)

As agreed in the issue, the conversion is performed locally. A new `transformHeadless` utility parses the style file and:

- empties style values while preserving structure (slot keys, variant/size names, prop keys, and JSDoc comments)
- retains referenced values as-is (e.g. `variants: nativeAccordionStyle.variants`), and keeps spreads while dropping inline styles (`{ ...nativeAccordionStyle.base?.button, css }` → `{ ...nativeAccordionStyle.base?.button }`)
- keeps non-style defaults in `defaultProps` (e.g. `animate: true`) while removing `variant`, `size`, and `colorScheme`
- empties `compounds` to `[]`

The output was verified to match the expected results posted in the issue for `button`, `accordion`, and `native-accordion`, and all 129 `*.style.ts` files in `packages/react` were verified to transform without parse errors.

## Is this a breaking change (Yes/No):

No. All new options are opt-in, and the `headless` field in `ui.json` / `registry.json` is optional, so existing projects are unaffected.

## Additional Information

This PR adds `typescript` (already in the workspace catalog) as a runtime dependency of `@yamada-ui/cli` to parse style files. Alternatives were considered and rejected:

- `esbuild` / `sucrase` (existing dependencies) do not expose an AST.
- `eslint` (espree) cannot parse TS-only syntax such as `export type`.
- Evaluating the module (existing `getModule` utility) loses JSDoc comments and reference expressions, which must be preserved.
- Regex-based parsing is fragile, as discussed in the issue.

The TypeScript compiler API is already the repository's standard approach for this kind of work (`gen:registries`, `gen:styles`, `gen:props`).
