### PR TITLE
fix(icon): avoid fake default size token

### DIFF
--- a/.changeset/silver-icons-smile.md
+++ b/.changeset/silver-icons-smile.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Avoid generating a fake font size token fallback for the default Icon size.

--- a/packages/react/src/components/icon/icon.style.ts
+++ b/packages/react/src/components/icon/icon.style.ts
@@ -2,10 +2,10 @@ import { defineComponentStyle } from "../../core"
 
 export const iconStyle = defineComponentStyle({
   base: {
+    "--size": "1em",
     color: "currentColor",
     display: "inline-block",
     flexShrink: 0,
-    fontSize: "1em",
     lineHeight: "1em",
   },
 })


### PR DESCRIPTION
Closes #7690

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Moves the default Icon size from fontSize to the --size variable so the literal `1em` is not treated as a fontSizes token candidate.

## Current behavior (updates)

Default Icon styles can emit `--size: var(--fontSizes1em, 1em)` even though `fontSizes.1em` is not a real token.

## New behavior

Default Icon styles set `--size: 1em` directly while preserving `boxSize: "{size}"` usage for width and height.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Verified with `pnpm react test:jsdom --run src/components/icon/`.