### PR TITLE
fix(lefthook): allow ignored files in format hook

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -91,7 +91,7 @@ pre-commit:
 
     - name: format
       glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts,md,mdx,yaml,yml,json,html,css}"
-      run: pnpm exec oxfmt {staged_files} --write
+      run: pnpm exec oxfmt {staged_files} --write --no-error-on-unmatched-pattern
       stage_fixed: true
 
 commit-msg:


### PR DESCRIPTION
Closes #7699

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds `--no-error-on-unmatched-pattern` to the pre-commit format hook so ignored-only staged files can pass the hook.

## Current behavior (updates)

A commit that only stages files ignored by `oxfmt`, such as `pnpm-lock.yaml`, fails because `oxfmt` exits with an unmatched target error.

## New behavior

The format hook still formats supported staged files, but ignored-only staged files are treated as a successful no-op.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified with:

- `pnpm exec oxfmt pnpm-lock.yaml --write --no-error-on-unmatched-pattern`
- `pnpm exec oxfmt lefthook.yaml pnpm-lock.yaml --check --no-error-on-unmatched-pattern`
- `pnpm exec lefthook run pre-commit --job format --file pnpm-lock.yaml --force`
