### PR TITLE
fix(dependabot): push updates with PAT token

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           ref: ${{ github.head_ref }}
 
       - name: Install


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates the Dependabot workflow checkout token to use `PAT_TOKEN`, matching the release workflow pattern.

## Current behavior (updates)

The Dependabot workflow pushes generated updates with `GITHUB_TOKEN`. The follow-up `pull_request` workflows for that bot-pushed commit can end up as `action_required` with no jobs.

## New behavior

The Dependabot workflow checks out with `PAT_TOKEN`, so generated updates are pushed by the PAT owner and subsequent checks can run normally.

## Is this a breaking change (Yes/No):

No

## Additional Information

No issue is linked by request.
