### PR TITLE
docs(pr): clarify issue linking guidance

### DIFF
--- a/.agents/rules/pr.md
+++ b/.agents/rules/pr.md
@@ -3,7 +3,9 @@
 Read the [template](../../.github/pull_request_template.md) and use its structure for the PR body. Replace the HTML comments with actual content.
 
 - Use the same format as the commit message for the title.
-- Always include `Closes #<issue-number>`.
+- Include `Closes #<issue-number>` when the PR resolves a tracked issue.
+- In principle, PRs should have a linked issue. However, an issue link is not required for small maintenance changes, follow-up fixes, dependency/workflow adjustments, or when the maintainer explicitly instructs to create a PR without an issue.
+- If no issue is linked, briefly explain why in the PR body.
 - Clearly state whether this is a breaking change.
 - The template includes an "AI used" section. If AI generated the PR, uncheck "I did not use AI" and check "I checked the generated content before submitting."
 


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Clarifies that linking an issue from a PR is the default expectation, not an absolute requirement.

## Current behavior (updates)

The PR rules say to always include `Closes #<issue-number>`, which can be interpreted as a hard requirement even for small maintenance changes or maintainer-directed exceptions.

## New behavior

The rule now says to include `Closes #<issue-number>` when resolving a tracked issue, explains that issue links are expected in principle, and documents allowed exceptions. It also asks authors to briefly explain why no issue is linked.

## Is this a breaking change (Yes/No):

No

## Additional Information

No issue is linked because this PR updates the issue-linking guidance itself and was requested as a maintainer-directed rule clarification.
