### PR TITLE
fix(www): pin stackblitz vite dependencies

### DIFF
--- a/www/libs/stackblitz.ts
+++ b/www/libs/stackblitz.ts
@@ -419,8 +419,8 @@ const PACKAGE = {
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
-    typescript: "^6",
-    vite: "^8",
+    typescript: "^5",
+    vite: "^7",
     "vite-tsconfig-paths": "^6",
   },
 }


### PR DESCRIPTION
Closes #7705

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Pins the generated StackBlitz example template to Vite 7 and TypeScript 5 compatible ranges.

## Current behavior (updates)

The generated StackBlitz project can resolve `vite@8` and `typescript@6`, causing peer dependency warnings and a WebContainer Rolldown runtime failure when starting Vite.

## New behavior

The generated StackBlitz project resolves Vite 7 and TypeScript 5 ranges that are compatible with the current React plugin and StackBlitz WebContainer environment.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified by `git diff --check` and commit hooks for the changed `www` file.
