### PR TITLE
build(deps): update js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,11 @@
       "axios": "^1.15.0",
       "esbuild@>=0.27.3 <0.28.1": "0.28.1",
       "follow-redirects": "^1.16.0",
+      "js-yaml": "^4.2.0",
       "jsdom": "29.0.1"
+    },
+    "patchedDependencies": {
+      "read-yaml-file@1.1.0": "patches/read-yaml-file@1.1.0.patch"
     }
   }
 }

--- a/patches/read-yaml-file@1.1.0.patch
+++ b/patches/read-yaml-file@1.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index bcb70193b4bf60c5a1d021a6756adf5f81d67ac6..aebe7d24cf2fb19f9aa483261126a3f3f46f51c6 100644
+--- a/index.js
++++ b/index.js
+@@ -5,7 +5,7 @@ const pify = require('pify')
+ const stripBom = require('strip-bom')
+ const yaml = require('js-yaml')
+ 
+-const parse = data => yaml.safeLoad(stripBom(data))
++const parse = data => yaml.load(stripBom(data))
+ 
+ const readYamlFile = fp => pify(fs.readFile)(fp, 'utf8').then(data => parse(data))
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,7 +122,13 @@ overrides:
   axios: ^1.15.0
   esbuild@>=0.27.3 <0.28.1: 0.28.1
   follow-redirects: ^1.16.0
+  js-yaml: ^4.2.0
   jsdom: 29.0.1
+
+patchedDependencies:
+  read-yaml-file@1.1.0:
+    hash: 488393f543748b1b0a4fbe3524f9536a55b385493bcf9c0c7c94a2e624ebf4f6
+    path: patches/read-yaml-file@1.1.0.patch
 
 importers:
 
@@ -849,9 +855,6 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       hast-util-heading-rank:
         specifier: ^3.0.0
         version: 3.0.0
@@ -891,6 +894,9 @@ importers:
       velite:
         specifier: ^0.3.1
         version: 0.3.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -5883,10 +5889,6 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
-  extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
-    engines: {node: '>=0.10.0'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -6203,10 +6205,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==, tarball: https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz}
     engines: {node: '>=20.11.1'}
@@ -6416,10 +6414,6 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-
-  is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==, tarball: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz}
@@ -6735,14 +6729,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -8217,10 +8203,6 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==, tarball: https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz}
 
-  section-matter@1.0.0:
-    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
-    engines: {node: '>=4'}
-
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -8466,10 +8448,6 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
-
-  strip-bom-string@1.0.0:
-    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
-    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -9268,11 +9246,11 @@ packages:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@1.10.3:
-    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==, tarball: https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz}
     engines: {node: '>= 6'}
 
   yaml@2.9.0:
-    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==, tarball: https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -9910,7 +9888,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -10827,7 +10805,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -11070,7 +11048,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 1.1.0(patch_hash=488393f543748b1b0a4fbe3524f9536a55b385493bcf9c0c7c94a2e624ebf4f6)
 
   '@mdn/browser-compat-data@7.3.17': {}
 
@@ -13595,7 +13573,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14238,10 +14216,6 @@ snapshots:
 
   exsolve@1.0.8: {}
 
-  extend-shallow@2.0.1:
-    dependencies:
-      is-extendable: 0.1.1
-
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
@@ -14562,13 +14536,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
-
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
@@ -14815,8 +14782,6 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
-
-  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -15330,15 +15295,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -16866,10 +16822,10 @@ snapshots:
 
   react@19.2.7: {}
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@1.1.0(patch_hash=488393f543748b1b0a4fbe3524f9536a55b385493bcf9c0c7c94a2e624ebf4f6):
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -17220,11 +17176,6 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  section-matter@1.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-      kind-of: 6.0.3
-
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -17527,8 +17478,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
-
-  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 

--- a/www/package.json
+++ b/www/package.json
@@ -69,7 +69,6 @@
     "commander": "catalog:",
     "dotenv": "catalog:",
     "github-slugger": "^2.0.0",
-    "gray-matter": "^4.0.3",
     "hast-util-heading-rank": "^3.0.0",
     "hast-util-to-string": "^3.0.1",
     "hastscript": "^9.0.1",
@@ -82,6 +81,7 @@
     "sucrase": "catalog:",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
-    "velite": "^0.3.1"
+    "velite": "^0.3.1",
+    "yaml": "^2.9.0"
   }
 }

--- a/www/scripts/generate/relations.ts
+++ b/www/scripts/generate/relations.ts
@@ -1,10 +1,10 @@
 import { isUndefined } from "@yamada-ui/utils"
 import { writeFileWithFormat } from "@yamada-ui/workspace/oxfmt"
-import matter from "gray-matter"
 import { glob, readdir, readFile } from "node:fs/promises"
 import path from "node:path"
 import ora from "ora"
 import c from "picocolors"
+import { matter } from "@/utils/markdown/matter"
 
 const MIN_RESEMBLE_SCORE = 0.3
 const MAX_RESEMBLE_COUNT = 8

--- a/www/utils/markdown/index.ts
+++ b/www/utils/markdown/index.ts
@@ -1,5 +1,6 @@
 export * from "./create-front-matter"
 export * from "./extract-toc"
+export * from "./matter"
 export * from "./replace-card-group"
 export * from "./replace-code-block"
 export * from "./replace-code-group"

--- a/www/utils/markdown/matter.ts
+++ b/www/utils/markdown/matter.ts
@@ -1,0 +1,14 @@
+import { parse } from "yaml"
+
+const regex = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/
+
+export function matter(content: string) {
+  const match = content.match(regex)
+
+  if (!match) return { content, data: {} as { [key: string]: any } }
+
+  return {
+    content: content.slice(match[0].length),
+    data: (parse(match[1] ?? "") ?? {}) as { [key: string]: any },
+  }
+}

--- a/www/utils/markdown/replace-relations.ts
+++ b/www/utils/markdown/replace-relations.ts
@@ -1,10 +1,10 @@
 import type { Relations } from "@/data"
 import type { Locale } from "@/utils/i18n"
-import matter from "gray-matter"
 import { glob, readFile } from "node:fs/promises"
 import path from "node:path"
 import data from "@/data/relations.json"
 import { getLang } from "@/utils/i18n"
+import { matter } from "./matter"
 
 const relations = data as Relations
 

--- a/www/utils/rehype-plugins/rehype-slug.ts
+++ b/www/utils/rehype-plugins/rehype-slug.ts
@@ -2,14 +2,13 @@ import type { Element } from "hast"
 import type { Root } from "mdast"
 import type { Plugin } from "unified"
 import GithubSlugger from "github-slugger"
-import matter from "gray-matter"
 import { headingRank } from "hast-util-heading-rank"
 import { toString } from "hast-util-to-string"
 import { readFile } from "node:fs/promises"
 import { visit } from "unist-util-visit"
 import { CONSTANTS } from "@/constants"
 import { getLocale, langs } from "@/utils/i18n"
-import { replaceProps } from "@/utils/markdown"
+import { matter, replaceProps } from "@/utils/markdown"
 
 function extractSlugs(content: string) {
   const slugger = new GithubSlugger()


### PR DESCRIPTION
Closes: N/A (resolves Dependabot alert #203)

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates all `js-yaml` resolutions to `4.2.0` to address the Dependabot security alert.

## Current behavior (updates)

The lockfile includes vulnerable `js-yaml` versions through transitive tooling dependencies.

## New behavior

The lockfile resolves `js-yaml` to `4.2.0`, removes the `gray-matter` dependency from `www`, and patches `read-yaml-file` to use `yaml.load` with js-yaml v4.

## Is this a breaking change (Yes/No):

No

## Additional Information

Verified with `pnpm why js-yaml -r`, `pnpm changeset status --since=origin/main`, `pnpm www gen:relations`, `pnpm www build:content`, and `pnpm install --frozen-lockfile`.