### PR TITLE
ci(lefthook): ignore unmatched oxlint patterns

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -9,84 +9,84 @@ pre-commit:
             root: packages/cli/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: react
             root: packages/react/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: utils
             root: packages/utils/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: workspace
             root: packages/workspace/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: forge
             root: packages/forge/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: www
             root: www/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: next-app
             root: playgrounds/next/app/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: next-pages
             root: playgrounds/next/pages/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: react-router-framework
             root: playgrounds/react-router/framework/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: vite
             root: playgrounds/vite/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: tanstack-router
             root: playgrounds/tanstack/router/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
           - name: tanstack-start
             root: playgrounds/tanstack/start/
             glob: "*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts}"
             run: |
-              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix
+              pnpm oxlint {staged_files} --type-check --max-warnings=0 --fix --no-error-on-unmatched-pattern
             stage_fixed: true
 
     - name: format


### PR DESCRIPTION
No linked issue: small workflow maintenance change.

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds `--no-error-on-unmatched-pattern` to the oxlint pre-commit commands in `lefthook.yaml`.

## Current behavior (updates)

When only files ignored by oxlint are committed, oxlint can fail because the staged file patterns do not match lintable files.

## New behavior

oxlint now matches the existing oxfmt behavior and does not fail when the staged file pattern has no matching lintable files.

## Is this a breaking change (Yes/No):

No

## Additional Information

Pre-commit hooks ran during commit; lint/typecheck steps were skipped because `lefthook.yaml` is not covered by those staged file globs, and format completed successfully.