### PR TITLE
docs(indicator): add usage tips

### DIFF
--- a/www/contents/components/(components)/indicator.ja.mdx
+++ b/www/contents/components/(components)/indicator.ja.mdx
@@ -48,6 +48,14 @@ import { Indicator } from "@workspaces/ui"
 <Indicator />
 ```
 
+:::tip
+要素の補足など短い情報をホバーまたはフォーカスしたときに表示する場合は、[Tooltip](/docs/components/tooltip)を使用します。
+:::
+
+:::tip
+アイテムのステータスを独立したラベルとして強調表示する場合は、[Badge](/docs/components/badge)を使用します。
+:::
+
 ### バリアントを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/indicator.mdx
+++ b/www/contents/components/(components)/indicator.mdx
@@ -48,6 +48,14 @@ import { Indicator } from "@workspaces/ui"
 <Indicator />
 ```
 
+:::tip
+If you want to display short information, such as supplementary details for an element, when the element is hovered or focused, use [Tooltip](/docs/components/tooltip).
+:::
+
+:::tip
+If you want to emphasize the status of an item as a standalone label, use [Badge](/docs/components/badge).
+:::
+
 ### Change Variant
 
 ```tsx preview


### PR DESCRIPTION
Closes #7606

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the English and Japanese `Indicator` documentation.

## Current behavior (updates)

The Usage section does not explain when `Tooltip` or `Badge` is more appropriate than `Indicator`.

## New behavior

The Usage section now recommends `Tooltip` for supplementary information shown on hover or focus, and `Badge` for emphasizing an item status as a standalone label.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Documentation-only change. Tests were not run.
