### PR TITLE
docs(icon): add usage tips

### DIFF
--- a/www/contents/components/(components)/icon.ja.mdx
+++ b/www/contents/components/(components)/icon.ja.mdx
@@ -35,6 +35,14 @@ import { GhostIcon } from "@workspaces/ui"
 
 [こちら](/icons)から提供しているすべてのアイコンを探すことができます。
 
+:::tip
+データの読み込み中などの待機時間にアイコンを表示する場合は、[Loading](/docs/components/loading)を使用します。
+:::
+
+:::tip
+ボタン内にアイコンを表示する場合は、[IconButton](/docs/components/icon-button)を使用します。
+:::
+
 ### React Iconsを使う
 
 [React Icons](https://react-icons.github.io/react-icons)を使う場合は、`as`にコンポーネントをセットします。

--- a/www/contents/components/(components)/icon.mdx
+++ b/www/contents/components/(components)/icon.mdx
@@ -35,6 +35,14 @@ import { GhostIcon } from "@workspaces/ui"
 
 You can find all the icons we offer at [here](/icons).
 
+:::tip
+If you want to display an icon during waiting times, such as when data is being loaded, use [Loading](/docs/components/loading).
+:::
+
+:::tip
+If you want to display an icon within a button, use [IconButton](/docs/components/icon-button).
+:::
+
 ### Using React Icons
 
 When using [React Icons](https://react-icons.github.io/react-icons), set the component to `as`.


### PR DESCRIPTION
Closes #7614

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the English and Japanese `Icon` documentation.

## Current behavior (updates)

The Usage section does not explain when `Loading` or `IconButton` is more appropriate than `Icon`.

## New behavior

The Usage section now recommends `Loading` when displaying an icon during waiting times and `IconButton` when displaying an icon within a button.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Documentation-only change. Tests were not run.
