### PR TITLE
docs(checkbox): add usage tips

### DIFF
--- a/www/contents/components/(components)/checkbox.ja.mdx
+++ b/www/contents/components/(components)/checkbox.ja.mdx
@@ -38,6 +38,14 @@ import { Checkbox, CheckboxGroup } from "@workspaces/ui"
 </CheckboxGroup.Root>
 ```
 
+:::tip
+ユーザーが複数の選択肢の中から1つの値を選択する場合は、[Radio](/docs/components/radio)を使用します。
+:::
+
+:::tip
+`Checkbox`、[Switch](/docs/components/switch)、[Toggle](/docs/components/toggle)はいずれも2つの状態を扱えます。ユーザーインターフェースの視覚的なデザインとセマンティクスの両方に最も合うコンポーネントを選択します。
+:::
+
 ### グループ化する
 
 ```tsx preview

--- a/www/contents/components/(components)/checkbox.mdx
+++ b/www/contents/components/(components)/checkbox.mdx
@@ -38,6 +38,14 @@ import { Checkbox, CheckboxGroup } from "@workspaces/ui"
 </CheckboxGroup.Root>
 ```
 
+:::tip
+To allow users to select one option from multiple choices, use [Radio](/docs/components/radio).
+:::
+
+:::tip
+`Checkbox`, [Switch](/docs/components/switch), and [Toggle](/docs/components/toggle) can all handle two states. Choose the component that best matches both the visual design and semantics of the user interface.
+:::
+
 ### Group
 
 ```tsx preview


### PR DESCRIPTION
Closes #7617

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the Checkbox documentation.

## Current behavior (updates)

The documentation does not explain when to use Radio instead or how to choose between Checkbox, Switch, and Toggle.

## New behavior

The Usage section explains when Radio is appropriate and how to choose among components that handle two states based on visual design and semantics.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.