### PR TITLE
docs(breadcrumb): add usage tips

### DIFF
--- a/www/contents/components/(components)/breadcrumb.ja.mdx
+++ b/www/contents/components/(components)/breadcrumb.ja.mdx
@@ -43,6 +43,14 @@ import { Breadcrumb } from "@workspaces/ui"
 </Breadcrumb.Root>
 ```
 
+:::tip
+`Breadcrumb.Link`は、デフォルトで`<a>`要素としてレンダリングされます。フレームワークがリンクコンポーネントを提供している場合は、`as={FrameworkLink}`を設定します。各フレームワークのリンクコンポーネントとの統合は、[こちら](/docs/get-started#pick-your-framework)から使用しているフレームワークのドキュメントをご覧ください。
+:::
+
+:::tip
+複数のステップのプロセスの進行状況を表示する場合は、[Steps](/docs/components/steps)を使用します。
+:::
+
 ### itemsを使う
 
 ```tsx preview functional

--- a/www/contents/components/(components)/breadcrumb.mdx
+++ b/www/contents/components/(components)/breadcrumb.mdx
@@ -43,6 +43,14 @@ import { Breadcrumb } from "@workspaces/ui"
 </Breadcrumb.Root>
 ```
 
+:::tip
+`Breadcrumb.Link` renders as an `<a>` element by default. If your framework provides a link component, set `as={FrameworkLink}`. For integration with each framework's link component, see the documentation for your framework [here](/docs/get-started#pick-your-framework).
+:::
+
+:::tip
+To display the progress of a multi-step process, use [Steps](/docs/components/steps).
+:::
+
 ### Use items
 
 ```tsx preview functional


### PR DESCRIPTION
Closes #7615

## AI used

- [ ] I did not use AI to create this PR.
- [x] I checked the generated content before submitting.

## Description

Added usage tips to the `Breadcrumb` documentation to explain routing framework integration and appropriate use cases.

## Current behavior (updates)

The `Breadcrumb` documentation had no usage tips explaining when to use it or how to integrate with routing frameworks.

## New behavior

Two tips were added:
1. Guidance on integrating with routing frameworks like Next.js using the `as` prop.
2. Clarification that `Steps` should be used for multi-step process progress instead of `Breadcrumb`.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Follows the same pattern as the `Button` routing integration tip.
- English and Japanese tips are semantically paired.