### PR TITLE
docs(checkbox-card): add usage tips

### DIFF
--- a/www/contents/components/(components)/checkbox-card.ja.mdx
+++ b/www/contents/components/(components)/checkbox-card.ja.mdx
@@ -57,6 +57,14 @@ import { CheckboxCard, CheckboxCardGroup } from "@workspaces/ui"
 </CheckboxCardGroup.Root>
 ```
 
+:::tip
+選択肢を視覚的に強調したり、関連する情報をグループ化して表示したりする必要がない場合は、[Checkbox](/docs/components/checkbox)を使用します。
+:::
+
+:::tip
+ユーザーが複数の選択肢の中から1つの値を選択する場合は、[RadioCard](/docs/components/radio-card)を使用します。
+:::
+
 ### itemsを使う
 
 ```tsx preview functional

--- a/www/contents/components/(components)/checkbox-card.mdx
+++ b/www/contents/components/(components)/checkbox-card.mdx
@@ -57,6 +57,14 @@ import { CheckboxCard, CheckboxCardGroup } from "@workspaces/ui"
 </CheckboxCardGroup.Root>
 ```
 
+:::tip
+If options do not need visual emphasis or related information to be grouped, use [Checkbox](/docs/components/checkbox).
+:::
+
+:::tip
+To allow users to select one option from multiple choices, use [RadioCard](/docs/components/radio-card).
+:::
+
 ### Use Items
 
 ```tsx preview functional


### PR DESCRIPTION
Closes #7618

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the CheckboxCard documentation.

## Current behavior (updates)

The documentation does not explain when Checkbox or RadioCard is more appropriate.

## New behavior

The Usage section explains when to use Checkbox instead and directs single-selection card interfaces to RadioCard.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.