### PR TITLE
docs(radio): add usage tips

### DIFF
--- a/www/contents/components/(components)/radio.ja.mdx
+++ b/www/contents/components/(components)/radio.ja.mdx
@@ -38,6 +38,14 @@ import { Radio, RadioGroup } from "@workspaces/ui"
 </RadioGroup.Root>
 ```
 
+:::tip
+ユーザーが複数の選択肢の中から複数の値を選択する場合は、[Checkbox](/docs/components/checkbox)を使用します。
+:::
+
+:::tip
+すべての選択肢を表示するスペースがない場合は、[Select](/docs/components/select)を使用します。
+:::
+
 ### itemsを使う
 
 ```tsx preview functional

--- a/www/contents/components/(components)/radio.mdx
+++ b/www/contents/components/(components)/radio.mdx
@@ -38,6 +38,14 @@ import { Radio, RadioGroup } from "@workspaces/ui"
 </RadioGroup.Root>
 ```
 
+:::tip
+If users need to select multiple values from multiple options, use [Checkbox](/docs/components/checkbox).
+:::
+
+:::tip
+If there is not enough space to display all options, use [Select](/docs/components/select).
+:::
+
 ### Use Items
 
 ```tsx preview functional


### PR DESCRIPTION
Closes #7635

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the Radio documentation.

## Current behavior (updates)

The documentation does not explain when Checkbox or Select is more appropriate.

## New behavior

The Usage section directs multiple-selection interfaces to Checkbox and interfaces without enough space to display all options to Select.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.