### PR TITLE
docs(radio-card): add usage tips

### DIFF
--- a/www/contents/components/(components)/radio-card.ja.mdx
+++ b/www/contents/components/(components)/radio-card.ja.mdx
@@ -57,6 +57,14 @@ import { RadioCard, RadioCardGroup } from "@workspaces/ui"
 </RadioCardGroup.Root>
 ```
 
+:::tip
+選択肢を視覚的に強調したり、関連する情報をグループ化して表示したりする必要がない場合は、[Radio](/docs/components/radio)を使用します。
+:::
+
+:::tip
+ユーザーが複数の選択肢の中から複数の値を選択する場合は、[CheckboxCard](/docs/components/checkbox-card)を使用します。
+:::
+
 ### itemsを使う
 
 ```tsx preview functional

--- a/www/contents/components/(components)/radio-card.mdx
+++ b/www/contents/components/(components)/radio-card.mdx
@@ -57,6 +57,14 @@ import { RadioCard, RadioCardGroup } from "@workspaces/ui"
 </RadioCardGroup.Root>
 ```
 
+:::tip
+If options do not need visual emphasis or related information to be grouped, use [Radio](/docs/components/radio).
+:::
+
+:::tip
+If users need to select multiple values from multiple options, use [CheckboxCard](/docs/components/checkbox-card).
+:::
+
 ### Using items
 
 ```tsx preview functional


### PR DESCRIPTION
Closes #7636

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the RadioCard documentation.

## Current behavior (updates)

The documentation does not explain when to use Radio or CheckboxCard instead of RadioCard.

## New behavior

The documentation explains when Radio is sufficient and when CheckboxCard is appropriate for multiple selections.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.