### PR TITLE
docs(switch): add usage tips

### DIFF
--- a/www/contents/components/(components)/switch.ja.mdx
+++ b/www/contents/components/(components)/switch.ja.mdx
@@ -33,6 +33,18 @@ import { Switch } from "@workspaces/ui"
 <Switch />
 ```
 
+:::tip
+ユーザーが複数の選択肢の中から1つの値を選択する場合は、[Radio](/docs/components/radio)を使用します。
+:::
+
+:::tip
+`Switch`、[Checkbox](/docs/components/checkbox)、[Toggle](/docs/components/toggle)はいずれも2つの状態を扱えます。ユーザーインターフェースの視覚的なデザインとセマンティクスの両方に最も合うコンポーネントを選択します。
+:::
+
+:::tip
+`Switch`の状態が変化しても、ラベルは変更しません。
+:::
+
 ### バリアントを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/switch.mdx
+++ b/www/contents/components/(components)/switch.mdx
@@ -33,6 +33,18 @@ import { Switch } from "@workspaces/ui"
 <Switch />
 ```
 
+:::tip
+To allow users to select one option from multiple choices, use [Radio](/docs/components/radio).
+:::
+
+:::tip
+`Switch`, [Checkbox](/docs/components/checkbox), and [Toggle](/docs/components/toggle) can all handle two states. Choose the component that best matches both the visual design and semantics of the user interface.
+:::
+
+:::tip
+Do not change the `Switch` label when its state changes.
+:::
+
 ### Change Variant
 
 ```tsx preview


### PR DESCRIPTION
Closes #7644

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the Switch documentation.

## Current behavior (updates)

The documentation does not explain when to use Radio instead, how Switch relates to Checkbox and Toggle, or that its label should remain unchanged across states.

## New behavior

The documentation explains the component selection criteria and the requirement to keep the Switch label unchanged when its state changes.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.