### PR TITLE
docs(picture): add usage tips

### DIFF
--- a/www/contents/components/(components)/picture.ja.mdx
+++ b/www/contents/components/(components)/picture.ja.mdx
@@ -54,6 +54,10 @@ import { Picture, Source, Image } from "@workspaces/ui"
 </Picture>
 ```
 
+:::tip
+異なる表示やデバイスのシナリオに応じて代替の画像を提供する場合は、`Picture`を使用します。代替の画像が不要な場合は、[Image](/docs/components/image)を使用します。
+:::
+
 ### sourcesを使う
 
 ```tsx preview

--- a/www/contents/components/(components)/picture.mdx
+++ b/www/contents/components/(components)/picture.mdx
@@ -54,6 +54,10 @@ import { Picture, Source, Image } from "@workspaces/ui"
 </Picture>
 ```
 
+:::tip
+Use `Picture` to provide alternative images for different display or device scenarios. If you do not need alternative images, use [Image](/docs/components/image).
+:::
+
 ### Use sources
 
 ```tsx preview


### PR DESCRIPTION
Closes #7631

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage guidance to the Picture documentation in English and Japanese.

## Current behavior (updates)

The Picture usage section does not explain when Image is more appropriate.

## New behavior

The usage section explains that Picture is for alternative images across display or device scenarios and that Image should be used when alternative images are unnecessary.

## Is this a breaking change (Yes/No):

No.

## Additional Information

The guidance aligns with the existing Picture and Image component descriptions.