### PR TITLE
docs(dropzone): add usage tips

### DIFF
--- a/www/contents/components/(components)/dropzone.ja.mdx
+++ b/www/contents/components/(components)/dropzone.ja.mdx
@@ -47,6 +47,14 @@ import { Dropzone } from "@workspaces/ui"
 </Dropzone.Root>
 ```
 
+:::tip
+ファイルをドラッグアンドドロップしない場合は、[FileInput](/docs/components/file-input)を使用します。
+:::
+
+:::tip
+`Dropzone`はファイルアップローダーではありません。ファイルの処理やサーバーへのHTTPリクエストは別に実装します。
+:::
+
 :::note
 `Dropzone`は、内部で[react-dropzone](https://react-dropzone.js.org/)を使用しています。
 :::

--- a/www/contents/components/(components)/dropzone.mdx
+++ b/www/contents/components/(components)/dropzone.mdx
@@ -47,6 +47,14 @@ import { Dropzone } from "@workspaces/ui"
 </Dropzone.Root>
 ```
 
+:::tip
+If users do not drag and drop files, use [FileInput](/docs/components/file-input).
+:::
+
+:::tip
+`Dropzone` is not a file uploader. Implement file processing and HTTP requests to a server separately.
+:::
+
 :::note
 `Dropzone` internally uses [react-dropzone](https://react-dropzone.js.org/).
 :::


### PR DESCRIPTION
Closes #7621

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage guidance to the English and Japanese Dropzone documentation.

## Current behavior (updates)

The Usage section does not explain when to choose FileInput or clarify that Dropzone does not process or upload files.

## New behavior

The Usage section recommends FileInput when files are not dragged and dropped, and clarifies that file processing and server requests must be implemented separately.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.