### PR TITLE
docs(qr-code): add usage tips

### DIFF
--- a/www/contents/components/(components)/qr-code.ja.mdx
+++ b/www/contents/components/(components)/qr-code.ja.mdx
@@ -38,6 +38,14 @@ import { QrCode } from "@workspaces/ui"
 </QrCode.Root>
 ```
 
+:::tip
+`QrCode`は、別のデバイスで情報を読み取らせる場合に使用します。ウェブページなど、同じデバイスで閲覧するコンテンツでは、[Link](/docs/components/link)を使用します。
+:::
+
+:::tip
+`QrCode`は、文字列から動的にQRコードを生成する場合に使用します。既存のQRコード画像を表示する場合は、[Image](/docs/components/image)を使用します。
+:::
+
 ### サイズを変更する
 
 ```tsx preview

--- a/www/contents/components/(components)/qr-code.mdx
+++ b/www/contents/components/(components)/qr-code.mdx
@@ -38,6 +38,14 @@ import { QrCode } from "@workspaces/ui"
 </QrCode.Root>
 ```
 
+:::tip
+Use `QrCode` when users need to scan information with another device. For content that users view on the same device, use [Link](/docs/components/link).
+:::
+
+:::tip
+Use `QrCode` to dynamically generate a QR code from a string. To display an existing QR code image, use [Image](/docs/components/image).
+:::
+
 ### Change Size
 
 ```tsx preview


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

Closes #7634

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds usage tips to the `QrCode` documentation in English and Japanese.

## Current behavior (updates)

The Usage section does not explain when to choose `QrCode` instead of `Link` or `Image`.

## New behavior

The Usage section distinguishes scanning information with another device from viewing content on the same device, and dynamically generated QR codes from existing QR code images.

## Is this a breaking change (Yes/No):

No.

## Additional Information

None.