### PR TITLE
docs(radio-card): align Japanese description wording

### DIFF
--- a/www/contents/components/(components)/radio-card.ja.mdx
+++ b/www/contents/components/(components)/radio-card.ja.mdx
@@ -1,6 +1,6 @@
 ---
 title: RadioCard
-description: "`RadioCard`は、ユーザーが複数の選択肢の中から1つを選択するために使用されるコンポーネントです。"
+description: "`RadioCard`は、ユーザーが複数の選択肢の中から1つの値を選択するために使用されるコンポーネントです。"
 tags: ["form-control", "selection", "card"]
 storybook: components-radiocard--basic
 source: components/radio-card


### PR DESCRIPTION
Closes #7743

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Updates the Japanese `RadioCard` documentation description to explicitly state that users select one value from multiple options.

## Current behavior (updates)

The Japanese description says that users select one item, which is inconsistent with the terminology used by related selection components.

## New behavior

The description uses「1つの値を選択」to align with `Radio`, `Checkbox`, and `CheckboxCard`.

## Is this a breaking change (Yes/No):

No.

## Additional Information

`git diff --check` passed. Tests were not run because this is a documentation-only wording change.
