### PR TITLE
fix(system): resolve color mode variables in shadow DOM

### DIFF
--- a/.changeset/dark-tokens-shadow-host.md
+++ b/.changeset/dark-tokens-shadow-host.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fix dark mode tokens in Shadow DOM.

--- a/packages/react/src/core/css/utils.ts
+++ b/packages/react/src/core/css/utils.ts
@@ -139,7 +139,7 @@ export function tokenToVar(system: System) {
 
 export function varToValue(system: System) {
   return function (variable: string): string {
-    const value = system.cssVars[variable]
+    const value = system.cssVars.light[variable]
 
     if (isCSSVar(value))
       return varToValue(system)(value.replace(/^var\(/, "").replace(/\)$/, ""))

--- a/packages/react/src/core/system/create-system.test.tsx
+++ b/packages/react/src/core/system/create-system.test.tsx
@@ -1,13 +1,15 @@
+import type { CSSVars } from "./index.types"
 import { renderHook } from "#test"
 import { createSystem, defaultSystem } from "./create-system"
 import { useSystem } from "./system-provider"
+import { createVarRules } from "./var"
 
 describe("defaultSystem", () => {
   test("has expected default structure", () => {
     expect(defaultSystem.breakpoints).toBeDefined()
     expect(defaultSystem.config).toStrictEqual({})
     expect(defaultSystem.cssMap).toStrictEqual({})
-    expect(defaultSystem.cssVars).toStrictEqual({})
+    expect(defaultSystem.cssVars).toStrictEqual({ light: {}, dark: {} })
     expect(defaultSystem.layers).toBeDefined()
     expect(defaultSystem.utils.getClassName).toBeDefined()
   })
@@ -84,17 +86,40 @@ describe("createSystem", () => {
 
   test("creates system with themeSchemes", () => {
     const system = createSystem({
-      colors: { red: { 500: "#ff0000" } },
+      colors: {
+        blue: { 500: "#0000ff" },
+        red: { 500: "#ff0000" },
+      },
+      semanticTokens: {
+        colors: { primary: ["red.500", "blue.500"] },
+      },
       themeSchemes: {
         dark: {
           colors: { red: { 500: "#cc0000" } },
         },
       },
     })
-    const hasDarkThemeCondition = Object.keys(system.cssVars).some((key) =>
-      key.includes("data-theme=dark"),
+
+    expect(system.cssVars.dark[system.cssMap["colors.primary"]!.var]).toBe(
+      "var(--ui-colors-blue-500)",
     )
-    expect(hasDarkThemeCondition).toBeTruthy()
+    expect(system.cssVars.themes?.dark).toBeDefined()
+  })
+
+  test("creates light and dark variables from color mode values", () => {
+    const system = createSystem({
+      colors: {
+        blue: { 500: "#0000ff" },
+        red: { 500: "#ff0000" },
+      },
+      semanticTokens: {
+        colors: { primary: ["red.500", "blue.500"] },
+      },
+    })
+    const variable = system.cssMap["colors.primary"]!.var
+
+    expect(system.cssVars.light[variable]).toBe("var(--ui-colors-red-500)")
+    expect(system.cssVars.dark[variable]).toBe("var(--ui-colors-blue-500)")
   })
 
   test("creates negative space tokens", () => {
@@ -104,20 +129,36 @@ describe("createSystem", () => {
     expect(system.cssMap["spaces.-md"]).toBeDefined()
   })
 
-  test("handles responsive config", () => {
+  test("creates responsive variables for each color mode", () => {
     const system = createSystem(
       {
         breakpoints: {
-          sm: "30em",
           md: "48em",
-          lg: "62em",
-          xl: "80em",
-          "2xl": "96em",
+        },
+        colors: {
+          blue: { 500: "#0000ff" },
+          red: { 500: "#ff0000" },
+        },
+        semanticTokens: {
+          colors: {
+            primary: {
+              base: ["red.500", "blue.500"],
+              md: ["blue.500", "red.500"],
+            },
+          },
         },
       },
       { theme: { responsive: true } },
     )
-    expect(system.breakpoints).toBeDefined()
+    const query = system.breakpoints.getQuery("md")!
+    const variable = system.cssMap["colors.primary"]!.var
+
+    expect(system.cssVars.light[query][variable]).toBe(
+      "var(--ui-colors-blue-500)",
+    )
+    expect(system.cssVars.dark[query][variable]).toBe(
+      "var(--ui-colors-red-500)",
+    )
   })
 })
 
@@ -140,5 +181,49 @@ describe("useSystem", () => {
     expect(result.current.breakpoints).toBeDefined()
     expect(result.current.cssMap).toBeDefined()
     expect(result.current.layers).toBeDefined()
+  })
+})
+
+describe("createVarRules", () => {
+  test("creates rules for color modes and theme scopes", () => {
+    const cssVars: CSSVars = {
+      light: { "--ui-colors-bg": "#fff" },
+      dark: { "--ui-colors-bg": "#000" },
+      themes: {
+        blue: {
+          light: { "--ui-colors-bg": "#def" },
+          dark: { "--ui-colors-bg": "#001" },
+        },
+      },
+    }
+
+    expect(createVarRules(":host, :root", cssVars)).toStrictEqual({
+      ":host([data-mode=dark]), :root[data-mode=dark], [data-mode=dark]": {
+        "--ui-colors-bg": "#000",
+      },
+      ":host([data-theme=blue]), :root[data-theme=blue], [data-theme=blue], [data-theme=blue] [data-mode=light], :host([data-theme=blue]) [data-mode=light]":
+        {
+          "--ui-colors-bg": "#def",
+        },
+      ":host([data-theme=blue][data-mode=dark]), :root[data-theme=blue][data-mode=dark], [data-theme=blue][data-mode=dark], [data-theme=blue] [data-mode=dark], [data-mode=dark] [data-theme=blue], :host([data-theme=blue]) [data-mode=dark], :host([data-mode=dark]) [data-theme=blue]":
+        {
+          "--ui-colors-bg": "#001",
+        },
+      ":host, :root, [data-mode=light]": { "--ui-colors-bg": "#fff" },
+    })
+  })
+
+  test("omits empty color mode and theme rules", () => {
+    const cssVars: CSSVars = {
+      light: { "--ui-colors-bg": "#fff" },
+      dark: {},
+      themes: {
+        blue: { light: {}, dark: {} },
+      },
+    }
+
+    expect(createVarRules(":host, :root", cssVars)).toStrictEqual({
+      ":host, :root, [data-mode=light]": { "--ui-colors-bg": "#fff" },
+    })
   })
 })

--- a/packages/react/src/core/system/create-system.ts
+++ b/packages/react/src/core/system/create-system.ts
@@ -106,7 +106,7 @@ export const defaultSystem: System = {
   breakpoints: createBreakpoints(),
   config: {},
   cssMap: {},
-  cssVars: {},
+  cssVars: { light: {}, dark: {} },
   layers: createLayers(),
   utils: { getClassName: bem },
 }
@@ -152,8 +152,6 @@ export function createSystem(
     const themeSchemeEntries = Object.entries<Dict>(theme.themeSchemes)
 
     for (const [themeScheme, nestedTheme] of themeSchemeEntries) {
-      const themeCondition = `[data-theme=${themeScheme}] &:not([data-theme]), &[data-theme=${themeScheme}]`
-
       const nestedPrimaryTokens = {
         ...createTokens(nestedTheme, "primary", shouldProcess),
         ...createColorSchemeTokens(theme, nestedTheme, shouldProcess),
@@ -175,7 +173,8 @@ export function createSystem(
         createVars(prefix, theme, breakpoints, rootNode)(nestedTertiaryTokens),
       )({ ...primaryTokens, ...secondaryTokens, ...tertiaryTokens })
 
-      cssVars[themeCondition] = nestedCSSVars
+      cssVars.themes ??= {}
+      cssVars.themes[themeScheme] = nestedCSSVars
     }
   }
 

--- a/packages/react/src/core/system/index.types.ts
+++ b/packages/react/src/core/system/index.types.ts
@@ -243,7 +243,7 @@ export interface ThemeConfig {
     /**
      * The root selector to attach to variable names when converting each token of the theme to CSS variable names.
      *
-     * @default ':host, :root, [data-mode]'
+     * @default ':host, :root'
      */
     varRoot?: string
   }
@@ -664,6 +664,12 @@ export interface CSSMap {
   [key: string]: { ref: string; var: string }
 }
 
+export interface CSSVars {
+  dark: Dict
+  light: Dict
+  themes?: { [key: string]: { dark: Dict; light: Dict } }
+}
+
 export interface CustomTheme {}
 export type DefaultTheme = typeof theme
 
@@ -713,7 +719,7 @@ export interface System {
   breakpoints: Breakpoints
   config: ThemeConfig
   cssMap: CSSMap
-  cssVars: Dict
+  cssVars: CSSVars
   layers: Layers
   utils: SystemUtils
   rootNode?: Document | Node | ShadowRoot

--- a/packages/react/src/core/system/theme-provider.test.tsx
+++ b/packages/react/src/core/system/theme-provider.test.tsx
@@ -1,9 +1,26 @@
 import type { Environment } from "./environment-provider"
 import type { ThemeScheme } from "./index.types"
-import { act, renderHook } from "#test"
+import { act, render, renderHook } from "#test"
+import { UIProvider } from "../../providers/ui-provider"
 import { getPreventTransition, useTheme } from "./theme-provider"
 
 describe("ThemeProvider", () => {
+  test("renders color mode variable rules", () => {
+    render(
+      <UIProvider>
+        <div />
+      </UIProvider>,
+      { withProvider: false },
+    )
+
+    const styles = [...document.head.querySelectorAll("style")]
+      .map((style) => style.textContent)
+      .join("")
+
+    expect(styles).toContain(":host([data-mode=dark])")
+    expect(styles).not.toContain(":host:host([data-mode=dark])")
+  })
+
   test("inserts transition styles into the shadow root", () => {
     const host = document.createElement("div")
     const shadowRoot = host.attachShadow({ mode: "open" })

--- a/packages/react/src/core/system/theme-provider.tsx
+++ b/packages/react/src/core/system/theme-provider.tsx
@@ -30,6 +30,7 @@ import { css } from "../css"
 import { useEnvironment } from "./environment-provider"
 import { createStorageManager } from "./storage-manager"
 import { useSystem } from "./system-provider"
+import { createVarRules } from "./var"
 
 export const getPreventTransition = (environment: Environment) => {
   const win = environment.getWindow()
@@ -170,18 +171,18 @@ export const GlobalStyles: FC = () => {
     return css(system, theme)(style)
   }, [system, theme])
 
-  const cssVars = useMemo(() => {
-    return {
-      [system.config.css?.varRoot ?? ":host, :root, [data-mode]"]:
-        system.cssVars,
-    }
+  const varRules = useMemo(() => {
+    return createVarRules(
+      system.config.css?.varRoot ?? ":host, :root",
+      system.cssVars,
+    )
   }, [system])
 
   return (
     <Global
       styles={[
         atRule,
-        wrap("tokens", cssVars),
+        wrap("tokens", varRules),
         wrap("reset", resetStyle),
         wrap("global", globalStyle),
       ]}

--- a/packages/react/src/core/system/var.ts
+++ b/packages/react/src/core/system/var.ts
@@ -1,7 +1,9 @@
 import type { Dict } from "../../utils"
 import type { CSSProperties, StyleValueWithCondition } from "../css"
 import type {
+  ColorMode,
   CSSMap,
+  CSSVars,
   DefineThemeValue,
   System,
   ThemeToken,
@@ -13,7 +15,9 @@ import type { Breakpoints } from "./breakpoint"
 import {
   calc,
   escape,
+  filterEmpty,
   isArray,
+  isEmptyObject,
   isNull,
   isObject,
   isString,
@@ -25,7 +29,6 @@ import { DEFAULT_VAR_PREFIX } from "../constant"
 import {
   animation,
   colorMix,
-  conditions,
   css,
   getStyle,
   gradient,
@@ -99,8 +102,6 @@ export function createVars(
   rootNode?: System["rootNode"],
 ) {
   return function (tokens: VariableTokens) {
-    const { getQuery, isResponsive } = breakpoints
-
     function tokenToVar(token: string): Variable {
       token = token.replace(/\./g, "-")
       token = token.replace(/\//g, "\\/")
@@ -113,9 +114,9 @@ export function createVars(
 
     return function (
       cssMap: CSSMap = {},
-      cssVars: Dict = {},
+      cssVars: CSSVars = { light: {}, dark: {} },
       prevTokens?: VariableTokens,
-    ): { cssMap: CSSMap; cssVars: Dict } {
+    ): { cssMap: CSSMap; cssVars: CSSVars } {
       const system: System = { ...defaultSystem, cssMap, rootNode }
       const options = { css, system, theme }
 
@@ -229,30 +230,29 @@ export function createVars(
         value: VariableValue,
         variable: string,
       ) {
-        return function (semantic: boolean, queries: string[] = []) {
+        return function (
+          semantic: boolean,
+          colorMode: ColorMode = "light",
+          breakpoint: string = "base",
+        ) {
           if (isAnimation(token)) value = createAnimationVar(value)
 
           if (isArray(value)) {
-            const [lightValue, darkValue] = value
-
-            createVar(token, lightValue, variable)(semantic, queries)
-            createVar(
-              token,
-              darkValue,
-              variable,
-            )(semantic, [...queries, conditions._dark])
-          } else if (isResponsive(value, true)) {
-            Object.entries(value).forEach(([key, value]) => {
-              if (key === "base") {
-                createVar(token, value, variable)(semantic, queries)
-              } else {
-                const query = getQuery(key)
-
-                if (!query) return
-
-                createVar(token, value, variable)(semantic, [...queries, query])
-              }
-            })
+            value.forEach((value, index) =>
+              createVar(token, value, variable)(
+                semantic,
+                !index ? "light" : "dark",
+                breakpoint,
+              ),
+            )
+          } else if (breakpoints.isResponsive(value, true)) {
+            Object.entries(value).forEach(([breakpoint, value]) =>
+              createVar(token, value, variable)(
+                semantic,
+                colorMode,
+                breakpoint,
+              ),
+            )
           } else {
             const computedValue: DefineThemeValue = valueToVar(value)
 
@@ -277,17 +277,18 @@ export function createVars(
             if (!isObject(resolvedValue))
               resolvedValue = { [variable]: resolvedValue }
 
-            const resolvedCssVars = queries.reduceRight<Dict>(
-              (prev, key) => ({ [key]: prev }),
-              resolvedValue,
-            )
+            const query = breakpoints.getQuery(breakpoint)
 
-            cssVars = merge(cssVars, resolvedCssVars)
+            if (query)
+              resolvedValue = { [colorMode]: { [query]: resolvedValue } }
+            else resolvedValue = { [colorMode]: resolvedValue }
+
+            cssVars = merge(cssVars, resolvedValue)
           }
         }
       }
 
-      for (let [token, { semantic, value }] of Object.entries(tokens)) {
+      for (const [token, { semantic, value }] of Object.entries(tokens)) {
         const { reference, variable } = tokenToVar(token)
 
         createVar(token, value, variable)(semantic)
@@ -314,7 +315,7 @@ export type CreateVars = ReturnType<ReturnType<typeof createVars>>
 export function mergeVars(...fns: CreateVars[]) {
   return function (prevTokens?: VariableTokens) {
     let cssMap: CSSMap = {}
-    let cssVars: Dict = {}
+    let cssVars: CSSVars = { light: {}, dark: {} }
 
     for (const fn of fns) {
       const result = fn(cssMap, cssVars, prevTokens)
@@ -325,6 +326,67 @@ export function mergeVars(...fns: CreateVars[]) {
 
     return { cssMap, cssVars }
   }
+}
+
+function createSelector(selectors: string, attr?: string): string {
+  return selectors
+    .split(",")
+    .map((selector) => {
+      selector = selector.trim()
+
+      if (!attr) return selector
+      else if (selector === ":host") return `${selector}(${attr})`
+      else return `${selector}${attr}`
+    })
+    .join(", ")
+}
+
+export function createVarRules(varRoot: string, cssVars: CSSVars): Dict {
+  return Object.fromEntries(
+    Object.entries(cssVars).flatMap(([colorMode, cssVars]) => {
+      if (isEmptyObject(cssVars)) return []
+
+      if (colorMode === "light" || colorMode === "dark") {
+        const dark = colorMode === "dark"
+        const attr = `[data-mode=${colorMode}]`
+        const selector = createSelector(varRoot, dark ? attr : undefined)
+
+        return [[[selector, attr].join(", "), cssVars]]
+      } else {
+        return Object.entries<Dict>(cssVars).flatMap(([themeScheme, cssVars]) =>
+          Object.entries(cssVars).flatMap(([colorMode, cssVars]) => {
+            if (isEmptyObject(cssVars)) return []
+
+            const dark = colorMode === "dark"
+            const attrs = {
+              colorMode: `[data-mode=${colorMode}]`,
+              themeScheme: `[data-theme=${themeScheme}]`,
+            }
+            const attr = !dark
+              ? attrs.themeScheme
+              : `${attrs.themeScheme}${attrs.colorMode}`
+            const selector = createSelector(varRoot, attr)
+
+            return [
+              [
+                filterEmpty([
+                  selector,
+                  attr,
+                  `${attrs.themeScheme} ${attrs.colorMode}`,
+                  dark ? `${attrs.colorMode} ${attrs.themeScheme}` : undefined,
+                  `:host(${attrs.themeScheme}) ${attrs.colorMode}`,
+                  dark
+                    ? `:host(${attrs.colorMode}) ${attrs.themeScheme}`
+                    : undefined,
+                ]).join(", "),
+                cssVars,
+              ],
+            ]
+          }),
+        )
+      }
+    }),
+  )
 }
 
 export function varAttr<Y = StyleValueWithCondition<number | string>>(


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix color mode token generation for Shadow DOM and scoped theme schemes.

Not linked to an issue because this is a focused regression fix discovered in the Shadow DOM playground.

## Current behavior (updates)

Dark mode token rules were nested through the generic dark condition, producing selectors that did not match a Shadow host.

## New behavior

Color mode and theme token declarations are stored separately and compiled into explicit rules for document roots, Shadow hosts, and supported nested theme/color-mode scopes.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Added coverage for color mode, responsive, theme-scope, and generated variable-rule behavior.
- Verified Shadow host variables switch while the document remains in light mode.