### PR TITLE
feat(theme): add infinity z-index token

### DIFF
--- a/.changeset/tiny-dragons-fly.md
+++ b/.changeset/tiny-dragons-fly.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": minor
+---
+
+Add the `infinity` z-index token.

--- a/packages/react/src/core/generated-theme-tokens.types.ts
+++ b/packages/react/src/core/generated-theme-tokens.types.ts
@@ -1068,6 +1068,7 @@ export interface GeneratedThemeTokens extends UsageThemeTokens {
     | "freeza"
     | "ginyu"
     | "guldo"
+    | "infinity"
     | "jeice"
     | "kurillin"
     | "nappa"

--- a/packages/react/src/theme/tokens/z-indices.ts
+++ b/packages/react/src/theme/tokens/z-indices.ts
@@ -18,4 +18,6 @@ export const zIndices = defineTokens.zIndices({
   vegeta: 9997,
   sonGoku: 9998,
   beerus: 9999,
+
+  infinity: 2147483647,
 })


### PR DESCRIPTION
Closes #7759

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Adds an `infinity` token to the default z-index tokens and generated theme token types. Includes a minor changeset for `@yamada-ui/react`.

## Current behavior (updates)

Consumers must use a raw numeric value when an element needs the maximum supported z-index.

## New behavior

Consumers can use the `infinity` z-index token, which resolves to `2147483647`.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Verified with `pnpm react test:jsdom --run src/core/system/create-system.test.tsx` (17 tests passed). The pre-commit lint, typecheck, and format hooks also passed.