### PR TITLE
fix(modal): add style props to root type

### DIFF
--- a/.changeset/fuzzy-modals-style.md
+++ b/.changeset/fuzzy-modals-style.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Add style props to the `Modal.Root` type definition.

--- a/packages/react/src/components/modal/modal.test.tsx
+++ b/packages/react/src/components/modal/modal.test.tsx
@@ -36,7 +36,7 @@ const TestComponent: FC<Modal.RootProps> = (props) => {
 
 describe("<Modal />", () => {
   test("passes a11y check", async () => {
-    await a11y(<TestComponent />)
+    await a11y(<TestComponent zIndex="modal" />)
   })
 
   test("sets aria attributes correctly", () => {

--- a/packages/react/src/components/modal/modal.test.tsx
+++ b/packages/react/src/components/modal/modal.test.tsx
@@ -36,7 +36,7 @@ const TestComponent: FC<Modal.RootProps> = (props) => {
 
 describe("<Modal />", () => {
   test("passes a11y check", async () => {
-    await a11y(<TestComponent zIndex="modal" />)
+    await a11y(<TestComponent />)
   })
 
   test("sets aria attributes correctly", () => {

--- a/packages/react/src/components/modal/modal.tsx
+++ b/packages/react/src/components/modal/modal.tsx
@@ -34,6 +34,7 @@ interface ComponentContext
 
 export interface ModalRootProps
   extends
+    Omit<HTMLStyledProps<"div">, "scrollBehavior" | "title">,
     ThemeProps<ModalStyle>,
     Omit<UseModalProps, "title">,
     Pick<


### PR DESCRIPTION
Closes #7761

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Add style props to the `Modal.Root` type definition so its public types match the existing runtime behavior.

## Current behavior (updates)

`Modal.Root` generates CSS for style props such as `zIndex`, but TypeScript rejects those props because `Modal.RootProps` does not include `HTMLStyledProps`.

## New behavior

`Modal.RootProps` extends `HTMLStyledProps<"div">` while omitting conflicting `scrollBehavior` and `title` properties.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Tested with `pnpm react test:jsdom --run src/components/modal/modal.test.tsx` (9 tests passed). Pre-commit lint, typecheck, formatting, and commitlint hooks also passed.