### PR TITLE
fix(gradient): support multiple gradient layers

### DIFF
--- a/.changeset/multiple-gradients.md
+++ b/.changeset/multiple-gradients.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Support multiple gradients in a single gradient property.

--- a/packages/react/src/components/color-swatch/color-swatch.tsx
+++ b/packages/react/src/components/color-swatch/color-swatch.tsx
@@ -8,10 +8,10 @@ import { colorSwatchStyle } from "./color-swatch.style"
 
 export const checkersProps: HTMLStyledProps = {
   bgImage: [
-    "linear-gradient(45deg, {checkers-fg} 25%, transparent 25%)",
-    "linear-gradient(-45deg, {checkers-fg} 25%, transparent 25%)",
-    "linear-gradient(45deg, transparent 75%, {checkers-fg} 75%)",
-    "linear-gradient(-45deg, {checkers-bg} 75%, {checkers-fg} 75%)",
+    "linear(45deg, {checkers-fg} 25%, transparent 25%)",
+    "linear(-45deg, {checkers-fg} 25%, transparent 25%)",
+    "linear(45deg, transparent 75%, {checkers-fg} 75%)",
+    "linear(-45deg, {checkers-bg} 75%, {checkers-fg} 75%)",
   ].join(", "),
   bgPosition: `0 0, 0 4px, 4px -4px, -4px 0`,
   bgSize: `8px 8px`,

--- a/packages/react/src/core/css/gradient.stories.tsx
+++ b/packages/react/src/core/css/gradient.stories.tsx
@@ -16,6 +16,18 @@ export const Basic = () => {
   )
 }
 
+export const Multiple = () => {
+  return (
+    <Box
+      bgAttachment="fixed"
+      bgGradient="radial(at 80% -20%, #fff 10%, transparent 40%), radial(at 0% 70%, #fff, transparent 50%), radial(at 0% 0%, #0ff, transparent), radial(at 80% 40%, #ff9, transparent 40%), radial(at 100% 100%, #675ee3, transparent)"
+      height="md"
+      rounded="l3"
+      w="full"
+    />
+  )
+}
+
 export const ColorCode = () => {
   return (
     <Heading

--- a/packages/react/src/core/css/gradient.test.ts
+++ b/packages/react/src/core/css/gradient.test.ts
@@ -141,4 +141,14 @@ describe("gradient", () => {
       "linear-gradient(to right, var(--ui-colors-red), var(--ui-colors-green), var(--ui-colors-blue), var(--ui-colors-yellow))",
     )
   })
+
+  test("handles multiple gradients", () => {
+    const result = gradient(
+      "radial(red.500, transparent), radial(red.300, transparent)",
+      options,
+    )
+    expect(result).toBe(
+      "radial-gradient(var(--ui-colors-red-500), var(--ui-colors-transparent)), radial-gradient(var(--ui-colors-red-300), var(--ui-colors-transparent))",
+    )
+  })
 })

--- a/packages/react/src/core/css/gradient.ts
+++ b/packages/react/src/core/css/gradient.ts
@@ -28,42 +28,47 @@ export function gradient(value: any, { system }: TransformOptions) {
 
   if (!prevent) return `url('${value}')`
 
-  let { type, values } = getCSSFunction(value)
+  return splitValues(value)
+    .map((value) => {
+      let { type, values } = getCSSFunction(value)
 
-  if (!type || !values) return value
+      if (!type || !values) return value
 
-  type = type.includes("-gradient") ? type : `${type}-gradient`
+      type = type.includes("-gradient") ? type : `${type}-gradient`
 
-  const [maybeDirection, ...colors] = splitValues(values)
+      const [maybeDirection, ...colors] = splitValues(values)
 
-  if (!colors.length) return value
+      if (!colors.length) return value
 
-  const direction =
-    maybeDirection && maybeDirection in directions
-      ? directions[maybeDirection]
-      : maybeDirection
+      const direction =
+        maybeDirection && maybeDirection in directions
+          ? directions[maybeDirection]
+          : maybeDirection
 
-  if (!isUndefined(direction)) colors.unshift(direction)
+      if (!isUndefined(direction)) colors.unshift(direction)
 
-  const computedValues = colors.map((_color) => {
-    if (isUndefined(_color)) return _color
+      const computedValues = colors.map((_color) => {
+        if (isUndefined(_color)) return _color
 
-    if (directionValues.has(_color)) return _color
+        if (directionValues.has(_color)) return _color
 
-    const i = _color.indexOf(" ")
+        const i = _color.indexOf(" ")
 
-    let [color, _ratio] =
-      i !== -1 ? [_color.slice(0, i), _color.slice(i + 1)] : [_color]
+        let [color, _ratio] =
+          i !== -1 ? [_color.slice(0, i), _color.slice(i + 1)] : [_color]
 
-    const ratio = isCSSFunction(_ratio) ? _ratio : _ratio?.split(" ")
+        const ratio = isCSSFunction(_ratio) ? _ratio : _ratio?.split(" ")
 
-    const token = `colors.${color}`
+        const token = `colors.${color}`
 
-    color = isCSSToken(system)(token) ? system.cssMap[token]!.ref : color
+        color = isCSSToken(system)(token) ? system.cssMap[token]!.ref : color
 
-    if (ratio) return [color, ...(isArray(ratio) ? ratio : [ratio])].join(" ")
-    else return color
-  })
+        if (ratio)
+          return [color, ...(isArray(ratio) ? ratio : [ratio])].join(" ")
+        else return color
+      })
 
-  return `${type}(${computedValues.join(", ")})`
+      return `${type}(${computedValues.join(", ")})`
+    })
+    .join(", ")
 }


### PR DESCRIPTION
Closes #7763

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Support comma-separated gradient layers in a single gradient property.

## Current behavior (updates)

The gradient transformer parses a comma-separated list as one CSS function, producing invalid CSS when a second gradient layer is present.

## New behavior

Each top-level gradient layer is transformed independently. The `ColorSwatch` checkerboard now uses the compact `linear(...)` notation for its layered background.

## Is this a breaking change (Yes/No):

No

## Additional Information

Adds regression coverage for multiple radial gradients.