### PR TITLE
chore(alpha-slider): remove commented-out gradient

### DIFF
--- a/.changeset/remove-alpha-slider-comment.md
+++ b/.changeset/remove-alpha-slider-comment.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Remove an unused commented-out gradient from the AlphaSlider story.

--- a/.changeset/remove-alpha-slider-comment.md
+++ b/.changeset/remove-alpha-slider-comment.md
@@ -1,5 +1,0 @@
----
-"@yamada-ui/react": patch
----
-
-Remove an unused commented-out gradient from the AlphaSlider story.

--- a/packages/react/src/components/alpha-slider/alpha-slider.stories.tsx
+++ b/packages/react/src/components/alpha-slider/alpha-slider.stories.tsx
@@ -133,5 +133,3 @@ export const CustomControl: Story = () => {
 
   return <AlphaSlider.Root color="#775999" value={value} onChange={setValue} />
 }
-
-// linear-gradient(117deg, rgb(102, 102, 102) 0%, rgb(216, 44, 69) 22%, rgb(255, 142, 95) 44%, rgb(113, 232, 255) 76%, rgb(245, 245, 245) 100%)


### PR DESCRIPTION
Closes #7765

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Remove an unused commented-out gradient from the `AlphaSlider` Storybook story.

## Current behavior (updates)

The story source contains an unused commented-out gradient value.

## New behavior

The unused comment is removed.

## Is this a breaking change (Yes/No):

No

## Additional Information

No behavior or public API changes.