### PR TITLE
refactor(gradient): use shorthand syntax

### DIFF
--- a/.changeset/gradient-shorthand.md
+++ b/.changeset/gradient-shorthand.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Refactor component gradient values to use shorthand syntax.

--- a/packages/react/src/components/progress/progress.style.ts
+++ b/packages/react/src/components/progress/progress.style.ts
@@ -72,7 +72,7 @@ export const progressStyle = defineComponentSlotStyle({
           "--stripe-angle": "45deg",
           "--stripe-color": ["rgba(255, 255, 255, 0.3)", "rgba(0, 0, 0, 0.3)"],
           "--stripe-size": "1rem",
-          bgImage: `linear-gradient(
+          bgImage: `linear(
             {stripe-angle},
             {stripe-color} 25%,
             transparent 25%,

--- a/packages/react/src/components/skeleton/skeleton.style.ts
+++ b/packages/react/src/components/skeleton/skeleton.style.ts
@@ -58,7 +58,7 @@ export const skeletonStyle = defineComponentStyle({
       animationName: "bg-position",
       animationTimingFunction: "ease-in-out",
       bgImage:
-        "linear-gradient(270deg, {start-color}, {end-color}, {end-color}, {start-color})",
+        "linear(270deg, {start-color}, {end-color}, {end-color}, {start-color})",
       bgSize: "400% 100%",
     },
   },

--- a/packages/react/src/theme/tokens/keyframes.stories.tsx
+++ b/packages/react/src/theme/tokens/keyframes.stories.tsx
@@ -65,7 +65,7 @@ export const Keyframes = () => {
                     bg="green"
                     bgImage={
                       token === "bg-position"
-                        ? `linear-gradient(
+                        ? `linear(
                       45deg,
                       {stripe-color} 25%,
                       transparent 25%,

--- a/www/components/mdx/tokens-preview.tsx
+++ b/www/components/mdx/tokens-preview.tsx
@@ -832,7 +832,7 @@ export function TokensPreview({
                       bg="green"
                       bgImage={
                         token === "bg-position"
-                          ? `linear-gradient(
+                          ? `linear(
                       45deg,
                       {stripe-color} 25%,
                       transparent 25%,


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Use the Yamada UI gradient shorthand in component styles and previews.

## Current behavior (updates)

Component styles and token previews use the native `linear-gradient(...)` function directly.

## New behavior

The same gradients use the `linear(...)` shorthand and continue to resolve through the gradient transformer.

## Is this a breaking change (Yes/No):

No

## Additional Information

No linked issue because this is a small internal refactoring.