### PR TITLE
fix(react): clear box shadow for none focus rings

### DIFF
--- a/.changeset/four-lions-dance.md
+++ b/.changeset/four-lions-dance.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fix `none` focus ring presets so they clear previously applied box shadows.

--- a/packages/react/src/core/css/focus-ring.ts
+++ b/packages/react/src/core/css/focus-ring.ts
@@ -21,6 +21,7 @@ export const focusRingStyle = {
     outlineWidth: "{focus-ring-width, 2px}",
   },
   none: {
+    boxShadow: "none",
     outline: "none",
   },
   outline: {


### PR DESCRIPTION
Closes #7774

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Clear box shadows when the `none` focus-ring preset overrides another preset.

## Current behavior (updates)

The `none` preset resets only `outline`, allowing a `boxShadow` from another focus-ring preset to remain applied.

## New behavior

The `none` preset also sets `boxShadow` to `none`.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tested with `pnpm react test:jsdom --run src/core/css/focus-ring.test.ts`.