### PR TITLE
fix(popover): support shadow DOM clicks

### DIFF
--- a/.changeset/fix-popover-shadow-dom.md
+++ b/.changeset/fix-popover-shadow-dom.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Prevent Popover from closing when its content is clicked inside a Shadow DOM.

--- a/packages/react/src/components/popover/popover.test.browser.tsx
+++ b/packages/react/src/components/popover/popover.test.browser.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom"
 import { page, render } from "#test/browser"
 import { Popover } from "."
 import { Button } from "../button"
@@ -130,6 +131,34 @@ describe("<Popover />", () => {
     await expect.poll(() => page.getByText("Popover Header").query()).toBeNull()
     await expect.poll(() => page.getByText("Popover Body").query()).toBeNull()
     await expect.poll(() => page.getByText("Popover Footer").query()).toBeNull()
+  })
+
+  test("should not close when content is clicked in shadow DOM", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(createPortal(<Component />, shadowRoot), {
+        providerProps: { rootNode: shadowRoot },
+      })
+      const triggerButton = page.getByRole("button", {
+        name: "Popover Trigger",
+      })
+
+      await user.click(triggerButton)
+
+      const content = page.getByRole("dialog")
+
+      await expect.element(content).toBeVisible()
+      expect(content.element().getRootNode()).toBe(shadowRoot)
+
+      await user.click(page.getByText("Popover Body"))
+
+      await expect.element(content).toBeVisible()
+    } finally {
+      host.remove()
+    }
   })
 
   test("should close when close trigger is activated", async () => {

--- a/packages/react/src/hooks/use-outside-click/index.ts
+++ b/packages/react/src/hooks/use-outside-click/index.ts
@@ -97,11 +97,15 @@ const isValidEvent = (
   ref: RefObject<HTMLElement | null> | RefObject<HTMLElement | null>[],
 ) => {
   const target = ev.target as HTMLElement | null
+  const path = ev.composedPath()
 
   if ("button" in ev && ev.button > 0) return false
 
   if (target) if (!getDocument(target).contains(target)) return false
 
-  if (isArray(ref)) return !ref.some((ref) => ref.current?.contains(target))
-  else return !ref.current?.contains(target)
+  const contains = (el: HTMLElement | null) =>
+    !!el && (path.includes(el) || el.contains(target))
+
+  if (isArray(ref)) return !ref.some(({ current }) => contains(current))
+  else return !contains(ref.current)
 }


### PR DESCRIPTION
Closes #7777

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fixes Popover closing when its content is clicked inside an open Shadow DOM.

## Current behavior (updates)

`useOutsideClick` treats an event retargeted to the Shadow host as outside the Popover content.

## New behavior

Outside-click detection uses the event composed path, so clicks within Popover content remain internal across an open Shadow DOM boundary.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Added browser coverage for a Popover rendered through an open Shadow DOM.