### PR TITLE
fix(utils): include container keys in Path

### DIFF
--- a/.changeset/fix-path-container-keys.md
+++ b/.changeset/fix-path-container-keys.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/utils": patch
+---
+
+Fix Path to include array and object keys.

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -1,3 +1,4 @@
+import type { Path, Primitive } from "./index.types"
 import * as utils from "."
 
 describe("index", () => {
@@ -14,5 +15,28 @@ describe("index", () => {
     expect(typeof utils.omitObject).toBe("function")
     expect(typeof utils.isNumber).toBe("function")
     expect(typeof utils.calc).toBe("function")
+  })
+
+  test("should include array and object keys in Path", () => {
+    expectTypeOf<
+      Path<{
+        array: [0, 0]
+        object: { value: 0 }
+      }>
+    >().toEqualTypeOf<"array" | "object" | "object.value" | `array.${number}`>()
+  })
+
+  test("should include Date and Function in Primitive", () => {
+    expectTypeOf<Primitive>().toEqualTypeOf<
+      | bigint
+      | boolean
+      | Date
+      | Function
+      | null
+      | number
+      | string
+      | symbol
+      | undefined
+    >()
   })
 })

--- a/packages/utils/src/index.types.ts
+++ b/packages/utils/src/index.types.ts
@@ -1,22 +1,26 @@
 export type Primitive =
   | bigint
   | boolean
+  | Date
+  | Function
   | null
   | number
   | string
   | symbol
   | undefined
 
-type PathImpl<Y extends number | string | symbol, M> = Y extends number | string
-  ? M extends Primitive
+type PathImpl<Y extends number | string | symbol, M, D = Primitive> = Y extends
+  | number
+  | string
+  ? M extends D
     ? `${Y}`
-    : `${Y}.${Path<M>}`
+    : `${Y}.${Path<M, D>}` | `${Y}`
   : ``
 
-export type Path<Y> = Y extends any[]
+export type Path<Y, M = Primitive> = Y extends any[]
   ? `${number}`
   : {
-      [M in keyof Y]-?: PathImpl<M, Y[M]>
+      [D in keyof Y]-?: PathImpl<D, Y[D], M>
     }[keyof Y]
 
 export type Value<
@@ -42,7 +46,7 @@ export type Length<Y extends any[]> = Y["length"]
 
 export type Merge<Y, M> = M & Omit<Y, keyof M>
 
-export type DeepMerge<Y, M> = Y extends any[] | Date | Function | Primitive
+export type DeepMerge<Y, M> = Y extends any[] | Primitive
   ? M
   : Y extends object
     ? M extends object
@@ -58,7 +62,7 @@ export type DeepMerge<Y, M> = Y extends any[] | Date | Function | Primitive
       : M
     : M
 
-export type DeepPartial<Y> = Y extends any[] | Date | Function | Primitive
+export type DeepPartial<Y> = Y extends any[] | Primitive
   ? Y
   : {
       [P in keyof Y]?: DeepPartial<Y[P]>


### PR DESCRIPTION
Closes #7783

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix `Path` so it includes array and object container keys, and treat `Date` and `Function` as primitive values.

## Current behavior (updates)

`Path` generates nested paths such as `array.0` and `object.value`, but omits the `array` and `object` paths themselves.

## New behavior

`Path` includes every container key alongside its nested paths, such as `array`, `array.0`, `object`, and `object.value`.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added type assertions for `Path` container keys and `Primitive` values.
- Verified with `pnpm utils test:jsdom --run src/index.test.ts`.