### PR TITLE
fix(dom): resolve related targets in shadow DOM

### DIFF
--- a/.changeset/silver-owls-glide.md
+++ b/.changeset/silver-owls-glide.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Resolve event related targets from the active Shadow DOM element.

--- a/packages/react/src/components/popover/popover.test.browser.tsx
+++ b/packages/react/src/components/popover/popover.test.browser.tsx
@@ -161,6 +161,38 @@ describe("<Popover />", () => {
     }
   })
 
+  test("should not close when focus moves to content in shadow DOM without a related target", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(createPortal(<Component />, shadowRoot), {
+        providerProps: { rootNode: shadowRoot },
+      })
+      const triggerButton = page.getByRole("button", {
+        name: "Popover Trigger",
+      })
+
+      await user.click(triggerButton)
+
+      const content = page.getByRole("dialog")
+
+      await user.click(content)
+      await expect.poll(() => shadowRoot.activeElement).toBe(content.element())
+
+      triggerButton
+        .element()
+        .dispatchEvent(
+          new FocusEvent("focusout", { bubbles: true, relatedTarget: null }),
+        )
+
+      await expect.element(content).toBeVisible()
+    } finally {
+      host.remove()
+    }
+  })
+
   test("should close when close trigger is activated", async () => {
     const { user } = await render(<ComponentWithCloseTrigger />)
 

--- a/packages/react/src/utils/dom.test.browser.ts
+++ b/packages/react/src/utils/dom.test.browser.ts
@@ -1,0 +1,30 @@
+import { getEventRelatedTarget } from "./dom"
+
+describe("getEventRelatedTarget", () => {
+  test("returns the active element nested in a shadow root", () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    const currentTarget = document.createElement("div")
+    const nestedHost = document.createElement("div")
+    const nestedShadowRoot = nestedHost.attachShadow({ mode: "open" })
+    const input = document.createElement("input")
+
+    input.setAttribute("aria-label", "Nested input")
+    nestedShadowRoot.append(input)
+    shadowRoot.append(currentTarget, nestedHost)
+    document.body.append(host)
+
+    try {
+      input.focus()
+
+      const ev = {
+        currentTarget,
+        relatedTarget: null,
+      } as unknown as React.FocusEvent
+
+      expect(getEventRelatedTarget(ev)).toBe(input)
+    } finally {
+      host.remove()
+    }
+  })
+})

--- a/packages/react/src/utils/dom.ts
+++ b/packages/react/src/utils/dom.ts
@@ -90,9 +90,14 @@ export function useAttributeObserver(
 export function getEventRelatedTarget(ev: React.FocusEvent | React.MouseEvent) {
   if (ev.relatedTarget) return ev.relatedTarget as HTMLElement
 
-  const root = ev.currentTarget.getRootNode() as Document | ShadowRoot
+  const getRootNode = (
+    ev.currentTarget as unknown as {
+      getRootNode?: () => Document | ShadowRoot
+    }
+  ).getRootNode
+  const root = getRootNode?.()
 
-  return (getActiveElement(root) ??
+  return ((root && getActiveElement(root)) ??
     ev.currentTarget.ownerDocument.activeElement) as HTMLElement | null
 }
 

--- a/packages/react/src/utils/dom.ts
+++ b/packages/react/src/utils/dom.ts
@@ -95,7 +95,7 @@ export function getEventRelatedTarget(ev: React.FocusEvent | React.MouseEvent) {
       getRootNode?: () => Document | ShadowRoot
     }
   ).getRootNode
-  const root = getRootNode?.()
+  const root = getRootNode?.call(ev.currentTarget)
 
   return ((root && getActiveElement(root)) ??
     ev.currentTarget.ownerDocument.activeElement) as HTMLElement | null

--- a/packages/react/src/utils/dom.ts
+++ b/packages/react/src/utils/dom.ts
@@ -1,4 +1,4 @@
-import type { AnyString } from "@yamada-ui/utils"
+import { type AnyString, getActiveElement } from "@yamada-ui/utils"
 import * as React from "react"
 
 type KeyboardNavigationKey =
@@ -88,7 +88,11 @@ export function useAttributeObserver(
 }
 
 export function getEventRelatedTarget(ev: React.FocusEvent | React.MouseEvent) {
-  return (ev.relatedTarget ??
+  if (ev.relatedTarget) return ev.relatedTarget as HTMLElement
+
+  const root = ev.currentTarget.getRootNode() as Document | ShadowRoot
+
+  return (getActiveElement(root) ??
     ev.currentTarget.ownerDocument.activeElement) as HTMLElement | null
 }
 


### PR DESCRIPTION
Closes #7781

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Resolves fallback event related targets from the active element in the current Shadow DOM root.

## Current behavior (updates)

Events without a related target fall back to the document active element, which is a Shadow host instead of the focused element.

## New behavior

Popover blur handling receives the focused element inside its Shadow DOM root.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Adds browser coverage for null related targets in Shadow DOM.