### PR TITLE
fix(number-input): support mouse wheel in shadow DOM

### DIFF
--- a/.changeset/quiet-otters-whistle.md
+++ b/.changeset/quiet-otters-whistle.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/react": patch
+"@yamada-ui/utils": patch
+---
+
+Fix NumberInput mouse wheel updates for focused inputs inside Shadow DOM.

--- a/packages/react/src/components/number-input/number-input.test.browser.tsx
+++ b/packages/react/src/components/number-input/number-input.test.browser.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom"
 import { page, render } from "#test/browser"
 import { NumberInput } from "."
 
@@ -138,6 +139,37 @@ describe("<NumberInput />", () => {
       .element()
       .dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: 100 }))
     await expect.element(numberInput).toHaveValue("10")
+  })
+
+  test("changes value on wheel when focused inside Shadow DOM", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(
+        createPortal(
+          <NumberInput allowMouseWheel defaultValue={10} />,
+          shadowRoot,
+        ),
+        { providerProps: { rootNode: shadowRoot } },
+      )
+      const numberInput = page.getByRole("spinbutton")
+      await expect.element(numberInput).toHaveValue("10")
+
+      await user.click(numberInput)
+
+      numberInput.element().dispatchEvent(
+        new WheelEvent("wheel", {
+          bubbles: true,
+          composed: true,
+          deltaY: -100,
+        }),
+      )
+      await expect.element(numberInput).toHaveValue("11")
+    } finally {
+      host.remove()
+    }
   })
 
   test("prevents invalid character input via keyboard", async () => {

--- a/packages/react/src/components/number-input/use-number-input.ts
+++ b/packages/react/src/components/number-input/use-number-input.ts
@@ -10,6 +10,7 @@ import { useCounter } from "../../hooks/use-counter"
 import { useEventListener } from "../../hooks/use-event-listener"
 import {
   ariaAttr,
+  isActiveElement,
   isComposing,
   mergeRefs,
   runKeyAction,
@@ -289,8 +290,12 @@ export const useNumberInput = (props: UseNumberInputProps = {}) => {
     inputRef.current,
     "wheel",
     (ev) => {
-      const ownerDocument = inputRef.current?.ownerDocument ?? document
-      const focused = ownerDocument.activeElement === inputRef.current
+      if (!inputRef.current) return
+
+      const focused = isActiveElement(
+        inputRef.current,
+        inputRef.current.getRootNode(),
+      )
 
       if (!allowMouseWheel || !focused) return
 

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -113,9 +113,12 @@ export function isFrame(el: any): el is HTMLIFrameElement {
 
 export function isActiveElement(
   el: HTMLElement,
-  rootNode: Document | ShadowRoot,
+  rootNode: Document | Node | ShadowRoot,
 ): boolean {
-  return getActiveElement(rootNode) === el
+  return (
+    (isDocument(rootNode) || isShadowRoot(rootNode)) &&
+    getActiveElement(rootNode) === el
+  )
 }
 
 export function isHiddenElement(el: HTMLElement): boolean {


### PR DESCRIPTION
Closes #7782

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Resolves the focused NumberInput from its Shadow DOM root before handling mouse wheel input.

## Current behavior (updates)

A focused NumberInput inside Shadow DOM ignores mouse wheel changes because the document active element is the Shadow host.

## New behavior

Focused NumberInput inputs update with the mouse wheel inside Shadow DOM.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Adds browser regression coverage for mouse wheel input inside Shadow DOM.