### PR TITLE
fix(editable): support shadow DOM focus cleanup

### DIFF
--- a/.changeset/witty-dragons-dream.md
+++ b/.changeset/witty-dragons-dream.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/react": patch
+"@yamada-ui/utils": patch
+---
+
+Fix Editable focus cleanup in Shadow DOM.

--- a/packages/react/src/components/editable/editable.test.browser.tsx
+++ b/packages/react/src/components/editable/editable.test.browser.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom"
 import { a11y, page, render } from "#test/browser"
 import { Editable } from "./"
 
@@ -187,6 +188,71 @@ describe("<Editable />", () => {
 
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
+  })
+
+  test("cancels without submitting when the input is blurred to a cancel trigger in shadow DOM", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ delegatesFocus: true, mode: "open" })
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn()
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(
+        createPortal(
+          <Editable.Root
+            defaultValue="Some text"
+            startWithEditView
+            onCancel={onCancel}
+            onSubmit={onSubmit}
+          >
+            <Editable.Preview />
+            <Editable.Input />
+            <Editable.CancelTrigger>
+              <button>Cancel</button>
+            </Editable.CancelTrigger>
+          </Editable.Root>,
+          shadowRoot,
+        ),
+        { providerProps: { rootNode: shadowRoot } },
+      )
+
+      await user.click(page.getByRole("button", { name: "Cancel" }))
+
+      expect(onCancel).toHaveBeenCalledExactlyOnceWith("Some text")
+      expect(onSubmit).not.toHaveBeenCalled()
+    } finally {
+      host.remove()
+    }
+  })
+
+  test("releases focus from the input after submitting in shadow DOM", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(
+        createPortal(
+          <Editable.Root defaultValue="Some text" startWithEditView>
+            <Editable.Preview />
+            <Editable.Input />
+          </Editable.Root>,
+          shadowRoot,
+        ),
+        { providerProps: { rootNode: shadowRoot } },
+      )
+
+      const input = page.getByRole("textbox")
+      const inputRoot = input.element().getRootNode() as ShadowRoot
+
+      await user.click(input)
+      await expect.poll(() => inputRoot.activeElement).toBe(input.element())
+      await user.keyboard("{Enter}")
+      await expect.poll(() => inputRoot.activeElement).toBeNull()
+    } finally {
+      host.remove()
+    }
   })
 
   test("supports children as a function reflecting the editing state", async () => {

--- a/packages/react/src/components/editable/use-editable.ts
+++ b/packages/react/src/components/editable/use-editable.ts
@@ -10,6 +10,8 @@ import {
   contains,
   createContext,
   handlerAll,
+  isActiveElement,
+  isShadowRoot,
   mergeRefs,
   useCallbackRef,
   useSafeLayoutEffect,
@@ -182,9 +184,12 @@ export const useEditable = (props: UseEditableProps = {}) => {
     (ev: FocusEvent) => {
       if (!editing) return
 
-      const ownerDocument = ev.currentTarget.ownerDocument
-      const relatedTarget = (ev.relatedTarget ??
-        ownerDocument.activeElement) as HTMLElement
+      const rootNode = ev.currentTarget.getRootNode() as Document | ShadowRoot
+      const relatedTarget = (
+        isShadowRoot(rootNode)
+          ? (rootNode.activeElement ?? ev.relatedTarget)
+          : (ev.relatedTarget ?? rootNode.activeElement)
+      ) as HTMLElement
       const targetIsCancel = contains(cancelRef.current, relatedTarget)
       const targetIsSubmit = contains(submitRef.current, relatedTarget)
       const validBlur = !targetIsCancel && !targetIsSubmit
@@ -226,12 +231,9 @@ export const useEditable = (props: UseEditableProps = {}) => {
   }, [editing, onEditRef, selectAllOnFocus])
 
   useEffect(() => {
-    if (editing) return
-
-    const el = inputRef.current
-    const activeEl = el?.ownerDocument.activeElement
-
-    if (activeEl === el) el?.blur()
+    if (editing || !inputRef.current) return
+    if (isActiveElement(inputRef.current, inputRef.current.getRootNode()))
+      inputRef.current.blur()
   }, [editing])
 
   const getRootProps: PropGetter = useCallback(

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -113,9 +113,12 @@ export function isFrame(el: any): el is HTMLIFrameElement {
 
 export function isActiveElement(
   el: HTMLElement,
-  rootNode: Document | ShadowRoot,
+  rootNode: Document | Node | ShadowRoot,
 ): boolean {
-  return getActiveElement(rootNode) === el
+  return (
+    (isDocument(rootNode) || isShadowRoot(rootNode)) &&
+    getActiveElement(rootNode) === el
+  )
 }
 
 export function isHiddenElement(el: HTMLElement): boolean {


### PR DESCRIPTION
Closes #7779

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Makes Editable resolve blur targets and focused inputs from its Shadow DOM root.

## Current behavior (updates)

Editable can misidentify Cancel and Submit focus transitions and retain input focus after editing ends inside Shadow DOM.

## New behavior

Editable preserves intended blur behavior and releases focus after editing within Shadow DOM.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Adds browser regression coverage for Shadow DOM editing flows.