### PR TITLE
fix(tooltip): add positioner props

### DIFF
--- a/.changeset/bright-frogs-listen.md
+++ b/.changeset/bright-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Add props for the tooltip positioner element.

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -35,11 +35,15 @@ export interface TooltipProps
   /**
    * Props for content element.
    */
-  contentProps?: HTMLMotionProps
+  contentProps?: TooltipContentProps
   /**
    * Props for portal component.
    */
   portalProps?: Omit<PortalProps, "children">
+  /**
+   * Props for positioner element.
+   */
+  positionerProps?: Omit<TooltipPositionerProps, "children">
 }
 
 const {
@@ -67,6 +71,7 @@ export const Tooltip: FC<TooltipProps> = (props) => {
       duration = 0.1,
       contentProps,
       portalProps,
+      positionerProps,
       ...rest
     },
   ] = useRootComponentProps(props)
@@ -88,7 +93,7 @@ export const Tooltip: FC<TooltipProps> = (props) => {
       <AnimatePresence>
         {open ? (
           <Portal {...portalProps}>
-            <TooltipPositioner {...getPositionerProps()}>
+            <TooltipPositioner {...getPositionerProps(positionerProps)}>
               <TooltipContent
                 {...popupAnimationProps}
                 {...cast<HTMLMotionProps>(


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Expose props for the tooltip positioner element.

## Current behavior (updates)

Tooltip consumers cannot pass props to the positioner element.

## New behavior

`positionerProps` is forwarded to `TooltipPositioner`.

## Is this a breaking change (Yes/No):

No

## Additional Information

No linked issue because this is a small, targeted bug fix.