### PR TITLE
fix(portal): preserve focus lock scope

### DIFF
--- a/.changeset/tough-stingrays-dance.md
+++ b/.changeset/tough-stingrays-dance.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fix focus locking for portalized content within modals in Shadow DOM.

--- a/packages/react/src/components/focus-lock/focus-lock.tsx
+++ b/packages/react/src/components/focus-lock/focus-lock.tsx
@@ -1,9 +1,19 @@
 "use client"
 
 import type { FC, PropsWithChildren, RefObject } from "react"
-import { useCallback } from "react"
+import { useCallback, useState } from "react"
 import ReactFocusLock from "react-focus-lock"
-import { getFocusableElements, interopDefault } from "../../utils"
+import {
+  createContext,
+  getFocusableElements,
+  interopDefault,
+} from "../../utils"
+
+const [FocusLockShardContext, useFocusLockShard] = createContext<
+  ((shard: HTMLElement) => () => void) | undefined
+>({ name: "FocusLockShardContext", strict: false })
+
+export { useFocusLockShard }
 
 const InternalFocusLock = interopDefault(ReactFocusLock)
 
@@ -70,7 +80,16 @@ export const FocusLock: FC<FocusLockProps> = ({
   persistentFocus,
   restoreFocus,
 }) => {
+  const [shards, setShards] = useState<HTMLElement[]>([])
   const returnFocus = restoreFocus && !finalFocusRef
+
+  const registerShard = useCallback((shard: HTMLElement) => {
+    setShards((prev) => (prev.includes(shard) ? prev : [...prev, shard]))
+
+    return () => {
+      setShards((prev) => prev.filter((item) => item !== shard))
+    }
+  }, [])
 
   const onActivation = useCallback(() => {
     if (initialFocusRef?.current) {
@@ -90,16 +109,19 @@ export const FocusLock: FC<FocusLockProps> = ({
   }, [finalFocusRef])
 
   return (
-    <InternalFocusLock
-      autoFocus={autoFocus}
-      crossFrame={lockFocusAcrossFrames}
-      disabled={disabled}
-      persistentFocus={persistentFocus}
-      returnFocus={returnFocus}
-      onActivation={onActivation}
-      onDeactivation={onDeactivation}
-    >
-      {children}
-    </InternalFocusLock>
+    <FocusLockShardContext value={registerShard}>
+      <InternalFocusLock
+        autoFocus={autoFocus}
+        crossFrame={lockFocusAcrossFrames}
+        disabled={disabled}
+        persistentFocus={persistentFocus}
+        returnFocus={returnFocus}
+        shards={shards}
+        onActivation={onActivation}
+        onDeactivation={onDeactivation}
+      >
+        {children}
+      </InternalFocusLock>
+    </FocusLockShardContext>
   )
 }

--- a/packages/react/src/components/focus-lock/index.ts
+++ b/packages/react/src/components/focus-lock/index.ts
@@ -1,2 +1,2 @@
-export { FocusLock } from "./focus-lock"
+export { FocusLock, useFocusLockShard } from "./focus-lock"
 export type { FocusLockProps } from "./focus-lock"

--- a/packages/react/src/components/portal/portal.test.browser.tsx
+++ b/packages/react/src/components/portal/portal.test.browser.tsx
@@ -1,0 +1,56 @@
+import { createPortal } from "react-dom"
+import { a11y, page, render } from "#test/browser"
+import { Button } from "../button"
+import { Modal } from "../modal"
+import { Portal } from "./portal"
+
+const Component = () => {
+  return (
+    <Modal.Root>
+      <Modal.OpenTrigger>
+        <Button>Open Modal</Button>
+      </Modal.OpenTrigger>
+
+      <Modal.Content>
+        <Modal.Header>
+          <Modal.Title>Modal Title</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <Button>Modal Action</Button>
+          <Portal>
+            <Button>Portal Action</Button>
+          </Portal>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  )
+}
+
+describe("<Portal />", () => {
+  test("passes a11y checks", async () => {
+    await a11y(<Component />)
+  })
+
+  test("keeps focus within a modal in shadow DOM", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(createPortal(<Component />, shadowRoot), {
+        providerProps: { rootNode: shadowRoot },
+      })
+      const portalAction = page.getByRole("button", { name: "Portal Action" })
+
+      await user.click(page.getByRole("button", { name: "Open Modal" }))
+      await user.click(portalAction)
+
+      await expect
+        .poll(() => shadowRoot.activeElement)
+        .toBe(portalAction.element())
+    } finally {
+      host.remove()
+    }
+  })
+})

--- a/packages/react/src/components/portal/portal.tsx
+++ b/packages/react/src/components/portal/portal.tsx
@@ -2,10 +2,11 @@
 
 import type { FC, PropsWithChildren, RefObject } from "react"
 import type { RootNode } from "../../core"
-import { Children, useEffect, useState } from "react"
+import { Children, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { useEnvironment } from "../../core"
 import { getDocument, isShadowRoot, useSsr } from "../../utils"
+import { useFocusLockShard } from "../focus-lock"
 
 const getPortalNode = (node?: RootNode) => {
   const rootNode = node?.getRootNode()
@@ -36,17 +37,30 @@ export const Portal: FC<PortalProps> = ({
   containerRef: ref,
   disabled,
 }) => {
+  const shardRef = useRef<HTMLDivElement>(null)
   const [target, setTarget] = useState(ref?.current)
   const ssr = useSsr()
   const { getRootNode } = useEnvironment()
+  const registerShard = useFocusLockShard()
 
   useEffect(() => {
     setTarget(() => ref?.current)
   }, [ref])
 
+  useEffect(() => {
+    const shard = shardRef.current
+
+    if (disabled || ssr || !shard) return
+
+    return registerShard?.(shard)
+  }, [disabled, registerShard, ssr])
+
   if (ssr || disabled) return children
 
   const container = target ?? getPortalNode(getRootNode())
+
+  if (registerShard)
+    return createPortal(<div ref={shardRef}>{children}</div>, container)
 
   return (
     <>{Children.map(children, (child) => createPortal(child, container))}</>


### PR DESCRIPTION
## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Allows Portal content rendered within a FocusLock to participate in its focus scope.

No linked issue: this is a follow-up fix for Shadow DOM focus handling.

## Current behavior (updates)

Portal content rendered from a modal is outside the modal FocusLock DOM subtree, so focus can be forced back into the modal.

## New behavior

Portal content within a FocusLock is registered as a focus-lock shard while preserving the existing Portal behavior elsewhere.

## Is this a breaking change (Yes/No):

No.

## Additional Information

- Adds browser coverage for portal focus in a Shadow DOM modal.