### PR TITLE
fix(i18n): resolve available locales

### DIFF
--- a/.changeset/brown-walls-retire.md
+++ b/.changeset/brown-walls-retire.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed an issue where `UIProvider` did not forward all `I18nProvider` props.

--- a/.changeset/calm-ways-press.md
+++ b/.changeset/calm-ways-press.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fixed an issue where `I18nProvider` did not resolve browser locales to available message dictionaries, and added a `fallbackLocale` prop.

--- a/packages/react/src/providers/i18n-provider/i18n-provider.test.tsx
+++ b/packages/react/src/providers/i18n-provider/i18n-provider.test.tsx
@@ -2,40 +2,7 @@ import type { FC } from "react"
 import { useContext } from "react"
 import { act, render, renderHook, screen, waitFor } from "#test"
 import { noop } from "../../utils"
-import {
-  getLanguage,
-  I18nContext,
-  I18nProvider,
-  useI18n,
-} from "./i18n-provider"
-
-describe("getLanguage", () => {
-  test("returns language with provided locale", () => {
-    const lang = getLanguage("ja")
-
-    expect(lang.locale).toBe("ja")
-    expect(lang.dir).toBe("ltr")
-  })
-
-  test("returns rtl direction for rtl locale", () => {
-    const lang = getLanguage("ar")
-
-    expect(lang.dir).toBe("rtl")
-  })
-
-  test("falls back to default for unsupported locale", () => {
-    const lang = getLanguage("invalid-xxxxx-yyy")
-
-    expect(lang.locale).toBe("en-US")
-  })
-
-  test("uses provided dir override", () => {
-    const lang = getLanguage("en", "rtl")
-
-    expect(lang.locale).toBe("en")
-    expect(lang.dir).toBe("rtl")
-  })
-})
+import { I18nContext, I18nProvider, useI18n } from "./i18n-provider"
 
 describe("I18nProvider", () => {
   test("renders children", () => {
@@ -70,12 +37,12 @@ describe("I18nProvider", () => {
       { withProvider: false },
     )
 
-    expect(screen.getByTestId("locale").textContent).toBe("en")
+    expect(screen.getByTestId("locale").textContent).toBe("en-GB")
 
     await user.click(screen.getByTestId("change"))
 
     await waitFor(() => {
-      expect(screen.getByTestId("locale").textContent).toBe("ja")
+      expect(screen.getByTestId("locale").textContent).toBe("ja-JP")
     })
   })
 
@@ -159,7 +126,7 @@ describe("I18nProvider", () => {
       { withProvider: false },
     )
 
-    expect(screen.getByTestId("locale").textContent).toBe("en")
+    expect(screen.getByTestId("locale").textContent).toBe("en-GB")
 
     rerender(
       <I18nProvider locale="ja">
@@ -168,7 +135,105 @@ describe("I18nProvider", () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId("locale").textContent).toBe("ja")
+      expect(screen.getByTestId("locale").textContent).toBe("ja-JP")
+    })
+  })
+
+  test("uses language-only messages for a regional locale", () => {
+    const intl = {
+      ja: {
+        closeButton: {
+          Close: "閉じる",
+        },
+      },
+    }
+
+    const { result } = renderHook(() => useI18n(), {
+      providerProps: { intl, locale: "ja-JP" },
+    })
+
+    expect(result.current.locale).toBe("ja")
+    expect(result.current.t("closeButton.Close" as any)).toBe("閉じる")
+  })
+
+  test("uses an available fallback locale", () => {
+    const intl = {
+      "en-GB": {
+        closeButton: {
+          Close: "Close",
+        },
+      },
+    }
+
+    const { result } = renderHook(() => useI18n(), {
+      providerProps: { intl, locale: "jk" },
+    })
+
+    expect(result.current.locale).toBe("en-GB")
+    expect(result.current.t("closeButton.Close" as any)).toBe("Close")
+  })
+
+  test("determines direction from locale", () => {
+    const { result } = renderHook(() => useI18n(), {
+      providerProps: { locale: "ar" },
+    })
+
+    expect(result.current.locale).toBe("ar-AE")
+    expect(result.current.dir).toBe("rtl")
+  })
+
+  test("uses a forced direction", () => {
+    const { result } = renderHook(() => useI18n(), {
+      providerProps: { dir: "rtl", locale: "en" },
+    })
+
+    expect(result.current.locale).toBe("en-GB")
+    expect(result.current.dir).toBe("rtl")
+  })
+
+  test("re-resolves the locale when intl changes", async () => {
+    const englishIntl = {
+      "en-US": {
+        closeButton: {
+          Close: "Close",
+        },
+      },
+    }
+    const japaneseIntl = {
+      "ja-JP": {
+        closeButton: {
+          Close: "閉じる",
+        },
+      },
+    }
+    const TestComponent: FC = () => {
+      const { locale, t } = useI18n()
+
+      return (
+        <>
+          <span data-testid="locale">{locale}</span>
+          <span data-testid="translation">{t("closeButton.Close" as any)}</span>
+        </>
+      )
+    }
+    const { rerender } = render(
+      <I18nProvider intl={englishIntl} locale="ja">
+        <TestComponent />
+      </I18nProvider>,
+      { withProvider: false },
+    )
+
+    expect(screen.getByTestId("locale").textContent).toBe("en-US")
+
+    rerender(
+      <I18nProvider intl={japaneseIntl} locale="ja">
+        <TestComponent />
+      </I18nProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("locale").textContent).toBe("ja-JP")
+      expect(screen.getByTestId("translation").textContent).toBe("閉じる")
     })
   })
 

--- a/packages/react/src/providers/i18n-provider/i18n-provider.tsx
+++ b/packages/react/src/providers/i18n-provider/i18n-provider.tsx
@@ -40,20 +40,6 @@ const DEFAULT_LANGUAGE: Language = {
 
 export const LOCALES = Object.keys(INTL) as readonly Locale[]
 
-export function getLanguage(locale?: string, dir?: TextDirection): Language {
-  locale ??= createdDom() ? navigator.language : DEFAULT_LOCALE
-
-  try {
-    Intl.DateTimeFormat.supportedLocalesOf([locale])
-  } catch (_err) {
-    locale = DEFAULT_LOCALE
-  }
-
-  dir ??= isRtl(locale) ? "rtl" : "ltr"
-
-  return { dir, locale }
-}
-
 type IntlData = DefaultIntlData
 type IntlKey = keyof IntlData
 type IntlPath = Path<IntlData>
@@ -94,6 +80,10 @@ export interface I18nProviderProps {
    */
   dir?: TextDirection
   /**
+   * The fallback locale to use if no matching locale is available.
+   */
+  fallbackLocale?: AnyString | Locale
+  /**
    * The formats to pass to the `intlMessageFormat` instance.
    */
   formats?: Formats
@@ -118,24 +108,105 @@ export interface I18nProviderProps {
 export const I18nProvider: FC<I18nProviderProps> = ({
   children,
   dir: forcedDir,
+  fallbackLocale = DEFAULT_LOCALE,
   formats,
-  intl = INTL as Dict,
+  intl: forcedIntl,
   intlMessageFormatOptions,
   locale: forcedLocale,
 }) => {
-  const [language, setLanguage] = useState(getLanguage(forcedLocale, forcedDir))
+  const intl = useMemo<Dict>(() => {
+    if (!forcedIntl) return INTL
+
+    if (isEmptyObject(forcedIntl)) return INTL
+
+    return forcedIntl
+  }, [forcedIntl])
+  const locales = useMemo(() => Object.keys(intl), [intl])
+
+  const getFallbackLocale = useCallback(
+    (language?: string) => {
+      if (language)
+        for (const key of locales) if (key.startsWith(language)) return key
+
+      if (locales.includes(fallbackLocale)) return fallbackLocale
+
+      if (createdDom()) {
+        try {
+          const { language } = new Intl.Locale(fallbackLocale)
+
+          for (const key of locales) if (key.startsWith(language)) return key
+        } catch {
+          return locales[0]!
+        }
+      } else {
+        const language = fallbackLocale.split("-")[0]!
+
+        for (const key of locales) if (key.startsWith(language)) return key
+      }
+
+      return locales[0]!
+    },
+    [locales, fallbackLocale],
+  )
+
+  const getLocale = useCallback(
+    (forcedLocale?: string) => {
+      if (forcedLocale) {
+        if (locales.includes(forcedLocale)) return forcedLocale
+
+        const language = forcedLocale.split("-")[0]!
+
+        return getFallbackLocale(language)
+      } else if (createdDom()) {
+        try {
+          const { language, region } = new Intl.Locale(navigator.language)
+          const locale = `${language}-${region}`
+
+          return locales.includes(locale) ? locale : getFallbackLocale(language)
+        } catch {
+          return getFallbackLocale()
+        }
+      } else {
+        return getFallbackLocale()
+      }
+    },
+    [locales, getFallbackLocale],
+  )
+
+  const getLanguage = useCallback(
+    (locale?: string, dir?: TextDirection): Language => {
+      locale = getLocale(locale)
+
+      try {
+        Intl.DateTimeFormat.supportedLocalesOf([locale])
+      } catch {
+        locale = getFallbackLocale()
+      }
+
+      dir ??= isRtl(locale) ? "rtl" : "ltr"
+
+      return { dir, locale }
+    },
+    [getLocale, getFallbackLocale],
+  )
+
+  const [{ dir, locale }, setLanguage] = useState(
+    getLanguage(forcedLocale, forcedDir),
+  )
   const controlled = !isUndefined(forcedLocale)
-  const { locale } = language
 
   const messages = useMemo(() => intl[locale], [intl, locale])
 
   const changeSystemLanguage = useCallback(() => {
     setLanguage(getLanguage())
-  }, [])
+  }, [getLanguage])
 
-  const changeLanguage = useCallback((locale?: string, dir?: TextDirection) => {
-    setLanguage(getLanguage(locale, dir))
-  }, [])
+  const changeLanguage = useCallback(
+    (locale?: string, dir?: TextDirection) => {
+      setLanguage(getLanguage(locale, dir))
+    },
+    [getLanguage],
+  )
 
   const getValue = useCallback(
     (path: number | string) => {
@@ -198,11 +269,16 @@ export const I18nProvider: FC<I18nProviderProps> = ({
     [getValue, locale, formats, intlMessageFormatOptions],
   )
 
-  const value = useMemo(() => {
-    const rest = { changeLanguage, getTranslation, t: getTranslation() }
-
-    return { ...language, ...rest }
-  }, [changeLanguage, getTranslation, language])
+  const value = useMemo(
+    () => ({
+      changeLanguage,
+      dir,
+      getTranslation,
+      locale,
+      t: getTranslation(),
+    }),
+    [changeLanguage, dir, getTranslation, locale],
+  )
 
   useEffect(() => {
     if (controlled) return
@@ -216,7 +292,7 @@ export const I18nProvider: FC<I18nProviderProps> = ({
 
   useUpdateEffect(() => {
     setLanguage(getLanguage(forcedLocale, forcedDir))
-  }, [forcedLocale, forcedDir])
+  }, [forcedLocale, forcedDir, getLanguage])
 
   return <I18nContext value={value}>{children}</I18nContext>
 }

--- a/packages/react/src/providers/ui-provider/ui-provider.test.tsx
+++ b/packages/react/src/providers/ui-provider/ui-provider.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "#test"
+import { useI18n } from "../i18n-provider"
 import { extendConfig, extendTheme, UIProvider } from "./ui-provider"
 
 describe("UIProvider", () => {
@@ -11,6 +12,54 @@ describe("UIProvider", () => {
     )
 
     expect(screen.getByTestId("child")).toHaveTextContent("Hello")
+  })
+
+  test("forwards i18n props", () => {
+    const intl = {
+      "en-US": {
+        test: {
+          price: "Price: {price, number, currency}",
+        },
+      },
+      "ja-JP": {
+        test: {
+          price: "価格: {price, number, currency}",
+        },
+      },
+    }
+    const TestComponent = () => {
+      const { locale, t } = useI18n()
+
+      return (
+        <>
+          <span data-testid="locale">{locale}</span>
+          <span data-testid="price">
+            {t("test.price" as any, { price: 1 } as any)}
+          </span>
+        </>
+      )
+    }
+
+    render(
+      <UIProvider
+        fallbackLocale="ja-JP"
+        formats={{
+          date: {},
+          number: {
+            currency: { style: "currency", currency: "JPY" },
+          },
+          time: {},
+        }}
+        intl={intl}
+        locale="jk"
+      >
+        <TestComponent />
+      </UIProvider>,
+      { withProvider: false },
+    )
+
+    expect(screen.getByTestId("locale")).toHaveTextContent("ja-JP")
+    expect(screen.getByTestId("price")).toHaveTextContent("価格: ￥1")
   })
 })
 

--- a/packages/react/src/providers/ui-provider/ui-provider.tsx
+++ b/packages/react/src/providers/ui-provider/ui-provider.tsx
@@ -51,7 +51,10 @@ export const UIProvider: FC<UIProviderProps> = ({
   config = defaultConfig,
   cookie,
   dir,
+  fallbackLocale,
+  formats,
   intl,
+  intlMessageFormatOptions,
   locale,
   rootNode,
   storage,
@@ -60,7 +63,14 @@ export const UIProvider: FC<UIProviderProps> = ({
 }) => {
   return (
     <EnvironmentProvider value={rootNode}>
-      <I18nProvider dir={dir} intl={intl} locale={locale}>
+      <I18nProvider
+        dir={dir}
+        fallbackLocale={fallbackLocale}
+        formats={formats}
+        intl={intl}
+        intlMessageFormatOptions={intlMessageFormatOptions}
+        locale={locale}
+      >
         <SystemProvider config={config} theme={theme}>
           <ThemeProvider
             config={config}


### PR DESCRIPTION
Closes #7810
Closes #7811

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Resolve browser and requested locales to available i18n message dictionaries, and forward all i18n props through `UIProvider`.

## Current behavior (updates)

`I18nProvider` could use a locale without a corresponding message dictionary. `UIProvider` ignored `fallbackLocale`, `formats`, and `intlMessageFormatOptions`.

## New behavior

`I18nProvider` resolves to the closest available message locale and supports an explicit fallback. `UIProvider` forwards all i18n configuration props.

## Is this a breaking change (Yes/No):

No

## Additional Information

Tests: `pnpm react test:jsdom --run src/providers/i18n-provider/i18n-provider.test.tsx src/providers/ui-provider/ui-provider.test.tsx`