### PR TITLE
fix(popover): preserve nested popup focus

### DIFF
--- a/.changeset/neat-pandas-laugh.md
+++ b/.changeset/neat-pandas-laugh.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Prevent Popover from closing when focus moves to a portalled nested popup.

--- a/packages/react/src/components/popover/popover.test.browser.tsx
+++ b/packages/react/src/components/popover/popover.test.browser.tsx
@@ -1,7 +1,8 @@
 import { createPortal } from "react-dom"
-import { page, render } from "#test/browser"
+import { a11y, page, render } from "#test/browser"
 import { Popover } from "."
 import { Button } from "../button"
+import { Menu } from "../menu"
 
 describe("<Popover />", () => {
   const Component = (props: Popover.RootProps) => {
@@ -39,6 +40,33 @@ describe("<Popover />", () => {
       </Popover.Root>
     )
   }
+
+  const ComponentWithMenu = () => {
+    return (
+      <Popover.Root>
+        <Popover.Trigger>
+          <Button>Popover Trigger</Button>
+        </Popover.Trigger>
+
+        <Popover.Content>
+          <Menu.Root>
+            <Menu.Trigger>
+              <Button>Menu Trigger</Button>
+            </Menu.Trigger>
+
+            <Menu.Content>
+              <Menu.Item value="item-1">Menu Item 1</Menu.Item>
+              <Menu.Item value="item-2">Menu Item 2</Menu.Item>
+            </Menu.Content>
+          </Menu.Root>
+        </Popover.Content>
+      </Popover.Root>
+    )
+  }
+
+  test("passes a11y checks", async () => {
+    await a11y(<Component defaultOpen />)
+  })
 
   test("should close with escape key", async () => {
     const { user } = await render(<Component />)
@@ -131,6 +159,20 @@ describe("<Popover />", () => {
     await expect.poll(() => page.getByText("Popover Header").query()).toBeNull()
     await expect.poll(() => page.getByText("Popover Body").query()).toBeNull()
     await expect.poll(() => page.getByText("Popover Footer").query()).toBeNull()
+  })
+
+  test("keeps parent popover open when hovering portalled menu items", async () => {
+    const { user } = await render(<ComponentWithMenu />)
+
+    await user.click(page.getByRole("button", { name: "Popover Trigger" }))
+    await user.click(page.getByRole("button", { name: "Menu Trigger" }))
+    await user.hover(page.getByRole("menuitem", { name: "Menu Item 1" }))
+    await user.hover(page.getByRole("menuitem", { name: "Menu Item 2" }))
+
+    await expect
+      .element(page.getByRole("menuitem", { name: "Menu Item 2" }))
+      .toHaveFocus()
+    await expect.element(page.getByRole("dialog")).toBeVisible()
   })
 
   test("should not close when content is clicked in shadow DOM", async () => {

--- a/packages/react/src/components/popover/use-popover.tsx
+++ b/packages/react/src/components/popover/use-popover.tsx
@@ -193,11 +193,11 @@ export const usePopover = ({
   const onBlur = useCallback(
     (ev: FocusEvent<HTMLDivElement>) => {
       const relatedTarget = getEventRelatedTarget(ev)
-      const popup = relatedTarget?.hasAttribute("data-popup")
+      const popup = relatedTarget?.closest("[data-popup]")
 
+      if (popup) return
       if (contains(triggerRef.current, relatedTarget)) return
       if (contains(contentRef.current, relatedTarget)) return
-      if (contains(contentRef.current, ev.target) && popup) return
 
       if (closeOnBlur) onClose()
     },


### PR DESCRIPTION
Closes #7813

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Prevent a parent Popover from closing while focus moves within a portalled nested popup.

## Current behavior (updates)

Moving the pointer between Menu items in a portalled Menu causes focusout events to reach the parent Popover and close it.

## New behavior

The parent Popover remains open while focus moves between items in a nested portalled Menu.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added browser coverage for hovering between two portalled Menu items.
- Verified in Chromium, Firefox, and WebKit.