### PR TITLE
fix(system): resolve color mode styles in shadow DOM

### DIFF
--- a/.changeset/fix-shadow-color-mode-condition.md
+++ b/.changeset/fix-shadow-color-mode-condition.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Fix color mode style conditions in Shadow DOM.

--- a/packages/react/src/core/css/use-css.test.browser.tsx
+++ b/packages/react/src/core/css/use-css.test.browser.tsx
@@ -1,9 +1,74 @@
-import type { FC } from "react"
+import type { FC, PropsWithChildren } from "react"
+import { __unsafe_useEmotionCache } from "@emotion/react"
+import { createPortal } from "react-dom"
 import { page, render } from "#test/browser"
+import { Box } from "../../components/box"
+import { Portal } from "../../components/portal"
+import { UIProvider } from "../../providers/ui-provider"
+import { useColorMode } from "../system"
 import { styled } from "../system/factory"
 import { useCSS } from "./use-css"
 
+const ColorModeComponent: FC = () => {
+  const { toggleColorMode } = useColorMode()
+
+  return (
+    <>
+      <Box bg={["red", "blue"]}>Box</Box>
+      <button onClick={toggleColorMode}>Toggle color mode</button>
+    </>
+  )
+}
+
+const ShadowCacheContainer: FC<
+  PropsWithChildren<{ container: ShadowRoot }>
+> = ({ children, container }) => {
+  const cache = __unsafe_useEmotionCache()
+
+  if (cache) cache.sheet.container = container
+
+  return children
+}
+
 describe("useCSS", () => {
+  test("applies color mode styles in Shadow DOM", async () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    document.body.appendChild(host)
+
+    try {
+      const { user } = await render(
+        createPortal(
+          <ShadowCacheContainer container={shadowRoot}>
+            <UIProvider
+              config={{ defaultColorMode: "light" }}
+              rootNode={shadowRoot}
+            >
+              <Portal>
+                <ColorModeComponent />
+              </Portal>
+            </UIProvider>
+          </ShadowCacheContainer>,
+          shadowRoot,
+        ),
+        { withProvider: false },
+      )
+      const box = page.getByText("Box")
+
+      await expect
+        .element(box)
+        .toHaveStyle("background-color: rgb(234, 67, 52)")
+
+      await user.click(page.getByRole("button", { name: "Toggle color mode" }))
+
+      await expect
+        .element(box)
+        .toHaveStyle("background-color: rgb(67, 135, 244)")
+    } finally {
+      host.remove()
+    }
+  })
+
   test("returns styles with theme values", async () => {
     const Component: FC<any> = () => {
       const className = useCSS({

--- a/packages/react/src/core/system/styled.tsx
+++ b/packages/react/src/core/system/styled.tsx
@@ -14,11 +14,7 @@ import type {
 import { withEmotionCache } from "@emotion/react"
 import { serializeStyles } from "@emotion/serialize"
 import { useInsertionEffectAlwaysWithSyncFallback } from "@emotion/use-insertion-effect-with-fallbacks"
-import {
-  getRegisteredStyles,
-  insertStyles,
-  registerStyles,
-} from "@emotion/utils"
+import { getRegisteredStyles, registerStyles } from "@emotion/utils"
 import { useMemo, useRef } from "react"
 import isEqual from "react-fast-compare"
 import { Slot } from "../../components/slot"
@@ -50,11 +46,57 @@ interface InsertionProps {
   serialized: SerializedStyles
 }
 
+function normalizeHostSelector(rule: string, className: string) {
+  const selector = `.${className}`
+
+  return rule
+    .replaceAll(
+      `${selector}:host([data-mode=dark]) ${selector}`,
+      `:host([data-mode=dark]) ${selector}`,
+    )
+    .replaceAll(
+      `${selector}:host([data-mode=light]) ${selector}`,
+      `:host([data-mode=light]) ${selector}`,
+    )
+}
+
+function insertStyles(cache: EmotionCache, serialized: SerializedStyles) {
+  const className = `${cache.key}-${serialized.name}`
+
+  if (!isUndefined(cache.inserted[serialized.name])) return
+
+  const sheet = Object.create(cache.sheet) as typeof cache.sheet
+
+  sheet.insert = (rule) => {
+    cache.sheet.insert(normalizeHostSelector(rule, className))
+  }
+
+  let styleForSsr = ""
+  let current: SerializedStyles | undefined = serialized
+
+  do {
+    const style =
+      cache.insert(
+        serialized === current ? `.${className}` : "",
+        current,
+        sheet,
+        true,
+      ) || undefined
+
+    if (!createdDom() && !isUndefined(style))
+      styleForSsr += normalizeHostSelector(style, className)
+
+    current = current.next
+  } while (current !== undefined)
+
+  return styleForSsr || undefined
+}
+
 const Insertion: FC<InsertionProps> = ({ cache, htmlTag, serialized }) => {
   registerStyles(cache, serialized, htmlTag)
 
   const style = useInsertionEffectAlwaysWithSyncFallback(() =>
-    insertStyles(cache, serialized, htmlTag),
+    insertStyles(cache, serialized),
   )
 
   if (!createdDom() && !isUndefined(style)) {


### PR DESCRIPTION
Closes #7815

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Fix color mode array styles in Shadow DOM.

## Current behavior (updates)

Emotion compatibility middleware generates a `:host([data-mode=...])` selector that cannot match the Shadow host. Color mode styles therefore do not update, including for Portal content.

## New behavior

Normalize the generated host selectors before they are inserted into the stylesheet so dark and light color mode styles apply inside Shadow DOM and through Portal.

## Is this a breaking change (Yes/No):

No

## Additional Information

- Added browser coverage for Shadow DOM and Portal color mode switching.
- Verified Chromium, Firefox, and WebKit.