### PR TITLE
fix(react): exclude test suffixes from registry generation

### DIFF
--- a/.changeset/fix-registry-test-files.md
+++ b/.changeset/fix-registry-test-files.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/react": patch
+---
+
+Exclude browser test files from component registry generation.

--- a/packages/react/scripts/generate/registries/index.ts
+++ b/packages/react/scripts/generate/registries/index.ts
@@ -65,6 +65,7 @@ const TARGET_SECTIONS = ["components", "hooks", "providers"]
 const PROVIDE_SECTIONS = ["core", "utils", "theme"]
 const IGNORED_FILE_NAME = [
   ".test.(ts|tsx)",
+  ".test.(browser|chromium|firefox|webkit).(ts|tsx)",
   ".stories.(ts|tsx)",
   "^(?!.*\\.(ts|tsx)$).*",
 ]
@@ -241,6 +242,7 @@ async function getSources() {
                     await Promise.all(
                       dirents.map(async (dirent) => {
                         if (dirent.isDirectory()) return
+                        if (shouldIgnoreFileName(dirent.name)) return
 
                         const targetPath = path.join(
                           dirent.parentPath,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, maintainers may intervene.
-->

- Closes #7821

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

<!-- Add a brief description. -->

Add specific browser test file suffixes (`.test.browser.(ts|tsx)`, `.test.chromium.(ts|tsx)`, etc.) to the registry generator's ignored file patterns and ensure nested subdirectories check for ignored files.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->

When generating registry JSON files, `IGNORED_FILE_NAME` only matched `.test.(ts|tsx)`, leaving `*.test.browser.tsx` and other engine-specific test files included in the registry sources, which were subsequently added when users installed components via the CLI.

## New behavior

<!-- Please describe the behavior or changes this PR adds. -->

All test files are ignored during registry generation and won't be included in component registries or added by the CLI.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

Unsure, users might use the test files part of their codebase. 

## Additional Information
