### PR TITLE
fix(www): use UTC for changelog release dates

### DIFF
--- a/www/scripts/generate/changelog.ts
+++ b/www/scripts/generate/changelog.ts
@@ -142,6 +142,7 @@ function main() {
         CONSTANTS.I18N.LOCALES.map(async (locale) => {
           const date = new Intl.DateTimeFormat(locale, {
             dateStyle: "long",
+            timeZone: "UTC",
           }).format(new Date(pullRequest.merged_at ?? pullRequest.updated_at))
           const { lang, t } = await getI18n(locale)
 


### PR DESCRIPTION
Closes #7839

## AI used

- [ ] I did not use AI to create this PR.
- [x] (If there is no check above) I checked the generated content before submitting.

## Description

Pass `timeZone: "UTC"` to `Intl.DateTimeFormat` in the changelog generator so release dates are deterministic regardless of the machine running `pnpm www gen:changelog`.

## Current behavior (updates)

Release dates are formatted in the machine's local timezone. For example, the v2.2.8 release PR merged at `2026-09-01T20:24:52Z` — "September 1, 2026" in UTC but "September 2, 2026" in UTC+9 — so regenerating the changelog on a JST machine rewrites committed dates.

## New behavior

Dates are always formatted in UTC. Re-running `pnpm www gen:changelog` on a JST machine now produces an empty diff against the committed files.

## Is this a breaking change (Yes/No):

No
